### PR TITLE
[#216] Add thread likes on the feed

### DIFF
--- a/web/src/components/post/LikeButton/LikeButton.tsx
+++ b/web/src/components/post/LikeButton/LikeButton.tsx
@@ -2,13 +2,11 @@ import { Box } from "@/styled-system/jsx";
 
 import { Props, useLikeButton } from "./useLikeButton";
 import { LikeAction } from "@/components/site/Action/Like";
-import { useFeedMutations } from "@/lib/feed/mutation";
-import { handle } from "@/api/client";
 
 export function LikeButton(props: Props) {
 
   const { handleClick } = useLikeButton(
-    {thread: props.thread}
+    {thread: props.thread},
   );
 
   return (

--- a/web/src/components/post/LikeButton/LikeButton.tsx
+++ b/web/src/components/post/LikeButton/LikeButton.tsx
@@ -1,0 +1,24 @@
+import { Box } from "@/styled-system/jsx";
+
+import { Props, useLikeButton } from "./useLikeButton";
+import { LikeAction } from "@/components/site/Action/Like";
+import { useFeedMutations } from "@/lib/feed/mutation";
+import { handle } from "@/api/client";
+
+export function LikeButton(props: Props) {
+
+  const { handleClick } = useLikeButton(
+    {thread: props.thread}
+  );
+
+  return (
+    <Box>
+      <LikeAction
+        variant="subtle"
+        size="xs"
+        liked={props.thread.likes.liked}
+        onClick={handleClick}
+      />
+    </Box>
+  );
+}

--- a/web/src/components/post/LikeButton/useLikeButton.ts
+++ b/web/src/components/post/LikeButton/useLikeButton.ts
@@ -3,38 +3,36 @@ import { PostReference } from "src/api/openapi-schema";
 import { handle } from "@/api/client";
 import { useFeedMutations } from "@/lib/feed/mutation";
 
-export type Props = {
-  thread: PostReference;
+export type UseLikeButtonProps = {
+ thread: PostReference;
 };
 
-export function useLikeButton({ thread }: Props) {
-  const { likePost, unlikePost, revalidate } = useFeedMutations();
+export function useLikeButton({ thread }: UseLikeButtonProps) {
+ const { likePost, unlikePost, revalidate } = useFeedMutations();
 
-  const handleClick = async () => {
-    // This is a toggle button, so we'll either like or unlike depending on what they have now.
-    if (thread.likes.liked) {
-        await handle(
-          async () => {
-            await unlikePost(thread.id);
-          },
-          {
-            cleanup: async () => await revalidate(),
-          },
-        );
-    } else {
-      await handle(
-        async () => {
-          await likePost(thread.id);
-        },
-        {
-          cleanup: async () => await revalidate(),
-        },
-      );
-    }
-  }
+ const cleanupHandler = async () => revalidate();
 
-  return {
-    ready: true as const,
-    handleClick
-  };
+ const handleClick = async () => {
+   // This is a toggle button, so we'll either like or unlike depending on what they have now.
+   if (thread.likes.liked) {
+     await handle(
+       async () => {
+         await unlikePost(thread.id);
+       },
+       { cleanup: cleanupHandler }
+     );
+   } else {
+     await handle(
+       async () => {
+         await likePost(thread.id);
+       },
+       { cleanup: cleanupHandler }
+     );
+   }
+ };
+
+ return {
+   ready: true as const,
+   handleClick,
+ };
 }

--- a/web/src/components/post/LikeButton/useLikeButton.ts
+++ b/web/src/components/post/LikeButton/useLikeButton.ts
@@ -3,11 +3,11 @@ import { PostReference } from "src/api/openapi-schema";
 import { handle } from "@/api/client";
 import { useFeedMutations } from "@/lib/feed/mutation";
 
-export type UseLikeButtonProps = {
+export type Props = {
  thread: PostReference;
 };
 
-export function useLikeButton({ thread }: UseLikeButtonProps) {
+export function useLikeButton({ thread }: Props) {
   const { likePost, unlikePost, revalidate } = useFeedMutations();
 
   const handleClick = async () => {

--- a/web/src/components/post/LikeButton/useLikeButton.ts
+++ b/web/src/components/post/LikeButton/useLikeButton.ts
@@ -8,28 +8,25 @@ export type UseLikeButtonProps = {
 };
 
 export function useLikeButton({ thread }: UseLikeButtonProps) {
- const { likePost, unlikePost, revalidate } = useFeedMutations();
+  const { likePost, unlikePost, revalidate } = useFeedMutations();
 
- const cleanupHandler = async () => revalidate();
-
- const handleClick = async () => {
-   // This is a toggle button, so we'll either like or unlike depending on what they have now.
-   if (thread.likes.liked) {
-     await handle(
-       async () => {
-         await unlikePost(thread.id);
-       },
-       { cleanup: cleanupHandler }
-     );
-   } else {
-     await handle(
-       async () => {
-         await likePost(thread.id);
-       },
-       { cleanup: cleanupHandler }
-     );
-   }
- };
+  const handleClick = async () => {
+    await handle(
+      async () => {
+        // This is a toggle button, so we'll either like or unlike depending on what they have now.
+        if (thread.likes.liked) {
+          await unlikePost(thread.id);
+        } else {
+          await likePost(thread.id);
+        }
+      },
+      {
+        async cleanup() {
+          await revalidate();
+        },
+      },
+    );
+  }
 
  return {
    ready: true as const,

--- a/web/src/components/post/LikeButton/useLikeButton.ts
+++ b/web/src/components/post/LikeButton/useLikeButton.ts
@@ -1,0 +1,40 @@
+import { PostReference } from "src/api/openapi-schema";
+
+import { handle } from "@/api/client";
+import { useFeedMutations } from "@/lib/feed/mutation";
+
+export type Props = {
+  thread: PostReference;
+};
+
+export function useLikeButton({ thread }: Props) {
+  const { likePost, unlikePost, revalidate } = useFeedMutations();
+
+  const handleClick = async () => {
+    // This is a toggle button, so we'll either like or unlike depending on what they have now.
+    if (thread.likes.liked) {
+        await handle(
+          async () => {
+            await unlikePost(thread.id);
+          },
+          {
+            cleanup: async () => await revalidate(),
+          },
+        );
+    } else {
+      await handle(
+        async () => {
+          await likePost(thread.id);
+        },
+        {
+          cleanup: async () => await revalidate(),
+        },
+      );
+    }
+  }
+
+  return {
+    ready: true as const,
+    handleClick
+  };
+}

--- a/web/src/components/post/ThreadCard.tsx
+++ b/web/src/components/post/ThreadCard.tsx
@@ -11,6 +11,7 @@ import { HStack, styled } from "@/styled-system/jsx";
 import { getAssetURL } from "@/utils/asset";
 
 import { ThreadMenu } from "../thread/ThreadMenu/ThreadMenu";
+import { LikeButton } from "./LikeButton/LikeButton";
 import {
   DiscussionIcon,
   DiscussionParticipatingIcon,
@@ -48,6 +49,7 @@ export const ThreadReferenceCard = memo(({ thread }: Props) => {
       controls={
         session && (
           <HStack>
+            <LikeButton thread={thread} />
             <CollectionMenu account={session} thread={thread} />
             <ThreadMenu thread={thread} />
           </HStack>

--- a/web/src/components/site/Action/Like.tsx
+++ b/web/src/components/site/Action/Like.tsx
@@ -1,0 +1,17 @@
+import { ButtonProps } from "@/components/ui/button";
+import { IconButton } from "@/components/ui/icon-button";
+import {
+  LikeIcon,
+  LikeSavedIcon,
+} from "@/components/ui/icons/Like";
+
+type Props = ButtonProps & { liked: boolean };
+
+export function LikeAction(props: Props) {
+  const { liked, ...rest } = props;
+  return (
+    <IconButton variant="subtle" size="xs" {...rest}>
+      {liked ? <LikeSavedIcon /> : <LikeIcon />}
+    </IconButton>
+  );
+}

--- a/web/src/components/site/Action/Like.tsx
+++ b/web/src/components/site/Action/Like.tsx
@@ -10,7 +10,13 @@ type Props = ButtonProps & { liked: boolean };
 export function LikeAction(props: Props) {
   const { liked, ...rest } = props;
   return (
-    <IconButton variant="subtle" size="xs" {...rest}>
+    <IconButton 
+      variant="subtle" 
+      size="xs" 
+      aria-pressed={liked} 
+      aria-label={liked ? "Unlike" : "Like"}
+      title={liked ? "Unlike" : "Like"}
+      {...rest}>
       {liked ? <LikeSavedIcon /> : <LikeIcon />}
     </IconButton>
   );

--- a/web/src/lib/feed/mutation.ts
+++ b/web/src/lib/feed/mutation.ts
@@ -145,8 +145,8 @@ export function useFeedMutations(session?: Account, params?: ThreadListParams) {
             ...thread,
             likes: {
               likes: thread.likes.likes + 1,
-              liked: true
-            }
+              liked: true,
+            },
           };
         }
         return thread;
@@ -175,8 +175,8 @@ export function useFeedMutations(session?: Account, params?: ThreadListParams) {
             ...thread,
             likes: {
               likes: thread.likes.likes - 1,
-              liked: false
-            }
+              liked: false,
+            },
           };
         }
         return thread;

--- a/web/src/lib/feed/mutation.ts
+++ b/web/src/lib/feed/mutation.ts
@@ -16,6 +16,7 @@ import {
   ThreadListParams,
   ThreadReference,
 } from "@/api/openapi-schema";
+import { likePostAdd, likePostRemove } from "@/api/openapi-client/likes";
 
 export function useFeedMutations(session?: Account, params?: ThreadListParams) {
   const { mutate } = useSWRConfig();
@@ -134,9 +135,71 @@ export function useFeedMutations(session?: Account, params?: ThreadListParams) {
     await threadDelete(id);
   }
 
+  async function likePost(id: Identifier) {
+    const mutator: MutatorCallback<ThreadListOKResponse> = (data) => {
+      if (!data) return;
+
+      const newThreads = data.threads.map((thread) => {
+        if (thread.id === id) {
+          return {
+            ...thread,
+            likes: {
+              likes: thread.likes.likes + 1,
+              liked: true
+            }
+          };
+        }
+        return thread;
+      });
+
+      return {
+        ...data,
+        threads: newThreads,
+      };
+    }
+
+    await mutate(threadListKeyFilterFn, mutator, {
+      revalidate: false,
+    });
+
+    await likePostAdd(id);
+  }
+
+  async function unlikePost(id: Identifier) {
+    const mutator: MutatorCallback<ThreadListOKResponse> = (data) => {
+      if (!data) return;
+
+      const newThreads = data.threads.map((thread) => {
+        if (thread.id === id) {
+          return {
+            ...thread,
+            likes: {
+              likes: thread.likes.likes - 1,
+              liked: false
+            }
+          };
+        }
+        return thread;
+      });
+
+      return {
+        ...data,
+        threads: newThreads,
+      };
+    }
+
+    await mutate(threadListKeyFilterFn, mutator, {
+      revalidate: false,
+    });
+
+    await likePostRemove(id);
+  }
+
   return {
     createThread,
     deleteThread,
+    likePost,
+    unlikePost,
     revalidate,
   };
 }


### PR DESCRIPTION
To resolve issue #216.

This PR adds a like button to threads on the feed, to the left of the collections menu. To accomplish this, it adds `likePost` and `unlikePost` to feed mutations, which mutates the current state and sends the request to like/unlike before eventually revalidating. 

I assume some eventual work would also be to put this in the thread view itself somewhere -- we can also add that now if it makes sense to do it all at once.

Some related questions that might also be worth considering: 
- Is useFeedMutations a good place for the like/unlike methods or is it cleaner as its own file? This does mutate the feed thread list's `liked` flag, but doesn't seem totally related other than the fact that it takes place on the feed view. 
- Is there a better approach than the mutation doing a full thread list, given that it will only update one thread, or is that insignificant here?

Happy to hear any feedback or improvements you would want made, or if you want to go another direction with how these work as a whole. Appreciate it :+1: 