### PR TITLE
rework layout of library pages and block menus

### DIFF
--- a/web/src/components/site/Navigation/navigation.module.css
+++ b/web/src/components/site/Navigation/navigation.module.css
@@ -30,6 +30,8 @@
   width: 100%;
   height: 100%;
 
+  --grid-col-padding-outer: var(--spacing-2);
+
   grid-template-rows:
     var(--grid-row-padding-outer)
     1fr
@@ -79,6 +81,7 @@
 @media screen and (min-width: 1280px) {
   .navgrid {
     --grid-col-padding-inner-right: var(--spacing-8);
+    --grid-col-padding-outer: var(--spacing-8);
     --navgrid-right-bar-display: block;
   }
 }
@@ -86,6 +89,8 @@
 @media screen and (min-width: 768px) {
   .navgrid {
     display: grid;
+
+    --grid-col-padding-outer: var(--spacing-8);
 
     grid-template-rows:
       var(--grid-row-padding-outer)

--- a/web/src/components/site/Navigation/navigation.module.css
+++ b/web/src/components/site/Navigation/navigation.module.css
@@ -16,8 +16,8 @@
   --grid-row-padding-outer: var(--spacing-5);
   --grid-row-padding-inner: var(--spacing-3);
 
-  --grid-col-padding-outer: var(--spacing-5);
-  --grid-col-padding-inner: var(--spacing-3);
+  --grid-col-padding-outer: var(--spacing-8);
+  --grid-col-padding-inner: var(--spacing-8);
   --grid-col-padding-inner-right: 0px;
 
   min-height: 100dvh;
@@ -78,7 +78,7 @@
 
 @media screen and (min-width: 1280px) {
   .navgrid {
-    --grid-col-padding-inner-right: var(--spacing-3);
+    --grid-col-padding-inner-right: var(--spacing-8);
     --navgrid-right-bar-display: block;
   }
 }

--- a/web/src/lib/library/blockIcons.tsx
+++ b/web/src/lib/library/blockIcons.tsx
@@ -1,0 +1,33 @@
+import {
+  GalleryThumbnailsIcon,
+  ImagesIcon,
+  Table2Icon,
+  TablePropertiesIcon,
+  TagsIcon,
+  TextIcon,
+  TypeIcon,
+} from "lucide-react";
+
+import { LinkIcon } from "@/components/ui/icons/Link";
+
+import { LibraryPageBlockType } from "./metadata";
+
+export const LibraryPageBlockIcon: Record<
+  LibraryPageBlockType,
+  React.ComponentType
+> = {
+  title: TypeIcon,
+  cover: GalleryThumbnailsIcon,
+  link: LinkIcon,
+  content: TextIcon,
+  assets: ImagesIcon,
+  properties: TablePropertiesIcon,
+  table: Table2Icon,
+  tags: TagsIcon,
+};
+
+export function BlockIcon({ blockType }: { blockType: LibraryPageBlockType }) {
+  const Icon = LibraryPageBlockIcon[blockType];
+
+  return <Icon />;
+}

--- a/web/src/lib/library/events.ts
+++ b/web/src/lib/library/events.ts
@@ -8,7 +8,7 @@ export type LibraryBlockEvents = {
     activeId: LibraryPageBlockType;
     overId: LibraryPageBlockType;
   };
-  "library:add-block": { type: LibraryPageBlockType };
+  "library:add-block": { type: LibraryPageBlockType; index?: number };
   "library:remove-block": { type: LibraryPageBlockType };
 };
 

--- a/web/src/lib/library/metadata.ts
+++ b/web/src/lib/library/metadata.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 
-import { Metadata, Node, NodeWithChildren } from "@/api/openapi-schema";
+import { Metadata, Node, NodeWithChildren, React } from "@/api/openapi-schema";
 
 export const CoverImageSchema = z.object({
   top: z.number(),

--- a/web/src/screens/library/LibraryPageScreen/LibraryPageScreen.tsx
+++ b/web/src/screens/library/LibraryPageScreen/LibraryPageScreen.tsx
@@ -44,7 +44,7 @@ LibraryPageForm.displayName = "LibraryPageForm";
 
 export function LibraryPage() {
   return (
-    <LStack h="full" gap="3" pl="3" alignItems="start">
+    <LStack h="full" gap="3" alignItems="start">
       <LibraryPageControls />
       <LibraryPageBlocks />
     </LStack>

--- a/web/src/screens/library/LibraryPageScreen/blocks/BlockMenu.tsx
+++ b/web/src/screens/library/LibraryPageScreen/blocks/BlockMenu.tsx
@@ -12,7 +12,6 @@ import { CreateBlockMenu } from "./CreateBlockMenu";
 
 type Props = {
   open?: boolean;
-  setOpen?: (open: boolean) => void;
   block: LibraryPageBlock;
 };
 

--- a/web/src/screens/library/LibraryPageScreen/blocks/BlockMenu.tsx
+++ b/web/src/screens/library/LibraryPageScreen/blocks/BlockMenu.tsx
@@ -1,9 +1,8 @@
 import { MenuSelectionDetails, Portal } from "@ark-ui/react";
+import { PropsWithChildren, forwardRef } from "react";
 
 import { ButtonProps } from "@/components/ui/button";
-import { IconButton } from "@/components/ui/icon-button";
 import { DeleteIcon } from "@/components/ui/icons/Delete";
-import { MoreIcon } from "@/components/ui/icons/More";
 import * as Menu from "@/components/ui/menu";
 import { useEmitLibraryBlockEvent } from "@/lib/library/events";
 import { LibraryPageBlock, LibraryPageBlockName } from "@/lib/library/metadata";
@@ -12,67 +11,66 @@ import { styled } from "@/styled-system/jsx";
 import { CreateBlockMenu } from "./CreateBlockMenu";
 
 type Props = {
+  open?: boolean;
+  setOpen?: (open: boolean) => void;
   block: LibraryPageBlock;
 };
 
-export function BlockMenu({ block }: Props & ButtonProps) {
-  const emit = useEmitLibraryBlockEvent();
+type AllProps = PropsWithChildren<Props & ButtonProps>;
 
-  function handleSelect(value: MenuSelectionDetails) {
-    switch (value.value) {
-      case "delete": {
-        emit("library:remove-block", {
-          type: block.type,
-        });
+export const BlockMenu = forwardRef<HTMLDivElement, AllProps>(
+  ({ children, open, block }: AllProps, ref) => {
+    const emit = useEmitLibraryBlockEvent();
+
+    function handleSelect(value: MenuSelectionDetails) {
+      switch (value.value) {
+        case "delete": {
+          emit("library:remove-block", {
+            type: block.type,
+          });
+        }
       }
     }
-  }
 
-  return (
-    <Menu.Root
-      lazyMount
-      onSelect={handleSelect}
-      positioning={{
-        placement: "right-start",
-        gutter: 0,
-      }}
-    >
-      <Menu.Trigger asChild>
-        <IconButton
-          variant="ghost"
-          size="xs"
-          minWidth="5"
-          width="5"
-          height="5"
-          padding="0"
-        >
-          <MoreIcon width="3" />
-        </IconButton>
-      </Menu.Trigger>
+    return (
+      <Menu.Root
+        open={open}
+        lazyMount
+        onSelect={handleSelect}
+        positioning={{
+          placement: "right-start",
+          gutter: 0,
+        }}
+      >
+        <Menu.Trigger asChild>
+          {/*  */}
+          {children}
+        </Menu.Trigger>
 
-      <Portal>
-        <Menu.Positioner>
-          <Menu.Content minW="36">
-            <Menu.ItemGroup>
-              <Menu.ItemGroupLabel
-                display="flex"
-                flexDir="column"
-                userSelect="none"
-              >
-                <styled.span>{LibraryPageBlockName[block.type]}</styled.span>
-              </Menu.ItemGroupLabel>
+        <Portal>
+          <Menu.Positioner ref={ref}>
+            <Menu.Content minW="36">
+              <Menu.ItemGroup>
+                <Menu.ItemGroupLabel
+                  display="flex"
+                  flexDir="column"
+                  userSelect="none"
+                >
+                  <styled.span>{LibraryPageBlockName[block.type]}</styled.span>
+                </Menu.ItemGroupLabel>
 
-              <Menu.Separator />
+                <Menu.Separator />
 
-              <Menu.Item value="delete">
-                <DeleteIcon />
-                &nbsp;Delete
-              </Menu.Item>
-              <CreateBlockMenu />
-            </Menu.ItemGroup>
-          </Menu.Content>
-        </Menu.Positioner>
-      </Portal>
-    </Menu.Root>
-  );
-}
+                <Menu.Item value="delete">
+                  <DeleteIcon />
+                  &nbsp;Delete
+                </Menu.Item>
+                <CreateBlockMenu />
+              </Menu.ItemGroup>
+            </Menu.Content>
+          </Menu.Positioner>
+        </Portal>
+      </Menu.Root>
+    );
+  },
+);

--- a/web/src/screens/library/LibraryPageScreen/blocks/BlockMenu.tsx
+++ b/web/src/screens/library/LibraryPageScreen/blocks/BlockMenu.tsx
@@ -13,11 +13,12 @@ import { CreateBlockMenu } from "./CreateBlockMenu";
 type Props = {
   open?: boolean;
   block: LibraryPageBlock;
+  index: number;
 };
 
 type AllProps = PropsWithChildren<Props & ButtonProps>;
 
-export function BlockMenu({ children, open, block }: AllProps) {
+export function BlockMenu({ children, open, block, index }: AllProps) {
   const emit = useEmitLibraryBlockEvent();
 
   function handleSelect(value: MenuSelectionDetails) {
@@ -63,7 +64,7 @@ export function BlockMenu({ children, open, block }: AllProps) {
                 <DeleteIcon />
                 &nbsp;Delete
               </Menu.Item>
-              <CreateBlockMenu />
+              <CreateBlockMenu index={index} />
             </Menu.ItemGroup>
           </Menu.Content>
         </Menu.Positioner>

--- a/web/src/screens/library/LibraryPageScreen/blocks/BlockMenu.tsx
+++ b/web/src/screens/library/LibraryPageScreen/blocks/BlockMenu.tsx
@@ -1,5 +1,5 @@
 import { MenuSelectionDetails, Portal } from "@ark-ui/react";
-import { PropsWithChildren, forwardRef } from "react";
+import { PropsWithChildren } from "react";
 
 import { ButtonProps } from "@/components/ui/button";
 import { DeleteIcon } from "@/components/ui/icons/Delete";
@@ -18,59 +18,57 @@ type Props = {
 
 type AllProps = PropsWithChildren<Props & ButtonProps>;
 
-export const BlockMenu = forwardRef<HTMLDivElement, AllProps>(
-  ({ children, open, block }: AllProps, ref) => {
-    const emit = useEmitLibraryBlockEvent();
+export function BlockMenu({ children, open, block }: AllProps) {
+  const emit = useEmitLibraryBlockEvent();
 
-    function handleSelect(value: MenuSelectionDetails) {
-      switch (value.value) {
-        case "delete": {
-          emit("library:remove-block", {
-            type: block.type,
-          });
-        }
+  function handleSelect(value: MenuSelectionDetails) {
+    switch (value.value) {
+      case "delete": {
+        emit("library:remove-block", {
+          type: block.type,
+        });
       }
     }
+  }
 
-    return (
-      <Menu.Root
-        open={open}
-        lazyMount
-        onSelect={handleSelect}
-        positioning={{
-          placement: "right-start",
-          gutter: 0,
-        }}
-      >
-        <Menu.Trigger asChild>
-          {/*  */}
-          {children}
-        </Menu.Trigger>
+  return (
+    <Menu.Root
+      open={open}
+      lazyMount
+      onSelect={handleSelect}
+      positioning={{
+        placement: "right-start",
+        gutter: 0,
+      }}
+    >
+      <Menu.Trigger asChild>
+        {/*  */}
+        {children}
+      </Menu.Trigger>
 
-        <Portal>
-          <Menu.Positioner ref={ref}>
-            <Menu.Content minW="36">
-              <Menu.ItemGroup>
-                <Menu.ItemGroupLabel
-                  display="flex"
-                  flexDir="column"
-                  userSelect="none"
-                >
-                  <styled.span>{LibraryPageBlockName[block.type]}</styled.span>
-                </Menu.ItemGroupLabel>
+      <Portal>
+        <Menu.Positioner>
+          <Menu.Content minW="36">
+            <Menu.ItemGroup>
+              <Menu.ItemGroupLabel
+                display="flex"
+                flexDir="column"
+                userSelect="none"
+              >
+                <styled.span>{LibraryPageBlockName[block.type]}</styled.span>
+              </Menu.ItemGroupLabel>
 
-                <Menu.Separator />
+              <Menu.Separator />
 
-                <Menu.Item value="delete">
-                  <DeleteIcon />
-                  &nbsp;Delete
-                </Menu.Item>
-                <CreateBlockMenu />
-              </Menu.ItemGroup>
-            </Menu.Content>
-          </Menu.Positioner>
-        </Portal>
-      </Menu.Root>
-    );
-  },
-);
+              <Menu.Item value="delete">
+                <DeleteIcon />
+                &nbsp;Delete
+              </Menu.Item>
+              <CreateBlockMenu />
+            </Menu.ItemGroup>
+          </Menu.Content>
+        </Menu.Positioner>
+      </Portal>
+    </Menu.Root>
+  );
+}

--- a/web/src/screens/library/LibraryPageScreen/blocks/CreateBlockMenu.tsx
+++ b/web/src/screens/library/LibraryPageScreen/blocks/CreateBlockMenu.tsx
@@ -19,9 +19,11 @@ export function CreateBlockMenu({
     </Menu.Item>
   ),
   positioning = undefined,
+  index = undefined,
 }: {
   trigger?: React.ReactElement;
   positioning?: PositioningOptions;
+  index?: number;
 }) {
   const emit = useEmitLibraryBlockEvent();
 
@@ -30,6 +32,7 @@ export function CreateBlockMenu({
   function handleSelect(value: MenuSelectionDetails) {
     emit("library:add-block", {
       type: value.value as LibraryPageBlock["type"],
+      index: index ? index : undefined,
     });
   }
 

--- a/web/src/screens/library/LibraryPageScreen/blocks/CreateBlockMenu.tsx
+++ b/web/src/screens/library/LibraryPageScreen/blocks/CreateBlockMenu.tsx
@@ -1,15 +1,28 @@
 import { MenuSelectionDetails, Portal } from "@ark-ui/react";
+import { PositioningOptions } from "@zag-js/popper";
 import { keyBy } from "lodash";
 
 import { AddIcon } from "@/components/ui/icons/Add";
 import * as Menu from "@/components/ui/menu";
+import { BlockIcon } from "@/lib/library/blockIcons";
 import { allBlockTypes } from "@/lib/library/blockTypes";
 import { useEmitLibraryBlockEvent } from "@/lib/library/events";
 import { LibraryPageBlock, LibraryPageBlockName } from "@/lib/library/metadata";
 
 import { useWatch } from "../store";
 
-export function CreateBlockMenu() {
+export function CreateBlockMenu({
+  trigger = (
+    <Menu.Item value="add">
+      <AddIcon />
+      &nbsp;Add Block
+    </Menu.Item>
+  ),
+  positioning = undefined,
+}: {
+  trigger?: React.ReactElement;
+  positioning?: PositioningOptions;
+}) {
   const emit = useEmitLibraryBlockEvent();
 
   const currentMetadata = useWatch((s) => s.draft.meta);
@@ -25,13 +38,8 @@ export function CreateBlockMenu() {
   const blockList = allBlockTypes.filter((b) => !existingBlocks[b]);
 
   return (
-    <Menu.Root lazyMount onSelect={handleSelect}>
-      <Menu.TriggerItem asChild>
-        <Menu.Item value="add">
-          <AddIcon />
-          &nbsp;Add Block
-        </Menu.Item>
-      </Menu.TriggerItem>
+    <Menu.Root lazyMount onSelect={handleSelect} positioning={positioning}>
+      <Menu.Trigger asChild>{trigger}</Menu.Trigger>
 
       <Portal>
         <Menu.Positioner>
@@ -39,6 +47,8 @@ export function CreateBlockMenu() {
             {blockList.map((block) => {
               return (
                 <Menu.Item key={block} value={block}>
+                  <BlockIcon blockType={block} />
+                  &nbsp;
                   {LibraryPageBlockName[block]}
                 </Menu.Item>
               );

--- a/web/src/screens/library/LibraryPageScreen/blocks/CreateBlockMenu.tsx
+++ b/web/src/screens/library/LibraryPageScreen/blocks/CreateBlockMenu.tsx
@@ -26,12 +26,12 @@ export function CreateBlockMenu() {
 
   return (
     <Menu.Root lazyMount onSelect={handleSelect}>
-      <Menu.Trigger asChild>
+      <Menu.TriggerItem asChild>
         <Menu.Item value="add">
           <AddIcon />
           &nbsp;Add Block
         </Menu.Item>
-      </Menu.Trigger>
+      </Menu.TriggerItem>
 
       <Portal>
         <Menu.Positioner>

--- a/web/src/screens/library/LibraryPageScreen/blocks/LibraryPageBlocks.tsx
+++ b/web/src/screens/library/LibraryPageScreen/blocks/LibraryPageBlocks.tsx
@@ -165,6 +165,13 @@ function LibraryPageBlockEditable({ block }: { block: LibraryPageBlock }) {
     setOpen((prev) => !prev);
   }
 
+  // Closing the menu is actually really awkward since there's a nested menu and
+  // they don't share the same DOM - so click-away doesn't do what you expect,
+  // hovering off the menu's parent hides the parent but keeps the menu. This is
+  // a usability hack to make it feel a bit nicer by allowing the menu to close
+  // when the cursor moves away from it. This is not a perfect solution but it's
+  // good enough for now. It wouldn't work on mobile but luckily we just hide
+  // these menus and the entire gutter on mobile anyway in favour of tap-hold.
   const { elementRef, distanceRef } = useMouseDistance<HTMLDivElement>();
   useEffect(() => {
     const timer = setInterval(
@@ -292,7 +299,7 @@ function LibraryPageBlockEditable({ block }: { block: LibraryPageBlock }) {
             height="6"
             pointerEvents="none"
           >
-            <BlockMenu block={block} open={isOpen} setOpen={setOpen}>
+            <BlockMenu block={block} open={isOpen}>
               <Box position="absolute" width="6" height="6" />
             </BlockMenu>
           </Box>

--- a/web/src/screens/library/LibraryPageScreen/blocks/LibraryPageBlocks.tsx
+++ b/web/src/screens/library/LibraryPageScreen/blocks/LibraryPageBlocks.tsx
@@ -223,7 +223,8 @@ function LibraryPageBlockEditable({ block }: { block: LibraryPageBlock }) {
         id={`block-${block.type}_gutter-container`}
         ref={setNodeRef}
         w="6"
-        left="-7"
+        left={{ base: "0", md: "-7" }}
+        top={{ base: "-7", md: "0" }}
         alignItems="start"
         height="full"
         position="absolute"
@@ -234,13 +235,16 @@ function LibraryPageBlockEditable({ block }: { block: LibraryPageBlock }) {
           {...listeners}
           {...attributes}
           w="full"
-          h="full"
+          h={{ base: "6", md: "full" }}
+          bgColor="bg.muted/50"
           color="fg.subtle"
           borderRadius="sm"
           visibility="hidden"
           _groupHover={{
             visibility: "visible",
           }}
+          // Hide on mobile: Not happy with the mobile experience of this yet.
+          display={{ base: "none", md: "flex" }}
         >
           <Tooltip.Root
             openDelay={0}
@@ -258,7 +262,10 @@ function LibraryPageBlockEditable({ block }: { block: LibraryPageBlock }) {
                   <IconButton
                     style={dragHandleStyle}
                     id={`block-${block.type}_gutter-drag-handle-button`}
-                    variant="ghost"
+                    variant={{
+                      base: "subtle",
+                      md: "ghost",
+                    }}
                     size="xs"
                     minWidth="5"
                     width="5"
@@ -314,7 +321,7 @@ function LibraryPageBlockEditable({ block }: { block: LibraryPageBlock }) {
           borderRadius: "sm",
           outlineColor: "bg.muted/50",
           outlineStyle: "solid",
-          outlineWidth: "thick",
+          outlineWidth: "medium",
         }}
       >
         <LibraryPageBlockRender block={block} />

--- a/web/src/screens/library/LibraryPageScreen/blocks/LibraryPageBlocks.tsx
+++ b/web/src/screens/library/LibraryPageScreen/blocks/LibraryPageBlocks.tsx
@@ -6,7 +6,7 @@ import {
   verticalListSortingStrategy,
 } from "@dnd-kit/sortable";
 import { CSS } from "@dnd-kit/utilities";
-import { useCallback, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 
 import { IconButton } from "@/components/ui/icon-button";
 import { DragHandleIcon } from "@/components/ui/icons/DragHandle";
@@ -15,6 +15,7 @@ import { DragItemNodeBlock } from "@/lib/dragdrop/provider";
 import { useLibraryBlockEvent } from "@/lib/library/events";
 import { LibraryPageBlock, LibraryPageBlockType } from "@/lib/library/metadata";
 import { Box, HStack, VStack, styled } from "@/styled-system/jsx";
+import { useMouseDistance } from "@/utils/useMouseDistance";
 
 import { useLibraryPageContext } from "../Context";
 import { useWatch } from "../store";
@@ -144,6 +145,28 @@ function LibraryPageBlockEditable({ block }: { block: LibraryPageBlock }) {
     setOpen((prev) => !prev);
   }
 
+  const { elementRef, distanceRef } = useMouseDistance<HTMLDivElement>();
+  useEffect(() => {
+    const timer = setInterval(
+      () => {
+        if (!isOpen) return;
+
+        const el = elementRef.current;
+        if (!el) return;
+
+        const distance = distanceRef.current;
+        // NOTE: Massive hack... distance might be wrong on different screens.
+        if (distance.d > 45) {
+          setOpen(false);
+        }
+      },
+
+      100,
+    );
+
+    return () => clearInterval(timer);
+  }, [isOpen, setOpen]);
+
   // Check if we're dragging anything at all, to hide the tooltip.
   const { active } = useDndContext();
   const isDraggingAnything = active !== null;
@@ -162,6 +185,7 @@ function LibraryPageBlockEditable({ block }: { block: LibraryPageBlock }) {
   return (
     <HStack
       id={`block-${block.type}_container`}
+      ref={elementRef}
       className="group"
       style={dragStyle}
       w="full"

--- a/web/src/screens/library/LibraryPageScreen/blocks/LibraryPageBlocks.tsx
+++ b/web/src/screens/library/LibraryPageScreen/blocks/LibraryPageBlocks.tsx
@@ -8,7 +8,9 @@ import {
 import { CSS } from "@dnd-kit/utilities";
 import { useCallback, useEffect, useState } from "react";
 
+import { Button } from "@/components/ui/button";
 import { IconButton } from "@/components/ui/icon-button";
+import { AddIcon } from "@/components/ui/icons/Add";
 import { DragHandleIcon } from "@/components/ui/icons/DragHandle";
 import * as Tooltip from "@/components/ui/tooltip";
 import { DragItemNodeBlock } from "@/lib/dragdrop/provider";
@@ -22,6 +24,7 @@ import { useWatch } from "../store";
 import { useEditState } from "../useEditState";
 
 import { BlockMenu } from "./BlockMenu";
+import { CreateBlockMenu } from "./CreateBlockMenu";
 import { LibraryPageAssetsBlock } from "./LibraryPageAssetsBlock/LibraryPageAssetsBlock";
 import { LibraryPageContentBlock } from "./LibraryPageContentBlock/LibraryPageContentBlock";
 import { LibraryPageCoverBlock } from "./LibraryPageCoverBlock/LibraryPageCoverBlock";
@@ -82,11 +85,28 @@ export function LibraryPageBlocks() {
     const editStateBlocks = meta.layout?.blocks ?? [];
 
     return (
-      <SortableContext items={blockIds} strategy={verticalListSortingStrategy}>
-        {editStateBlocks.map((block) => {
-          return <LibraryPageBlockEditable key={block.type} block={block} />;
-        })}
-      </SortableContext>
+      <>
+        <SortableContext
+          items={blockIds}
+          strategy={verticalListSortingStrategy}
+        >
+          {editStateBlocks.map((block) => {
+            return <LibraryPageBlockEditable key={block.type} block={block} />;
+          })}
+        </SortableContext>
+
+        <CreateBlockMenu
+          trigger={
+            <Button variant="outline" size="xs" w="full">
+              <AddIcon />
+              &nbsp;Add Block
+            </Button>
+          }
+          positioning={{
+            placement: "bottom",
+          }}
+        />
+      </>
     );
   }
 

--- a/web/src/screens/library/LibraryPageScreen/blocks/LibraryPageBlocks.tsx
+++ b/web/src/screens/library/LibraryPageScreen/blocks/LibraryPageBlocks.tsx
@@ -58,13 +58,13 @@ export function LibraryPageBlocks() {
   });
 
   const handleAddBlock = useCallback(
-    (type: LibraryPageBlockType) => {
-      addBlock(type);
+    (type: LibraryPageBlockType, index?: number) => {
+      addBlock(type, index);
     },
     [addBlock],
   );
-  useLibraryBlockEvent("library:add-block", ({ type }) => {
-    handleAddBlock(type);
+  useLibraryBlockEvent("library:add-block", ({ type, index }) => {
+    handleAddBlock(type, index);
   });
 
   const handleRemoveBlock = useCallback(
@@ -90,8 +90,14 @@ export function LibraryPageBlocks() {
           items={blockIds}
           strategy={verticalListSortingStrategy}
         >
-          {editStateBlocks.map((block) => {
-            return <LibraryPageBlockEditable key={block.type} block={block} />;
+          {editStateBlocks.map((block, index) => {
+            return (
+              <LibraryPageBlockEditable
+                key={block.type}
+                block={block}
+                index={index}
+              />
+            );
           })}
         </SortableContext>
 
@@ -140,7 +146,13 @@ function LibraryPageBlockRender({ block }: { block: LibraryPageBlock }) {
   }
 }
 
-function LibraryPageBlockEditable({ block }: { block: LibraryPageBlock }) {
+function LibraryPageBlockEditable({
+  block,
+  index,
+}: {
+  block: LibraryPageBlock;
+  index: number;
+}) {
   const { initialNode } = useLibraryPageContext();
   const {
     attributes,
@@ -183,7 +195,7 @@ function LibraryPageBlockEditable({ block }: { block: LibraryPageBlock }) {
 
         const distance = distanceRef.current;
         // NOTE: Massive hack... distance might be wrong on different screens.
-        if (distance.d > 45) {
+        if (distance.d > 75) {
           setOpen(false);
         }
       },
@@ -306,7 +318,7 @@ function LibraryPageBlockEditable({ block }: { block: LibraryPageBlock }) {
             height="6"
             pointerEvents="none"
           >
-            <BlockMenu block={block} open={isOpen}>
+            <BlockMenu block={block} open={isOpen} index={index}>
               <Box position="absolute" width="6" height="6" />
             </BlockMenu>
           </Box>

--- a/web/src/screens/library/LibraryPageScreen/store.ts
+++ b/web/src/screens/library/LibraryPageScreen/store.ts
@@ -66,7 +66,7 @@ export type Actions = {
 
   // Layout blocks
   moveBlock: (type: LibraryPageBlockType, newIndex: number) => void;
-  addBlock: (type: LibraryPageBlockType) => void;
+  addBlock: (type: LibraryPageBlockType, index?: number) => void;
   removeBlock: (type: LibraryPageBlockType) => void;
   overwriteBlock: (type: LibraryPageBlock) => void;
 
@@ -423,7 +423,7 @@ export const createNodeStore = (initState: State) => {
           });
         },
 
-        addBlock: (type: LibraryPageBlockType) => {
+        addBlock: (type: LibraryPageBlockType, index?: number) => {
           set((state) => {
             const layout = (state.draft.meta.layout ??= DefaultLayout);
 
@@ -432,7 +432,11 @@ export const createNodeStore = (initState: State) => {
               return;
             }
 
-            layout.blocks.push({ type });
+            if (index === undefined || index > layout.blocks.length) {
+              layout.blocks.push({ type });
+            } else {
+              layout.blocks.splice(index + 1, 0, { type });
+            }
           });
         },
 

--- a/web/src/utils/useMouseDistance.ts
+++ b/web/src/utils/useMouseDistance.ts
@@ -1,0 +1,35 @@
+import { useEffect, useRef } from "react";
+
+export function useMouseDistance<T extends HTMLElement = HTMLElement>() {
+  const elementRef = useRef<T>(null);
+  const distanceRef = useRef<{ x: number; y: number; d: number }>({
+    x: 0,
+    y: 0,
+    d: Infinity,
+  });
+
+  useEffect(() => {
+    const update = (e: MouseEvent) => {
+      const el = elementRef.current;
+      if (!el) return;
+
+      const rect = el.getBoundingClientRect();
+      const x = e.clientX;
+      const y = e.clientY;
+
+      const cx = Math.max(rect.left, Math.min(x, rect.right));
+      const cy = Math.max(rect.top, Math.min(y, rect.bottom));
+
+      const dx = x - cx;
+      const dy = y - cy;
+      const d = Math.sqrt(dx * dx + dy * dy);
+
+      distanceRef.current = { x: dx, y: dy, d };
+    };
+
+    window.addEventListener("mousemove", update);
+    return () => window.removeEventListener("mousemove", update);
+  }, []);
+
+  return { elementRef, distanceRef };
+}


### PR DESCRIPTION
<img width="193" height="145" alt="image" src="https://github.com/user-attachments/assets/e247fc8a-4c80-472e-9cab-4a0f01201160" />

<img width="259" height="168" alt="image" src="https://github.com/user-attachments/assets/5a7f9d5b-7aaa-435f-a26f-29be8c5da4a9" />

issues so far:

- menu is portalled but controlled so closing it when clicking away is awkward (not done yet)
- menu stays open if not closed by clicking the exact handle used to open it
- if mouse moves away, menu stays present, but the trigger to close it disappears, hiding from the user

potential solutions:

- fully control the entire tree, passing refs to portal menus to handle click away
- use mouse distance to close - easier but potentially unintuitive
- control hover state in react rather than css to keep the hover state present when interacting with menu
- remove portals and use absolutely positioned menus instead, keeping them within the hovered element's tree