### PR TITLE
use a separate address config for SSR calls

### DIFF
--- a/app/transports/http/bindings/nodes.go
+++ b/app/transports/http/bindings/nodes.go
@@ -133,6 +133,7 @@ func (c *Nodes) NodeList(ctx context.Context, request openapi.NodeListRequestObj
 		return nil, fault.Wrap(err, fctx.With(ctx))
 	}
 
+	// TODO: Clean this mess up.
 	acc, err := opt.MapErr(session.GetOptAccountID(ctx), func(aid account.AccountID) (account.Account, error) {
 		a, err := c.accountQuery.GetByID(ctx, aid)
 		if err != nil {
@@ -142,7 +143,11 @@ func (c *Nodes) NodeList(ctx context.Context, request openapi.NodeListRequestObj
 		return *a, nil
 	})
 	if err != nil {
-		return nil, fault.Wrap(err, fctx.With(ctx))
+		if ftag.Get(err) == ftag.NotFound {
+			acc = opt.NewEmpty[account.Account]()
+		} else {
+			return nil, fault.Wrap(err, fctx.With(ctx))
+		}
 	}
 
 	var cs []*library.Node

--- a/app/transports/http/middleware/session_cookie/cookie.go
+++ b/app/transports/http/middleware/session_cookie/cookie.go
@@ -6,11 +6,9 @@ package session_cookie
 import (
 	"context"
 	"net/http"
-	"net/url"
 	"time"
 
 	"github.com/rs/xid"
-	"golang.org/x/net/publicsuffix"
 
 	"github.com/Southclaws/fault"
 	"github.com/Southclaws/fault/fmsg"
@@ -23,7 +21,7 @@ import (
 // TODO: Allow changing this via config.
 const (
 	secureCookieName = "storyden-session"
-	sameSiteMode     = http.SameSiteDefaultMode
+	sameSiteMode     = http.SameSiteLaxMode
 	cookieLifespan   = time.Hour * 24 * 90
 )
 
@@ -38,7 +36,7 @@ type Jar struct {
 }
 
 func New(cfg config.Config, ss *securecookie.Session) (*Jar, error) {
-	domain, err := getDomain(cfg.PublicAPIAddress)
+	domain, err := getCookieDomain(cfg.PublicAPIAddress, cfg.PublicWebAddress)
 	if err != nil {
 		return nil, fault.Wrap(err, fmsg.With("failed to parse domain from public API address"))
 	}
@@ -48,31 +46,6 @@ func New(cfg config.Config, ss *securecookie.Session) (*Jar, error) {
 		ss:               ss,
 		secureCookieName: secureCookieName,
 	}, nil
-}
-
-func getDomain(address url.URL) (string, error) {
-	// We want to use the site's domain, not the API's subdomain to ensure that
-	// cookies can be used in both the frontend and for the API. This assumption
-	// is based on the idea that Storyden must be hosted on a single domain with
-	// the API and frontend on different subdomains. For example, if your site
-	// was "www.cats.com" and the API was "api.cats.com", then the domain config
-	// would be set up with `www.cats.com` as the `PUBLIC_WEB_ADDRESS` and then
-	// `api.cats.com` as the `PUBLIC_API_ADDRESS` and then this code would use
-	// the API address hostname to parse `cats.com` as the actual cookie domain.
-	// The reason for this is that it makes SSR frontends trivial to implement.
-
-	hostname := address.Hostname()
-
-	if hostname == "localhost" {
-		return hostname, nil
-	}
-
-	domain, err := publicsuffix.EffectiveTLDPlusOne(hostname)
-	if err != nil {
-		return "", fault.Wrap(err, fmsg.With("failed to parse domain from public API address"))
-	}
-
-	return domain, nil
 }
 
 func (j *Jar) createWithValue(value string, expire time.Time) *http.Cookie {

--- a/app/transports/http/middleware/session_cookie/domain.go
+++ b/app/transports/http/middleware/session_cookie/domain.go
@@ -1,0 +1,143 @@
+package session_cookie
+
+import (
+	"net/url"
+	"slices"
+	"strings"
+
+	"github.com/Southclaws/fault"
+	"golang.org/x/net/publicsuffix"
+)
+
+type Domain []string
+
+func DomainFromURL(u url.URL) (Domain, error) {
+	return DomainFromString(u.Hostname())
+}
+
+func DomainFromString(s string) (Domain, error) {
+	if s == "" {
+		return nil, fault.New("empty domain")
+	}
+
+	if s != "localhost" {
+		_, err := publicsuffix.EffectiveTLDPlusOne(s)
+		if err != nil {
+			return nil, fault.Wrap(err)
+		}
+	}
+
+	parts := strings.Split(s, ".")
+	slices.Reverse(parts)
+
+	return parts, nil
+}
+
+func (d Domain) String() string {
+	parts := d
+	slices.Reverse(parts)
+	return strings.Join(parts, ".")
+}
+
+func (d Domain) IsSubdomainOf(other Domain) bool {
+	if len(d) < len(other) {
+		return false
+	}
+
+	for i := 0; i < len(other); i++ {
+		if d[i] != other[i] {
+			return false
+		}
+	}
+
+	return true
+}
+
+func (d Domain) IsSiblingOf(other Domain) bool {
+	if len(d) != len(other) {
+		return false
+	}
+
+	length := len(d)
+
+	for i := 0; i < length-1; i++ {
+		if d[i] != other[i] {
+			return false
+		}
+	}
+
+	return true
+}
+
+func (d Domain) IsEqual(other Domain) bool {
+	if len(d) != len(other) {
+		return false
+	}
+
+	for i := 0; i < len(other); i++ {
+		if d[i] != other[i] {
+			return false
+		}
+	}
+
+	return true
+}
+
+func (d Domain) IsLocalhost() bool {
+	return len(d) == 1 && d[0] == "localhost"
+}
+
+func (d Domain) IsTopLevel() bool {
+	tldp1, err := publicsuffix.EffectiveTLDPlusOne(strings.Join(d, "."))
+	if err != nil {
+		return false
+	}
+
+	return strings.Join(d, ".") == tldp1
+}
+
+func (d Domain) GetETLDp1() Domain {
+	s := d.String()
+
+	if s == "localhost" {
+		return d
+	}
+
+	// error already handled during d's construction
+	etldp1, _ := publicsuffix.EffectiveTLDPlusOne(s)
+	// only error from this is from the above call, so won't happen.
+	d2, _ := DomainFromString(etldp1)
+
+	return d2
+}
+
+func getCookieDomain(backend, frontend url.URL) (string, error) {
+	// If both frontend and backend are hosted on the same domain just use that.
+	if backend.Hostname() == frontend.Hostname() {
+		return backend.Hostname(), nil
+	}
+
+	backendDomain, err := DomainFromURL(backend)
+	if err != nil {
+		return "", err
+	}
+
+	frontendDomain, err := DomainFromURL(frontend)
+	if err != nil {
+		return "", err
+	}
+
+	// If frontend and backend are on different subdomains use backend's domain.
+	// example: api.cats.com and site.cats.com
+	if frontendDomain.IsSiblingOf(backendDomain) {
+		return backendDomain.String(), nil
+	}
+
+	// If frontend is on a lower level domain than the backend use TLD+1.
+	// example: api.cats.com and cats.com
+	if backendDomain.IsSubdomainOf(frontendDomain) {
+		return frontendDomain.String(), nil
+	}
+
+	return backendDomain.String(), nil
+}

--- a/app/transports/http/middleware/session_cookie/domain_test.go
+++ b/app/transports/http/middleware/session_cookie/domain_test.go
@@ -1,0 +1,151 @@
+package session_cookie
+
+import (
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestDomainType(t *testing.T) {
+	r := require.New(t)
+
+	d, err := DomainFromString("localhost")
+	r.NoError(err)
+	r.Equal(Domain{"localhost"}, d)
+	r.Equal("localhost", d.String())
+
+	d, err = DomainFromString("example.com")
+	r.NoError(err)
+	r.Equal(Domain{"com", "example"}, d)
+	r.Equal("example.com", d.String())
+
+	d, err = DomainFromString("sub.example.com")
+	r.NoError(err)
+	r.Equal(Domain{"com", "example", "sub"}, d)
+	r.Equal("sub.example.com", d.String())
+
+	d, err = DomainFromString("sub.sub.example.com")
+	r.NoError(err)
+	r.Equal(Domain{"com", "example", "sub", "sub"}, d)
+	r.Equal("sub.sub.example.com", d.String())
+
+	_, err = DomainFromString("")
+	r.Error(err)
+
+	_, err = DomainFromString("example")
+	r.Error(err)
+}
+
+func TestIsSubdomainOf(t *testing.T) {
+	r := require.New(t)
+
+	d1, _ := DomainFromString("sub.example.com")
+	d2, _ := DomainFromString("example.com")
+
+	r.True(d1.IsSubdomainOf(d2))
+	r.False(d2.IsSubdomainOf(d1))
+
+	d3, _ := DomainFromString("sub.example.com")
+	d4, _ := DomainFromString("dom.example.com")
+
+	r.False(d3.IsSubdomainOf(d4))
+	r.False(d4.IsSubdomainOf(d3))
+}
+
+func TestIsSiblingOf(t *testing.T) {
+	r := require.New(t)
+
+	d1, _ := DomainFromString("sub.example.com")
+	d2, _ := DomainFromString("example.com")
+
+	r.False(d1.IsSiblingOf(d2))
+	r.False(d2.IsSiblingOf(d1))
+
+	d3, _ := DomainFromString("sub.example.com")
+	d4, _ := DomainFromString("dom.example.com")
+
+	r.True(d3.IsSiblingOf(d4))
+	r.True(d4.IsSiblingOf(d3))
+}
+
+func TestIsEqual(t *testing.T) {
+	r := require.New(t)
+
+	d1, _ := DomainFromString("sub.example.com")
+	d2, _ := DomainFromString("example.com")
+
+	r.False(d1.IsEqual(d2))
+	r.False(d2.IsEqual(d1))
+
+	d3, _ := DomainFromString("sub.example.com")
+	d4, _ := DomainFromString("sub.example.com")
+
+	r.True(d3.IsEqual(d4))
+	r.True(d4.IsEqual(d3))
+}
+
+func TestIsLocalhost(t *testing.T) {
+	r := require.New(t)
+
+	d1, _ := DomainFromString("localhost")
+	r.True(d1.IsLocalhost())
+
+	d2, _ := DomainFromString("example.com")
+	r.False(d2.IsLocalhost())
+}
+
+func TestIsETLDPlus1(t *testing.T) {
+	r := require.New(t)
+
+	d1, _ := DomainFromString("localhost")
+	r.False(d1.IsTopLevel())
+
+	d2, _ := DomainFromString("example.com")
+	r.True(d2.IsTopLevel())
+
+	d3, _ := DomainFromString("sub.example.com")
+	r.False(d3.IsTopLevel())
+}
+
+func TestGetETLDp1(t *testing.T) {
+	r := require.New(t)
+
+	d1, _ := DomainFromString("localhost")
+	r.Equal(Domain{"localhost"}, d1.GetETLDp1())
+
+	d2, _ := DomainFromString("example.com")
+	r.Equal(Domain{"com", "example"}, d2.GetETLDp1())
+
+	d3, _ := DomainFromString("sub.example.com")
+	r.Equal(Domain{"com", "example"}, d3.GetETLDp1())
+}
+
+func TestGetCookieDomain(t *testing.T) {
+	r := require.New(t)
+
+	d1, err := getCookieDomain(u("http://localhost:8080"), u("http://localhost:8080"))
+	r.NoError(err)
+	r.Equal("localhost", d1)
+
+	d2, err := getCookieDomain(u("https://api.makeroom.club"), u("https://makeroom.club"))
+	r.NoError(err)
+	r.Equal("makeroom.club", d2)
+
+	d3, err := getCookieDomain(u("https://api.makeroom.club"), u("https://www.makeroom.club"))
+	r.NoError(err)
+	r.Equal("api.makeroom.club", d3)
+
+	d4, err := getCookieDomain(u("https://makeroom.club"), u("https://community.makeroom.club"))
+	r.NoError(err)
+	r.Equal("makeroom.club", d4)
+
+	d5, err := getCookieDomain(u("https://makeroom.club"), u("https://makeroom.club"))
+	r.NoError(err)
+	r.Equal("makeroom.club", d5)
+}
+
+func u(s string) url.URL {
+	u, _ := url.Parse(s)
+	return *u
+}

--- a/docker/all/Dockerfile
+++ b/docker/all/Dockerfile
@@ -80,4 +80,15 @@ VOLUME [ "/data" ]
 ENV RUN_FRONTEND "server.js"
 ENV PROXY_FRONTEND_ADDRESS "http://localhost:3000"
 
+# The fullstack image uses the backend as a proxy for the frontend, this means
+# that the address for both are the same. Change via -e if deployed publicly.
+ENV PUBLIC_API_ADDRESS="http://localhost:8000"
+ENV PUBLIC_WEB_ADDRESS="http://localhost:8000"
+
+# You won't need to change this ever, if you do then this image is not for you.
+# This tells the Next.js server to make local HTTP requests directly to the API
+# server instead of going via some external network and through the API proxy.
+# This setting is pretty much only used when both services run side by side.
+ENV SSR_API_ADDRESS="http://localhost:8000"
+
 ENTRYPOINT ["./backend"]

--- a/web/next.config.js
+++ b/web/next.config.js
@@ -7,6 +7,7 @@ const nextConfig = {
   images: {
     loader: "custom",
     loaderFile: "./src/lib/asset/loader.js",
+    unoptimized: true,
   },
 };
 

--- a/web/src/api/common.ts
+++ b/web/src/api/common.ts
@@ -1,6 +1,6 @@
 import { filter, flow, reduce, toPairs } from "lodash/fp";
 
-import { API_ADDRESS } from "@/config";
+import { getAPIAddress } from "@/config";
 
 export type Options = {
   url: string;
@@ -30,7 +30,8 @@ export function buildRequest({
   data,
   revalidate,
 }: Options): Request {
-  const address = `${API_ADDRESS}/api${url}${cleanQuery(params)}`;
+  const apiAddress = getAPIAddress();
+  const address = `${apiAddress}/api${url}${cleanQuery(params)}`;
   const _method = method.toUpperCase();
 
   return new Request(address, {

--- a/web/src/app/layout.tsx
+++ b/web/src/app/layout.tsx
@@ -4,6 +4,7 @@ import { PropsWithChildren } from "react";
 import { getColourAsHex } from "src/utils/colour";
 
 import { inter, interDisplay } from "@/app/fonts";
+import { serverEnvironment } from "@/config";
 import { getSettings } from "@/lib/settings/settings-server";
 import { getIconURL } from "@/utils/icon";
 
@@ -13,10 +14,7 @@ import { Providers } from "./providers";
 
 export const dynamic = "force-dynamic";
 
-const API_ADDRESS =
-  global.process.env["NEXT_PUBLIC_API_ADDRESS"] ?? "http://localhost:8000";
-const WEB_ADDRESS =
-  global.process.env["NEXT_PUBLIC_WEB_ADDRESS"] ?? "http://localhost:3000";
+const { API_ADDRESS, WEB_ADDRESS } = serverEnvironment();
 
 export default async function RootLayout({ children }: PropsWithChildren) {
   return (

--- a/web/src/config.ts
+++ b/web/src/config.ts
@@ -1,7 +1,7 @@
 import { z } from "zod";
 
-const DEFAULT_API_ADDRESS = "http://localhost:8000";
-const DEFAULT_WEB_ADDRESS = "http://localhost:3000";
+export const DEFAULT_API_ADDRESS = "http://localhost:8000";
+export const DEFAULT_WEB_ADDRESS = "http://localhost:3000";
 
 export const ConfigSchema = z.object({
   API_ADDRESS: z.string(),
@@ -10,23 +10,27 @@ export const ConfigSchema = z.object({
 });
 export type Config = z.infer<typeof ConfigSchema>;
 
+export function serverEnvironment() {
+  return {
+    API_ADDRESS:
+      global.process.env["NEXT_PUBLIC_API_ADDRESS"] ??
+      global.process.env["PUBLIC_API_ADDRESS"] ??
+      DEFAULT_API_ADDRESS,
+    WEB_ADDRESS:
+      global.process.env["NEXT_PUBLIC_WEB_ADDRESS"] ??
+      global.process.env["PUBLIC_WEB_ADDRESS"] ??
+      DEFAULT_WEB_ADDRESS,
+    source: "server" as const,
+  };
+}
+
 function isomorphicEnvironment(): Config {
   if (typeof window !== "undefined") {
     const config = ConfigSchema.parse((window as any).__storyden__);
     console.log("loaded window config", config);
     return config;
   } else {
-    const config = {
-      API_ADDRESS:
-        global.process.env["NEXT_PUBLIC_API_ADDRESS"] ??
-        global.process.env["PUBLIC_API_ADDRESS"] ??
-        DEFAULT_API_ADDRESS,
-      WEB_ADDRESS:
-        global.process.env["NEXT_PUBLIC_WEB_ADDRESS"] ??
-        global.process.env["PUBLIC_WEB_ADDRESS"] ??
-        DEFAULT_WEB_ADDRESS,
-      source: "server" as const,
-    };
+    const config = serverEnvironment();
     console.log("loaded server config", config);
     return config;
   }
@@ -37,3 +41,21 @@ const env = isomorphicEnvironment();
 export const API_ADDRESS = env.API_ADDRESS;
 
 export const WEB_ADDRESS = env.WEB_ADDRESS;
+
+export function getAPIAddress() {
+  if (typeof window !== "undefined") {
+    // When called on the client, return the public API address, such as:
+    // https://api.mystorydencommunity.com
+    return env.API_ADDRESS;
+  } else {
+    // When called on the server side, we may be running in a container beside
+    // the API (the "fullstack" container image) so return the internal address
+    // if it's set, otherwise the regular API_ADDRESS configuration value.
+    return (
+      // The default fullstack image will set this value automatically to :8000.
+      global.process.env["SSR_API_ADDRESS"] ??
+      // There's no SSR address set so just use the public API address.
+      env.API_ADDRESS
+    );
+  }
+}


### PR DESCRIPTION
this fixes a minor issue where if backend and frontend are deployed side by side, API calls from SSR components will use the public address even when the server side (local network) version is better for most cases.

This introduces an additional configuration value for the frontend called `SSR_API_ADDRESS` which only applies to SSR API calls.