### PR TITLE
Fix category badge mobile overflow in RichCard footer

### DIFF
--- a/web/src/recipes/rich-card.ts
+++ b/web/src/recipes/rich-card.ts
@@ -75,6 +75,7 @@ export const richCard = defineSlotRecipe({
       display: "flex",
       justifyContent: "start",
       width: "full",
+      minWidth: "0",
     },
 
     mediaBackdropContainer: {


### PR DESCRIPTION
## Summary
Fixes the category badge overflow issue on mobile devices in the RichCard component's bottom row.

## Changes
- Added `minWidth: "0"` to `footerContainer` in the rich-card recipe (web/src/recipes/rich-card.ts)

## Problem
The bottom row of the RichCard component wasn't properly handling overflow on mobile. Category badges were causing the MemberIdent (author handle) to overflow instead of being clipped with ellipsis.

## Solution
The flexbox layout requires `min-width: 0` to be set on flex children for overflow to propagate correctly. Without this, flex items default to `min-width: auto`, which prevents text from being clipped.

By adding `minWidth: "0"` to the footerContainer, the flex layout now properly handles overflow, allowing the MemberIdent component (which already has proper text-overflow styles) to clip long handles with ellipsis.

## Testing
- Verified the CSS change follows the pattern used elsewhere in the codebase (e.g., line 66 contentContainer already has minWidth: "0")
- The MemberIdent component already has the necessary overflow handling (textOverflow: "ellipsis", overflowX: "hidden")

Closes #558