### PR TITLE
reworks edit mode layout

### DIFF
--- a/web/src/screens/library/LibraryPageScreen/LibraryPageScreen.tsx
+++ b/web/src/screens/library/LibraryPageScreen/LibraryPageScreen.tsx
@@ -44,7 +44,7 @@ LibraryPageForm.displayName = "LibraryPageForm";
 
 export function LibraryPage() {
   return (
-    <LStack h="full" gap="3" pl="3" alignItems="start">
+    <LStack h="full" gap="3" alignItems="start">
       <LibraryPageControls />
       <LibraryPageBlocks />
     </LStack>

--- a/web/src/screens/library/LibraryPageScreen/blocks/LibraryPageBlocks.tsx
+++ b/web/src/screens/library/LibraryPageScreen/blocks/LibraryPageBlocks.tsx
@@ -6,11 +6,18 @@ import {
 import { CSS } from "@dnd-kit/utilities";
 import { useCallback } from "react";
 
+import { IconButton } from "@/components/ui/icon-button";
 import { DragHandleIcon } from "@/components/ui/icons/DragHandle";
+import { MenuIcon } from "@/components/ui/icons/Menu";
 import { DragItemNodeBlock } from "@/lib/dragdrop/provider";
 import { useLibraryBlockEvent } from "@/lib/library/events";
-import { LibraryPageBlock, LibraryPageBlockType } from "@/lib/library/metadata";
-import { Box, HStack, VStack } from "@/styled-system/jsx";
+import {
+  LibraryPageBlock,
+  LibraryPageBlockName,
+  LibraryPageBlockType,
+} from "@/lib/library/metadata";
+import { Box, HStack, VStack, WStack, styled } from "@/styled-system/jsx";
+import { token } from "@/styled-system/tokens";
 
 import { useLibraryPageContext } from "../Context";
 import { useWatch } from "../store";
@@ -147,44 +154,30 @@ function LibraryPageBlockEditable({ block }: { block: LibraryPageBlock }) {
   };
 
   return (
-    <HStack
+    <VStack
       className="group"
       style={dragStyle}
       ref={setNodeRef}
-      w="var(--width-adjusted)"
-      ml="-5"
-      gap="0"
+      w="full"
+      gap="1"
+      outlineWidth="thin"
+      outlineColor="accent.300"
+      outlineStyle="dashed"
+      outlineOffset="1"
+      borderRadius="sm"
     >
-      <VStack
-        {...attributes}
-        {...listeners}
-        style={dragHandleStyle}
-        w="5"
-        pr="1"
-        alignItems="start"
-        height="full"
-        position="relative"
-      >
-        <VStack
-          position="absolute"
-          w="full"
-          color="fg.subtle"
-          borderRadius="sm"
-          visibility="hidden"
-          _groupHover={{
-            bgColor: "bg.muted",
-            visibility: "visible",
-          }}
-          title={block.type}
-          gap="1"
-        >
-          <DragHandleIcon width="4" />
-          <BlockMenu block={block} />
-        </VStack>
-      </VStack>
+      <WStack>
+        <HStack {...attributes} {...listeners} style={dragHandleStyle} gap="1">
+          <DragHandleIcon h="4" w="4" color="fg.subtle" />
+          <styled.p fontWeight="medium" color="fg.subtle">
+            {LibraryPageBlockName[block.type]}
+          </styled.p>
+        </HStack>
+        <BlockMenu block={block} />
+      </WStack>
       <Box w="full" minW="0">
         <LibraryPageBlockRender block={block} />
       </Box>
-    </HStack>
+    </VStack>
   );
 }


### PR DESCRIPTION
Instead of a left-hand gutter like Notion, puts block controls above each block.

<img width="1077" height="745" alt="image" src="https://github.com/user-attachments/assets/f764e4bb-0b9f-45dc-a9ca-8e01bd3c6e42" />


The issue with this approach is when entering edit mode, it causes a ton of layout shift as every block gets about 32-40 pixels added on top for the control bar. So I'm not super convinced this is the way forward.

The only other options are:

- A hover state menu (not mobile friendly, but Notion also doesn't provide this functionality on mobile either so...)
- A larger gutter built in to the underlying navigation layout grid, which would squish the entire site's layout but provide space on the left and right for gutter controls such as drag handles and block menus.

Here's Notion's gutter menu:

<img width="193" height="134" alt="image" src="https://github.com/user-attachments/assets/dffabd1e-743c-4f7d-b1d2-8833749f1a77" />

However on mobile, they hide it entirely:

<img width="86" height="118" alt="image" src="https://github.com/user-attachments/assets/83bbfb38-51b4-4545-8e77-c551963a90b8" />

And put it behind a tap-and-hold drawer:

<img width="301" height="464" alt="image" src="https://github.com/user-attachments/assets/7a2e8820-b805-4e65-a0b2-826e393ff91a" />

Which is fine, a little hidden (I didn't realise until I tried, it's not obvious but also a mobile-first pattern)

And on desktop, they use hover states to show the gutter menu, same as Storyden does currently:

<img width="372" height="97" alt="image" src="https://github.com/user-attachments/assets/ec625367-0660-4e4b-ae9b-bc5639b908a3" />
