### PR TITLE
Set up version numbering and releases

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,22 @@ docker run -p 8000:8000 ghcr.io/southclaws/storyden
 
 ![A screenshot of a Storyden instance](home/public/2025_app_screenshot_viewport.png)
 
+## Releases and versions
+
+Storyden releases tagged versions using a simple version number which applies to the product _as a whole_ not the API surface. For this reason, we do not use "semantic versioning" and breaking API changes are avoided as much as possible. Sometimes breaking changes may occur but these will always be documented and called out in release notes as well as in a separate list of just breaking changes.
+
+```
+  v1.25.8
+   │ │  │
+   │ │  └── Release: increments for every release in the year.
+   │ └───── Year: releases happen frequently so we use a year marker for simplicity
+   └─────── Major: will always be 1
+```
+
+This format was chosen for compatibility with package/app registries and developer expectations, but it does not follow semantic versioning, it's more of a "build number" similar to how video games are versioned.
+
+Outside of a release commit/image, version numbers inside files and the API will be suffixed with `-canary` to indicate you're off a stable release.
+
 ## What can it do
 
 > https://www.storyden.org/docs/introduction/what-is-storyden

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -4,42 +4,78 @@ dotenv:
   - .env
 
 vars:
-  VERSION:
-    sh: git describe --always --tags
-  DOCKER_IMAGE_TAG: "storyden:{{.VERSION}}"
+  NEXT_VERSION:
+    sh: go run ./version.go
+
+  CURRENT_VERSION:
+    sh: git describe --tags --abbrev=0
 
 tasks:
-  default:
-    deps: [backend]
-    cmds:
-      - ./backend.exe
-    sources:
-      - cmd/**/*.go
-      - internal/**/*.go
-      - app/**/*.go
+  version:
+    desc: >
+      Yields the next version number for a new release. Will update all relevant
+      files with the new version number. These files include:
+        - openapi.yaml specification
+        - package.json for the frontend
+        - version.go for the backend
+      Due to the fact generated files also contain the version, this will also
+      trigger the codegen task to regenerate all of the related files.
 
-  production:
-    cmds:
-      - ./backend.exe
+      Example: v1.25.1
 
-  backend:
-    cmds:
-      - go build -o backend.exe -ldflags="-X 'github.com/Southclaws/storyden/internal/config.Version={{.VERSION}}'" ./cmd/backend
-  backend:test:
-    cmds:
-      - go test ./...
+    prompt:
+      - "Current version: {{.CURRENT_VERSION}} Next version: {{.NEXT_VERSION}} | Write new version to relevant files?"
 
-  # -
-  # Docker
-  # -
+    preconditions:
+      # Must be on main branch
+      - sh: '[ "$(git symbolic-ref --short HEAD)" = "main" ]'
+        msg: "Release must be done from the 'main' branch"
 
-  backend:image:build:
-    cmds:
-      - docker build -t {{.DOCKER_IMAGE_TAG}} .
+      # Working directory must be clean (no staged or unstaged changes)
+      - sh: '[ -z "$(git status --porcelain)" ]'
+        msg: "Working directory must be clean (no uncommitted changes)"
 
-  backend:image:run:
     cmds:
-      - docker run {{.DOCKER_IMAGE_TAG}}
+      - go run ./version.go -w
+      - task generate
+
+  release:post:
+    desc: >
+      After a tagged release, we write a version number again to the relevant
+      files to indicate they are canary builds. This happens after the actual
+      commit and tag have been created with the "next" version number and is 
+      there to ensure commits that land on `main` *after* a tagged release are
+      still identifiable as canary builds.
+
+      Example: 1.25.1-canary
+
+      Canary version numbers are NOT used as git tags. They are only used in
+      files to indicate the current commit or running version is not stable.
+    cmds:
+      - go run ./version.go -w -c
+      - git add .
+      - git commit -m "Post-release {{.CURRENT_VERSION}}"
+
+  release:
+    desc: >
+      Creates a new release by committing the changes made by the `version` task
+      and tagging the commit with the new version number. This does not however
+      push the changes or create the GitHub release resource itself. You must
+      do that separately as well as write a user-oriented change log for it.
+    deps: [version]
+    cmds:
+      - git add .
+      - git commit -m "Release {{.NEXT_VERSION}}"
+      - git tag {{.NEXT_VERSION}}
+      - task release:post
+
+  release:undo:
+    desc: >
+      Undoes the last release by deleting the last tag and resetting the working
+      directory to the state before the release commit.
+    cmds:
+      - git reset --hard HEAD~1
+      - git tag -d {{.CURRENT_VERSION}}
 
   # -
   # Code generation
@@ -65,6 +101,7 @@ tasks:
   generate:openapi:docs:
     dir: home
     cmds: [yarn openapi]
+
   # -
   # Database
   # -
@@ -72,7 +109,3 @@ tasks:
   seed:
     cmds:
       - go run ./cmd/seed
-
-  db:ui:
-    cmds:
-      - atlas schema inspect -d {{.DATABASE_URL}} -w

--- a/version.go
+++ b/version.go
@@ -101,15 +101,15 @@ func patchFile(path, pattern, replacement string) error {
 
 func writeVersion(v version) error {
 	if err := patchFile(packageJsonPath, `"version":\s*".+?"`, fmt.Sprintf(`"version": "%s"`, v.String())); err != nil {
-		return fmt.Errorf("failed to update openapi.yaml version: %w", err)
-	}
-
-	if err := patchFile(openapiPath, `version:\s*".+?"`, fmt.Sprintf(`version: "%s"`, v.String())); err != nil {
 		return fmt.Errorf("failed to update package.json version: %w", err)
 	}
 
+	if err := patchFile(openapiPath, `version:\s*".+?"`, fmt.Sprintf(`version: "%s"`, v.String())); err != nil {
+		return fmt.Errorf("failed to update openapi.yaml version: %w", err)
+	}
+
 	if err := patchFile(apiVersionPath, `Version\s*=\s*".+?"`, fmt.Sprintf(`Version = "%s"`, v.String())); err != nil {
-		return fmt.Errorf("failed to update internal/config/version.go: %w", err)
+		return fmt.Errorf("failed to update version.go: %w", err)
 	}
 
 	return nil

--- a/version.go
+++ b/version.go
@@ -1,0 +1,173 @@
+//go:build release
+
+package main
+
+import (
+	"bytes"
+	"errors"
+	"flag"
+	"fmt"
+	"os"
+	"os/exec"
+	"regexp"
+	"strconv"
+	"strings"
+	"time"
+)
+
+const (
+	packageJsonPath = `./web/package.json`
+	openapiPath     = `./api/openapi.yaml`
+	apiVersionPath  = `./internal/config/version.go`
+)
+
+type version struct {
+	one     int  // always v1
+	year    int  // two-digit year
+	release int  // release identifier
+	canary  bool // true if not a release but a canary build
+}
+
+func (v *version) String() string {
+	str := fmt.Sprintf("v%d.%02d.%d", v.one, v.year, v.release)
+	if v.canary {
+		str += "-canary"
+	}
+	return str
+}
+
+func parse(s string) (*version, error) {
+	var v version
+	_, err := fmt.Sscanf(s, "v%d.%d.%d", &v.one, &v.year, &v.release)
+	if err != nil {
+		return nil, err
+	}
+	return &v, nil
+}
+
+func (v *version) next() (*version, error) {
+	year, err := strconv.Atoi(time.Now().Format("06"))
+	if err != nil {
+		return nil, err
+	}
+
+	// Reset the release number if the year has changed.
+	if v.year != year {
+		v.year = year % 100 // Keep it two-digit
+		v.release = 1
+	} else {
+		v.release++
+	}
+
+	return v, nil
+}
+
+func getMostRecentTag() (string, error) {
+	cmd := exec.Command("git", "describe", "--tags", "--abbrev=0")
+	var out bytes.Buffer
+	var outerr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &outerr
+
+	err := cmd.Run()
+	if err != nil {
+		if strings.Contains(outerr.String(), "No names found, cannot describe anything.") {
+			return "v1.25.0", nil
+		}
+		return "", errors.Join(err, fmt.Errorf("failed to get current version: %s", outerr.String()))
+	}
+
+	return strings.TrimSpace(out.String()), nil
+}
+
+func getCurrent() (*version, error) {
+	tag, err := getMostRecentTag()
+	if err != nil {
+		return nil, err
+	}
+
+	return parse(tag)
+}
+
+func patchFile(path, pattern, replacement string) error {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return err
+	}
+	re := regexp.MustCompile(pattern)
+	out := re.ReplaceAll(data, []byte(replacement))
+	return os.WriteFile(path, out, 0o644)
+}
+
+func writeVersion(v version) error {
+	if err := patchFile(packageJsonPath, `"version":\s*".+?"`, fmt.Sprintf(`"version": "%s"`, v.String())); err != nil {
+		return fmt.Errorf("failed to update openapi.yaml version: %w", err)
+	}
+
+	if err := patchFile(openapiPath, `version:\s*".+?"`, fmt.Sprintf(`version: "%s"`, v.String())); err != nil {
+		return fmt.Errorf("failed to update package.json version: %w", err)
+	}
+
+	if err := patchFile(apiVersionPath, `Version\s*=\s*".+?"`, fmt.Sprintf(`Version = "%s"`, v.String())); err != nil {
+		return fmt.Errorf("failed to update internal/config/version.go: %w", err)
+	}
+
+	return nil
+}
+
+func runNext(current version, write bool) error {
+	next, err := current.next()
+	if err != nil {
+		return fmt.Errorf("failed to generate next version: %w", err)
+	}
+
+	if write {
+		if err := writeVersion(*next); err != nil {
+			return fmt.Errorf("failed to write new version: %w", err)
+		}
+	}
+
+	fmt.Println(next.String())
+
+	return nil
+}
+
+func runCanary(current version) error {
+	current.canary = true
+	if err := writeVersion(current); err != nil {
+		return fmt.Errorf("failed to write new version: %w", err)
+	}
+	fmt.Println(current.String())
+	return nil
+}
+
+func run(write, canary bool) error {
+	current, err := getCurrent()
+	if err != nil {
+		return fmt.Errorf("failed to get current version: %w", err)
+	}
+
+	if canary {
+		if err := runCanary(*current); err != nil {
+			return fmt.Errorf("failed to run canary version: %w", err)
+		}
+	} else {
+		if err := runNext(*current, write); err != nil {
+			return fmt.Errorf("failed to run next version: %w", err)
+		}
+	}
+
+	return nil
+}
+
+func main() {
+	write := flag.Bool("w", false, "Write the new version to files")
+	canary := flag.Bool("c", false, "For post-release run, run this script again with -c to write a canary version to files")
+	flag.Parse()
+
+	if err := run(*write, *canary); err != nil {
+		fmt.Fprintf(os.Stderr, "failed to run release script: %v\n", err)
+		os.Exit(1)
+	}
+	os.Exit(0)
+}


### PR DESCRIPTION
The people asked...

Up until now, versions were rolling and users pull from main or the latest docker image.

As the project matures, I've decided based on feedback to introduce versioning. This will be documented further in the readme.