### PR TITLE
fix OAuth2 redirect URI construction

### DIFF
--- a/app/services/authentication/provider/oauth/oauth.go
+++ b/app/services/authentication/provider/oauth/oauth.go
@@ -1,7 +1,23 @@
 package oauth
 
+import (
+	"fmt"
+	"net/url"
+
+	"github.com/Southclaws/storyden/app/resources/account/authentication"
+)
+
 type Configuration struct {
 	Enabled      bool
 	ClientID     string
 	ClientSecret string
+}
+
+func Redirect(publicWebURL url.URL, svc authentication.Service) url.URL {
+	name := svc.String()
+
+	// TODO: Let the client/caller control this callback URL path.
+	ref, _ := url.Parse(fmt.Sprintf("/auth/%s/callback", name))
+
+	return *publicWebURL.ResolveReference(ref)
 }


### PR DESCRIPTION
Still not done via frontend but that's a larger piece of work. For now, we're assuming the frontend URL structure (path) and building the OAuth2 redirect URL on the backend. This means custom frontends must currently satisfy:

```
/auth/{provider}/callback
```

However in a future change this will be fully customisable by the client so custom frontends can use their own URL structure for OAuth callbacks. Or, the OAuth callback can be direct to the API. Undecided so we'll see.