### PR TITLE
add back automatic migrations

### DIFF
--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -58,6 +58,15 @@ func newEntClient(lc fx.Lifecycle, db *sql.DB) (*ent.Client, error) {
 	}
 
 	lc.Append(fx.Hook{
+		OnStart: func(ctx context.Context) error {
+			// Run create-only migrations after initialisation.
+			// This is done in tests and scripts too.
+			if err := client.Schema.Create(ctx); err != nil {
+				return fault.Wrap(err, fctx.With(ctx))
+			}
+
+			return nil
+		},
 		OnStop: func(ctx context.Context) error {
 			defer cancel()
 


### PR DESCRIPTION
These weren't working with the test suite due to concurrency issues but it seems running them on the start hook mitigates this.