### PR TITLE
fix a bunch of UX and API issues with library page tree

### DIFF
--- a/tests/library/tree/tree_visibility/tree_visibility_test.go
+++ b/tests/library/tree/tree_visibility/tree_visibility_test.go
@@ -1,0 +1,154 @@
+package tree_visibility_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/rs/xid"
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/fx"
+
+	"github.com/Southclaws/storyden/app/resources/account/account_writer"
+	"github.com/Southclaws/storyden/app/resources/seed"
+	"github.com/Southclaws/storyden/app/transports/http/middleware/session"
+	"github.com/Southclaws/storyden/app/transports/http/openapi"
+	"github.com/Southclaws/storyden/internal/integration"
+	"github.com/Southclaws/storyden/internal/integration/e2e"
+	"github.com/Southclaws/storyden/tests"
+)
+
+func TestNodesTreeQueryingVisibilityFilters(t *testing.T) {
+	t.Parallel()
+
+	integration.Test(t, nil, e2e.Setup(), fx.Invoke(func(
+		lc fx.Lifecycle,
+		root context.Context,
+		cl *openapi.ClientWithResponses,
+		cj *session.Jar,
+		aw *account_writer.Writer,
+	) {
+		lc.Append(fx.StartHook(func() {
+			adminCtx, _ := e2e.WithAccount(root, aw, seed.Account_001_Odin)
+			adminSession := e2e.WithSession(adminCtx, cj)
+
+			member1Ctx, _ := e2e.WithAccount(root, aw, seed.Account_007_Freyr)
+			member1Session := e2e.WithSession(member1Ctx, cj)
+
+			// member2Ctx, _ := e2e.WithAccount(root, aw, seed.Account_008_Heimdallr)
+			// member2Session := e2e.WithSession(member2Ctx, cj)
+
+			published := openapi.Published
+			draft := openapi.Draft
+
+			// SETUP: 4 published library pages
+			//
+			// node1       <- root               has 2 children: node2 and node3
+			// |- node2    <- child of node1     has no children
+			// |- node3    <- child of node1     has 1 child: node4
+			//    |- node4 <- child of node3     has no children
+
+			node1, err := cl.NodeCreateWithResponse(root, openapi.NodeInitialProps{Name: un("n1"), Visibility: &published}, adminSession)
+			tests.Ok(t, err, node1)
+
+			node2, err := cl.NodeCreateWithResponse(root, openapi.NodeInitialProps{Name: un("n2"), Visibility: &published, Parent: &node1.JSON200.Slug}, adminSession)
+			tests.Ok(t, err, node2)
+
+			node3, err := cl.NodeCreateWithResponse(root, openapi.NodeInitialProps{Name: un("n3"), Visibility: &published, Parent: &node1.JSON200.Slug}, adminSession)
+			tests.Ok(t, err, node3)
+
+			node4, err := cl.NodeCreateWithResponse(root, openapi.NodeInitialProps{Name: un("n4"), Visibility: &published, Parent: &node3.JSON200.Slug}, adminSession)
+			tests.Ok(t, err, node4)
+
+			rootNodeIDs := []string{node1.JSON200.Id}
+			nonRootNodeIDs := []string{node2.JSON200.Id, node3.JSON200.Id, node4.JSON200.Id}
+
+			t.Run("query_all_top_level", func(t *testing.T) {
+				a := assert.New(t)
+
+				// member 1 creates a draft under node3
+				draft1, err := cl.NodeCreateWithResponse(root, openapi.NodeInitialProps{Name: un("m1draft"), Visibility: &draft, Parent: &node3.JSON200.Slug}, member1Session)
+				tests.Ok(t, err, draft1)
+
+				draftIDs := []string{draft1.JSON200.Id}
+
+				// listing with no filters should return only published nodes
+				list1, err := cl.NodeListWithResponse(root, &openapi.NodeListParams{}, member1Session)
+				tests.Ok(t, err, list1)
+				list1IDs := ids(list1.JSON200.Nodes)
+				a.Subset(list1IDs, rootNodeIDs)
+				a.NotSubset(list1IDs, nonRootNodeIDs)
+
+				// listing only drafts yields nothing because there are no
+				// drafts at the root meaning there are no fully draft trees.
+				list2, err := cl.NodeListWithResponse(root, &openapi.NodeListParams{Visibility: &[]openapi.Visibility{draft}}, member1Session)
+				tests.Ok(t, err, list2)
+				list2IDs := ids(list2.JSON200.Nodes)
+				a.NotSubset(list2IDs, rootNodeIDs)
+				a.NotSubset(list2IDs, draftIDs)
+				a.NotSubset(list2IDs, nonRootNodeIDs)
+			})
+
+			t.Run("query_published_and_drafts", func(t *testing.T) {
+				a := assert.New(t)
+
+				// member 1 creates a draft under node3
+				draft1, err := cl.NodeCreateWithResponse(root, openapi.NodeInitialProps{Name: un("m1draft"), Visibility: &draft, Parent: &node3.JSON200.Slug}, member1Session)
+				tests.Ok(t, err, draft1)
+
+				draftIDs := []string{draft1.JSON200.Id}
+
+				// listing published and drafts yields published nodes as well
+				// as drafts from this member interspersed with the full tree.
+				list3, err := cl.NodeListWithResponse(root, &openapi.NodeListParams{Visibility: &[]openapi.Visibility{published, draft}}, member1Session)
+				tests.Ok(t, err, list3)
+				list3IDs := ids(list3.JSON200.Nodes)
+				a.Subset(list3IDs, rootNodeIDs)
+				a.NotSubset(list3IDs, draftIDs)
+				a.NotSubset(list3IDs, nonRootNodeIDs)
+
+				n5 := find(t, list3.JSON200.Nodes, draft1.JSON200.Id)
+				a.Equal(draft1.JSON200.Id, n5.Id, "draft node is in the list under node3")
+			})
+		}))
+	}))
+}
+
+func un(n string) string {
+	return n + " " + xid.New().String()
+}
+
+func ids(nodes []openapi.NodeWithChildren) []string {
+	ids := make([]string, len(nodes))
+	for i, n := range nodes {
+		ids[i] = n.Id
+	}
+	return ids
+}
+
+func find(t *testing.T, roots []openapi.NodeWithChildren, id string) *openapi.NodeWithChildren {
+	t.Helper()
+
+	// walk from root through children looking for node with id == id
+	var walk func([]openapi.NodeWithChildren) *openapi.NodeWithChildren
+	walk = func(nodes []openapi.NodeWithChildren) *openapi.NodeWithChildren {
+		for _, n := range nodes {
+			if n.Id == id {
+				return &n
+			}
+			if n.Children != nil {
+				if r := walk(n.Children); r != nil {
+					return r
+				}
+			}
+		}
+		return nil
+	}
+
+	r := walk(roots)
+
+	if r == nil {
+		t.Fatalf("could not find node with id %s", id)
+	}
+
+	return r
+}

--- a/web/src/components/library/LibraryPageImportFromURL/LibraryPageImportFromURL.tsx
+++ b/web/src/components/library/LibraryPageImportFromURL/LibraryPageImportFromURL.tsx
@@ -1,11 +1,8 @@
 "use client";
 
-import { useState } from "react";
 import { Controller, ControllerProps } from "react-hook-form";
 
-import { InfoTip } from "@/components/site/InfoTip";
 import { FormErrorText } from "@/components/ui/FormErrorText";
-import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Form } from "@/screens/library/LibraryPageScreen/useLibraryPageScreen";
 import { HStack, LStack } from "@/styled-system/jsx";
@@ -27,14 +24,14 @@ export function LibraryPageImportFromURL(
         return (
           <LStack gap="0">
             <HStack w="full" justify="space-between">
-              {/* <Input
+              <Input
                 w="full"
                 size="sm"
                 variant="ghost"
                 color="fg.muted"
                 placeholder="External URL..."
-                {...form.field}
-              /> */}
+                onChange={form.field.onChange}
+              />
 
               {/* <HStack>
                 <InfoTip title="Generating a page from a URL">

--- a/web/src/components/library/LibraryPageMenu/LibraryPageMenu.tsx
+++ b/web/src/components/library/LibraryPageMenu/LibraryPageMenu.tsx
@@ -12,16 +12,12 @@ import { Props, useLibraryPageMenu } from "./useLibraryPageMenu";
 
 export function LibraryPageMenu({
   node,
-  onVisibilityChange,
-  onDelete,
   onClose,
   ...props
 }: Props & ButtonProps) {
-  const { reviewFlow, deleteEnabled, deleteProps, handleSelect } =
+  const { availableOperations, deleteEnabled, deleteProps, handleSelect } =
     useLibraryPageMenu({
       node,
-      onVisibilityChange,
-      onDelete,
       onClose,
     });
 
@@ -69,23 +65,14 @@ export function LibraryPageMenu({
 
               <Menu.Separator />
 
-              {reviewFlow && (
-                <>
-                  {reviewFlow.draftToReview && (
-                    <Menu.Item value="review">Submit for review</Menu.Item>
-                  )}
-                  {(reviewFlow.reviewToPublish ||
-                    reviewFlow.draftToPublish) && (
-                    <Menu.Item value="publish">Publish</Menu.Item>
-                  )}
-                  {reviewFlow.publishToReview && (
-                    <Menu.Item value="review">Unpublish</Menu.Item>
-                  )}
-                  {reviewFlow.reviewToDraft && (
-                    <Menu.Item value="draft">Revert to draft</Menu.Item>
-                  )}
-                </>
-              )}
+              {availableOperations.map((op) => (
+                <Menu.Item
+                  key={op.targetVisibility}
+                  value={op.targetVisibility}
+                >
+                  {op.label}
+                </Menu.Item>
+              ))}
 
               {deleteEnabled && (
                 <>

--- a/web/src/components/library/LibraryPageTree/LibraryPageTree.tsx
+++ b/web/src/components/library/LibraryPageTree/LibraryPageTree.tsx
@@ -3,20 +3,21 @@ import {
   TreeView as ArkTreeView,
   type TreeViewRootProps,
 } from "@ark-ui/react/tree-view";
+import { keyBy } from "lodash";
 import Link from "next/link";
 import { forwardRef, useState } from "react";
 
-import { NodeWithChildren } from "@/api/openapi-schema";
+import { NodeWithChildren, Visibility } from "@/api/openapi-schema";
 import { CreatePageAction } from "@/components/site/Navigation/Actions/CreatePage";
+import { NavigationHeader } from "@/components/site/Navigation/ContentNavigationList/NavigationHeader";
+import { visibilityColour } from "@/lib/library/visibilityColours";
 import { css, cx } from "@/styled-system/css";
-import { Box, HStack, splitCssProps } from "@/styled-system/jsx";
+import { HStack, splitCssProps } from "@/styled-system/jsx";
 import { type TreeViewVariantProps, treeView } from "@/styled-system/recipes";
 import { token } from "@/styled-system/tokens";
 import type { JsxStyleProps } from "@/styled-system/types";
 
 import { LibraryPageMenu } from "../LibraryPageMenu/LibraryPageMenu";
-
-import { useLibraryPageTree } from "./useLibraryPageTree";
 
 export interface TreeViewData {
   label: string;
@@ -30,16 +31,30 @@ export interface TreeViewProps
   currentNode: string | undefined;
 }
 
+const visibilitySortKey: Record<Visibility, number> = {
+  [Visibility.published]: 0,
+  [Visibility.review]: 1,
+  [Visibility.draft]: 2,
+  [Visibility.unlisted]: 3,
+};
+
+const visibilityLabels: Record<Visibility, string> = {
+  [Visibility.published]: "Published",
+  [Visibility.review]: "In review",
+  [Visibility.draft]: "Drafts",
+  [Visibility.unlisted]: "Unlisted",
+};
+
 export const LibraryPageTree = forwardRef<HTMLDivElement, TreeViewProps>(
   (props, ref) => {
     const [cssProps, localProps] = splitCssProps(props);
     const { data, currentNode, className, ...rootProps } = localProps;
 
-    const { handleDelete } = useLibraryPageTree(currentNode);
-
     const styles = treeView();
 
     const defaultExpandedValue: string[] = [];
+
+    const rootNodeMap = keyBy(data.children, (child) => child.id);
 
     // recursively find currentNode in data and add each parent to defaultExpandedValue
     const findCurrentNode = (node: NodeWithChildren) => {
@@ -62,29 +77,53 @@ export const LibraryPageTree = forwardRef<HTMLDivElement, TreeViewProps>(
 
     data.children.forEach(findCurrentNode);
 
-    const renderChild = (child: NodeWithChildren) => {
+    const renderChild = (child: NodeWithChildren, index: number) => {
+      const previous = index > 0 ? data.children[index - 1] : null;
+
+      const sameVisibilityAsPrevious = previous
+        ? previous.visibility === child.visibility
+        : true;
+
+      const isRoot = Boolean(rootNodeMap[child.id]);
+
+      const dividerLabel = visibilityLabels[child.visibility];
+
+      // We only show dividers on the root list, as this is the only list that's
+      // sorted by visibility.
+      const showDivider = isRoot && !sameVisibilityAsPrevious;
+
+      const isHighlighted = child.slug === currentNode;
+
       return (
         <ArkTreeView.Branch
           key={child.id}
           value={child.slug}
           className={styles.branch}
         >
+          {showDivider && (
+            <HStack mb="1">
+              <NavigationHeader href="/drafts">{dividerLabel}</NavigationHeader>
+            </HStack>
+          )}
+
           <TreeBranch
             styles={styles}
             child={child}
-            handleDelete={handleDelete}
+            isHighlighted={isHighlighted}
+            isRoot={isRoot}
           />
 
           <ArkTreeView.BranchContent className={styles.branchContent}>
-            {child.children?.map((child) =>
+            {child.children?.map((child, i) =>
               child.children ? (
-                renderChild(child)
+                renderChild(child, i)
               ) : (
                 <TreeItem
                   key={child.id}
                   styles={styles}
                   child={child}
-                  handleDelete={handleDelete}
+                  isHighlighted={isHighlighted}
+                  isRoot={isRoot}
                 />
               ),
             )}
@@ -93,16 +132,22 @@ export const LibraryPageTree = forwardRef<HTMLDivElement, TreeViewProps>(
       );
     };
 
+    const sortedByVisibility = data.children.sort((a, b) => {
+      return visibilitySortKey[a.visibility] - visibilitySortKey[b.visibility];
+    });
+
     return (
       <ArkTreeView.Root
         ref={ref}
         aria-label={data.label}
         className={cx(styles.root, css(cssProps), className)}
         defaultExpandedValue={defaultExpandedValue}
+        selectedValue={defaultExpandedValue}
+        focusedValue={currentNode}
         {...rootProps}
       >
         <ArkTreeView.Tree className={styles.tree}>
-          {data.children.map(renderChild)}
+          {sortedByVisibility.map(renderChild)}
         </ArkTreeView.Tree>
       </ArkTreeView.Root>
     );
@@ -114,24 +159,53 @@ LibraryPageTree.displayName = "DatagraphNodeTree";
 type BranchProps = {
   child: NodeWithChildren;
   styles: any;
-  handleDelete: (slug: string) => void;
+  isHighlighted: boolean;
+  isRoot: boolean;
 };
 
-function TreeBranch({ styles, child, handleDelete }: BranchProps) {
+function TreeBranch({ styles, child, isHighlighted, isRoot }: BranchProps) {
   // NOTE: We need some state here to track open/close of the menu because CSS
   // isn't quite enough to track this nicely. The reason for this is that when
   // the mouse moves away from the branch control, the container that holds the
   // menu trigger moves to display: none; and the menu closes unexpectedly.
   const [menuOpen, setOpen] = useState(false);
 
+  const isPublished = child.visibility === Visibility.published;
+  const visibilityLabel = child.visibility;
+
+  const label = isPublished ? child.name : `${child.name}`;
+
+  const branchColourPalette = visibilityColour(child.visibility);
+
+  const visibilityStyles = isRoot
+    ? "" // Don't show the visibility state styles for root items, is cluttered.
+    : css({
+        paddingX: "0.5",
+        borderRadius: "sm",
+        colorPalette: branchColourPalette,
+        borderWidth:
+          child.visibility === Visibility.published ? "none" : "thin",
+        borderColor: "colorPalette.8",
+        borderStyle:
+          child.visibility === Visibility.published ? "solid" : "dashed",
+      });
+
+  const highlightStyles = css({
+    background: isHighlighted ? "gray.a2" : undefined,
+  });
+
   return (
-    <ArkTreeView.BranchControl className={cx("group", styles.branchControl)}>
+    <ArkTreeView.BranchControl
+      className={cx("group", styles.branchControl, highlightStyles)}
+    >
       <ArkTreeView.BranchIndicator className={styles.branchIndicator}>
         {child.children?.length ? <ChevronRightIcon /> : <BulletIcon />}
       </ArkTreeView.BranchIndicator>
 
-      <ArkTreeView.BranchText asChild className={styles.branchText}>
-        <Link href={`/l/${child.slug}`}>{child.name}</Link>
+      <ArkTreeView.BranchText asChild className={cx(styles.branchText)}>
+        <Link href={`/l/${child.slug}`}>
+          <span className={visibilityStyles}>{label}</span>
+        </Link>
       </ArkTreeView.BranchText>
 
       <HStack
@@ -150,7 +224,6 @@ function TreeBranch({ styles, child, handleDelete }: BranchProps) {
           variant="ghost"
           onClose={() => setOpen(false)}
           node={child}
-          onDelete={handleDelete}
         />
       </HStack>
     </ArkTreeView.BranchControl>

--- a/web/src/components/site/Navigation/ContentNavigationList/ContentNavigationList.tsx
+++ b/web/src/components/site/Navigation/ContentNavigationList/ContentNavigationList.tsx
@@ -4,7 +4,7 @@ import { CategoryList } from "@/components/category/CategoryList/CategoryList";
 import { Divider, LStack, styled } from "@/styled-system/jsx";
 
 import { MembersAnchor } from "../Anchors/Members";
-import { DatagraphNavTree } from "../DatagraphNavTree/DatagraphNavTree";
+import { LibraryNavigationTree } from "../LibraryNavigationTree/LibraryNavigationTree";
 import { useNavigation } from "../useNavigation";
 
 export function ContentNavigationList() {
@@ -23,17 +23,11 @@ export function ContentNavigationList() {
     >
       <LStack gap="1">
         <CategoryList />
-        <DatagraphNavTree
+        <LibraryNavigationTree
           label="Library"
           href="/l"
           currentNode={nodeSlug}
-          visibility={["published"]}
-        />
-        <DatagraphNavTree
-          label="Private"
-          href="/drafts"
-          currentNode={nodeSlug}
-          visibility={["draft", "review", "unlisted"]}
+          visibility={["draft", "review", "unlisted", "published"]}
         />
       </LStack>
 

--- a/web/src/components/site/Navigation/LibraryNavigationTree/LibraryNavigationTree.tsx
+++ b/web/src/components/site/Navigation/LibraryNavigationTree/LibraryNavigationTree.tsx
@@ -1,46 +1,17 @@
 "use client";
 
-import { useNodeList } from "@/api/openapi-client/nodes";
-import { Visibility } from "@/api/openapi-schema";
-import { useSession } from "@/auth";
 import { LibraryPageTree } from "@/components/library/LibraryPageTree/LibraryPageTree";
 import { LStack } from "@/styled-system/jsx";
-import { hasPermission } from "@/utils/permissions";
 
 import { Unready } from "../../Unready";
 import { CreatePageAction } from "../Actions/CreatePage";
 import { NavigationHeader } from "../ContentNavigationList/NavigationHeader";
 
-type Props = {
-  label: string;
-  href: string;
-  currentNode: string | undefined;
-  visibility: Visibility[];
-};
+import { Props, useLibraryNavigationTree } from "./useLibraryNavigationTree";
 
-export function useDatagraphNavTree({ visibility }: Props) {
-  const session = useSession();
-  const { data, error } = useNodeList({
-    visibility,
-  });
-  if (!data) {
-    return {
-      ready: false as const,
-      error,
-    };
-  }
-
-  const canManageLibrary = hasPermission(session, "MANAGE_LIBRARY");
-
-  return {
-    ready: true as const,
-    data,
-    canManageLibrary,
-  };
-}
-
-export function DatagraphNavTree(props: Props) {
-  const { ready, error, data, canManageLibrary } = useDatagraphNavTree(props);
+export function LibraryNavigationTree(props: Props) {
+  const { ready, error, data, canManageLibrary } =
+    useLibraryNavigationTree(props);
   if (!ready) {
     return <Unready error={error} />;
   }

--- a/web/src/components/site/Navigation/LibraryNavigationTree/useLibraryNavigationTree.ts
+++ b/web/src/components/site/Navigation/LibraryNavigationTree/useLibraryNavigationTree.ts
@@ -1,0 +1,34 @@
+"use client";
+
+import { useNodeList } from "@/api/openapi-client/nodes";
+import { Visibility } from "@/api/openapi-schema";
+import { useSession } from "@/auth";
+import { hasPermission } from "@/utils/permissions";
+
+export type Props = {
+  label: string;
+  href: string;
+  currentNode: string | undefined;
+  visibility: Visibility[];
+};
+
+export function useLibraryNavigationTree({ visibility }: Props) {
+  const session = useSession();
+  const { data, error } = useNodeList({
+    visibility,
+  });
+  if (!data) {
+    return {
+      ready: false as const,
+      error,
+    };
+  }
+
+  const canManageLibrary = hasPermission(session, "MANAGE_LIBRARY");
+
+  return {
+    ready: true as const,
+    data,
+    canManageLibrary,
+  };
+}

--- a/web/src/lib/library/library.ts
+++ b/web/src/lib/library/library.ts
@@ -270,6 +270,7 @@ export function useLibraryMutation(params?: NodeListParams) {
 
     await nodeDelete(slug, { target_node: newParent });
 
+    // TODO: Ensure redirect only happens if you're viewing this actual page.
     if (newParent) {
       const newPath = replaceLibraryPath(libraryPath, slug, newParent);
       router.push(newPath);

--- a/web/src/lib/library/visibilityColours.ts
+++ b/web/src/lib/library/visibilityColours.ts
@@ -1,0 +1,15 @@
+import { Visibility } from "@/api/openapi-schema";
+import { ColorPalette } from "@/styled-system/tokens";
+
+export function visibilityColour(v: Visibility): ColorPalette {
+  switch (v) {
+    case Visibility.published:
+      return "bg";
+    case Visibility.review:
+      return "blue";
+    case Visibility.draft:
+      return "green";
+    case Visibility.unlisted:
+      return "pink";
+  }
+}

--- a/web/src/recipes/tree-view.ts
+++ b/web/src/recipes/tree-view.ts
@@ -108,7 +108,7 @@ export const treeView = defineSlotRecipe({
           top: "0",
           width: "2px",
           height: "full",
-          bg: "accent.default",
+          bg: "fg.default",
           zIndex: "1",
         },
       },

--- a/web/src/screens/library/LibraryPageScreen/LibraryPageScreen.tsx
+++ b/web/src/screens/library/LibraryPageScreen/LibraryPageScreen.tsx
@@ -96,11 +96,7 @@ export function LibraryPage(props: Props) {
                     <EditAction onClick={handleEditMode}>Edit</EditAction>
                   </>
                 )}
-                <LibraryPageMenu
-                  node={node}
-                  onVisibilityChange={handleVisibilityChange}
-                  onDelete={handleDelete}
-                />
+                <LibraryPageMenu node={node} />
               </HStack>
             )}
           </HStack>


### PR DESCRIPTION
now, all items are rendered in a single tree, published and draft are interspersed for easier management, drafts/submissions are kept in the correct position in the tree so authors can find them. drafts/etc are highlighted using a coloured border for easier identification of non-published items.

new implementation and tests for visibility filtering