### PR TITLE
refactor(web): replace `@uidotdev/usehooks` by internal hooks

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -34,7 +34,6 @@
     "@tiptap/react": "^2.8.0",
     "@tiptap/starter-kit": "^2.8.0",
     "@tiptap/suggestion": "^2.8.0",
-    "@uidotdev/usehooks": "^2.4.1",
     "@use-gesture/react": "^10.3.1",
     "chroma-js": "^3.1.2",
     "date-fns": "^4.1.0",

--- a/web/src/components/asset/AssetLightbox.tsx
+++ b/web/src/components/asset/AssetLightbox.tsx
@@ -1,5 +1,4 @@
 import { Portal, Presence, UsePresenceProps } from "@ark-ui/react";
-import { useClickAway } from "@uidotdev/usehooks";
 import { ArrowRight } from "lucide-react";
 import Image from "next/image";
 import { useQueryState } from "nuqs";
@@ -8,6 +7,7 @@ import { Asset } from "@/api/openapi-schema";
 import { css, cx } from "@/styled-system/css";
 import { Box, Center, HStack } from "@/styled-system/jsx";
 import { getAssetURL } from "@/utils/asset";
+import { useClickAway } from "@/utils/useClickAway";
 
 import { IconButton } from "../ui/icon-button";
 import { ArrowLeftIcon, ArrowRightIcon } from "../ui/icons/Arrow";

--- a/web/src/components/category/CategoryMenu/CategoryMenu.tsx
+++ b/web/src/components/category/CategoryMenu/CategoryMenu.tsx
@@ -1,5 +1,4 @@
 import { MenuSelectionDetails, Portal } from "@ark-ui/react";
-import { useCopyToClipboard } from "@uidotdev/usehooks";
 
 import { Category, Permission } from "@/api/openapi-schema";
 import { useSession } from "@/auth";
@@ -10,6 +9,7 @@ import { WEB_ADDRESS } from "@/config";
 import { styled } from "@/styled-system/jsx";
 import { useShare } from "@/utils/client";
 import { hasPermission } from "@/utils/permissions";
+import { useCopyToClipboard } from "@/utils/useCopyToClipboard";
 
 import { CategoryCreateMenuItem } from "../CategoryCreate/CategoryCreateMenuItem";
 import { CategoryDeleteMenuItem } from "../CategoryDelete/CategoryDeleteMenuItem";
@@ -40,7 +40,6 @@ export function useCategoryMenu({ category }: Props) {
       text: category.description,
     });
   }
-
 
   async function handleSelect({ value }: MenuSelectionDetails) {
     switch (value) {

--- a/web/src/components/collection/CollectionMenu/useCollectionMenu.ts
+++ b/web/src/components/collection/CollectionMenu/useCollectionMenu.ts
@@ -1,6 +1,5 @@
 "use client";
 
-import { useCopyToClipboard } from "@uidotdev/usehooks";
 import { useRouter } from "next/navigation";
 
 import { Account, Collection } from "src/api/openapi-schema";
@@ -15,6 +14,7 @@ import {
 } from "@/lib/collection/permissions";
 import { useFeedMutations } from "@/lib/feed/mutation";
 import { useShare } from "@/utils/client";
+import { useCopyToClipboard } from "@/utils/useCopyToClipboard";
 
 export type Props = {
   session?: Account;

--- a/web/src/components/feed/QuickShare/useQuickShare.ts
+++ b/web/src/components/feed/QuickShare/useQuickShare.ts
@@ -1,5 +1,4 @@
 import { zodResolver } from "@hookform/resolvers/zod";
-import { useClickAway } from "@uidotdev/usehooks";
 import { useEffect, useState } from "react";
 import { useForm } from "react-hook-form";
 import { z } from "zod";
@@ -10,6 +9,7 @@ import { Account, Category, LinkReference } from "@/api/openapi-schema";
 import { useSession } from "@/auth";
 import { NO_CATEGORY_VALUE } from "@/components/category/CategorySelect/useCategorySelect";
 import { useFeedMutations } from "@/lib/feed/mutation";
+import { useClickAway } from "@/utils/useClickAway";
 
 export type Props = {
   initialSession?: Account;

--- a/web/src/components/member/MemberOptions/MemberOptionsMenu.tsx
+++ b/web/src/components/member/MemberOptions/MemberOptionsMenu.tsx
@@ -1,5 +1,4 @@
 import { MenuSelectionDetails, Portal } from "@ark-ui/react";
-import { useCopyToClipboard } from "@uidotdev/usehooks";
 import Link from "next/link";
 import { PropsWithChildren } from "react";
 import { toast } from "sonner";
@@ -10,6 +9,7 @@ import { ProfileReference } from "@/api/openapi-schema";
 import * as Menu from "@/components/ui/menu";
 import { WEB_ADDRESS } from "@/config";
 import { hasPermission } from "@/utils/permissions";
+import { useCopyToClipboard } from "@/utils/useCopyToClipboard";
 
 import { MemberIdent } from "../MemberBadge/MemberIdent";
 import { MemberRoleMenu } from "../MemberRoleMenu/MemberRoleMenu";

--- a/web/src/components/site/CommandDock/CommandDock.tsx
+++ b/web/src/components/site/CommandDock/CommandDock.tsx
@@ -1,8 +1,8 @@
-import { useClickAway } from "@uidotdev/usehooks";
 import { JSX, PropsWithChildren } from "react";
 
 import { Box, Flex } from "@/styled-system/jsx";
 import { Floating } from "@/styled-system/patterns";
+import { useClickAway } from "@/utils/useClickAway";
 
 export type Props = {
   isOpen: boolean;

--- a/web/src/components/thread/ReplyMenu/useReplyMenu.ts
+++ b/web/src/components/thread/ReplyMenu/useReplyMenu.ts
@@ -1,7 +1,5 @@
 "use client";
 
-import { useCopyToClipboard } from "@uidotdev/usehooks";
-
 import { Reply, Thread } from "src/api/openapi-schema";
 import { useSession } from "src/auth";
 import { useShare } from "src/utils/client";
@@ -9,6 +7,7 @@ import { useShare } from "src/utils/client";
 import { handle } from "@/api/client";
 import { useThreadMutations } from "@/lib/thread/mutation";
 import { withUndo } from "@/lib/thread/undo";
+import { useCopyToClipboard } from "@/utils/useCopyToClipboard";
 
 import { getPermalinkForPost } from "../utils";
 

--- a/web/src/components/thread/ThreadMenu/useThreadMenu.ts
+++ b/web/src/components/thread/ThreadMenu/useThreadMenu.ts
@@ -1,6 +1,5 @@
 "use client";
 
-import { useCopyToClipboard } from "@uidotdev/usehooks";
 import { useRouter } from "next/navigation";
 import { parseAsBoolean, useQueryState } from "nuqs";
 
@@ -13,6 +12,7 @@ import { useFeedMutations } from "@/lib/feed/mutation";
 import { canDeletePost, canEditPost } from "@/lib/thread/permissions";
 import { withUndo } from "@/lib/thread/undo";
 import { useShare } from "@/utils/client";
+import { useCopyToClipboard } from "@/utils/useCopyToClipboard";
 
 import { getPermalinkForThread } from "../utils";
 

--- a/web/src/components/ui/link-button.tsx
+++ b/web/src/components/ui/link-button.tsx
@@ -18,7 +18,6 @@ export function LinkButton({
   href,
   ...props
 }: PropsWithChildren<LinkProps>) {
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const [vp, stripped] = button.splitVariantProps(props);
 
   const cn = cx(button(vp), css(stripped));

--- a/web/src/screens/library/LibraryPageScreen/blocks/LibraryPageDirectoryBlock/AddPropertyMenu/AddPropertyMenu.tsx
+++ b/web/src/screens/library/LibraryPageScreen/blocks/LibraryPageDirectoryBlock/AddPropertyMenu/AddPropertyMenu.tsx
@@ -1,5 +1,5 @@
 import { MenuSelectionDetails, Portal } from "@ark-ui/react";
-import { useClickAway } from "@uidotdev/usehooks";
+import { useClickAway } from "@/utils/useClickAway";
 import { PropsWithChildren, useState } from "react";
 
 import { handle } from "@/api/client";

--- a/web/src/screens/library/links/LinkScreen.tsx
+++ b/web/src/screens/library/links/LinkScreen.tsx
@@ -33,6 +33,13 @@ export function LinkScreen(props: Props) {
 
   const domainSearch = `/links?q=${link.domain}`;
 
+  const assetsForThumbnails =
+    link.assets && link.assets.length > 0
+      ? link.assets
+      : link.primary_image
+        ? [link.primary_image]
+        : [];
+
   return (
     <LStack>
       <Breadcrumbs
@@ -91,7 +98,7 @@ export function LinkScreen(props: Props) {
         </LStack>
       </Flex>
 
-      <AssetThumbnailList assets={link.assets} />
+      <AssetThumbnailList assets={assetsForThumbnails} />
     </LStack>
   );
 }

--- a/web/src/utils/useClickAway.ts
+++ b/web/src/utils/useClickAway.ts
@@ -1,0 +1,27 @@
+import { useEffect, useRef } from "react";
+
+export function useClickAway<T extends HTMLElement = HTMLElement>(
+  handler: (event: MouseEvent | TouchEvent) => void,
+) {
+  const ref = useRef<T>(null);
+
+  useEffect(() => {
+    const listener = (event: MouseEvent | TouchEvent) => {
+      const element = ref.current;
+      if (!element || element.contains(event.target as Node)) {
+        return;
+      }
+      handler(event);
+    };
+
+    document.addEventListener("mousedown", listener);
+    document.addEventListener("touchstart", listener);
+
+    return () => {
+      document.removeEventListener("mousedown", listener);
+      document.removeEventListener("touchstart", listener);
+    };
+  }, [handler]);
+
+  return ref;
+}

--- a/web/src/utils/useCopyToClipboard.ts
+++ b/web/src/utils/useCopyToClipboard.ts
@@ -1,0 +1,26 @@
+import { useCallback, useState } from "react";
+
+export function useCopyToClipboard(): [
+  string | null,
+  (text: string) => Promise<void>,
+  boolean,
+] {
+  const [copiedText, setCopiedText] = useState<string | null>(null);
+  const isClipboardAvailable = !!navigator?.clipboard;
+
+  const copyToClipboard = useCallback(async (text: string) => {
+    if (!navigator?.clipboard) {
+      console.warn("Clipboard not supported");
+      return;
+    }
+
+    try {
+      await navigator.clipboard.writeText(text);
+      setCopiedText(text);
+    } catch (error) {
+      console.error("Failed to copy text: ", error);
+    }
+  }, []);
+
+  return [copiedText, copyToClipboard, isClipboardAvailable];
+}

--- a/web/yarn.lock
+++ b/web/yarn.lock
@@ -4294,16 +4294,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@uidotdev/usehooks@npm:^2.4.1":
-  version: 2.4.1
-  resolution: "@uidotdev/usehooks@npm:2.4.1"
-  peerDependencies:
-    react: ">=18.0.0"
-    react-dom: ">=18.0.0"
-  checksum: 10c0/181c43fb324dbe4fef9762c61ab4b8235efa48abedf39a9bfeab65872522c43dae789c4f85b82a1164ed7bb18ae7ff25c3a19e7c4e0eb944937ac7f8109cee9b
-  languageName: node
-  linkType: hard
-
 "@ungap/structured-clone@npm:^1.0.0":
   version: 1.2.1
   resolution: "@ungap/structured-clone@npm:1.2.1"
@@ -13565,7 +13555,6 @@ __metadata:
     "@types/react-avatar-editor": "npm:^13.0.4"
     "@typescript-eslint/eslint-plugin": "npm:^8.37.0"
     "@typescript-eslint/parser": "npm:^8.37.0"
-    "@uidotdev/usehooks": "npm:^2.4.1"
     "@use-gesture/react": "npm:^10.3.1"
     chroma-js: "npm:^3.1.2"
     date-fns: "npm:^4.1.0"


### PR DESCRIPTION
Takes care of the first item on the list of https://github.com/Southclaws/storyden/issues/536: re-implement two hooks `useClickAway` and `useCopyToClipboard` in `@/utils`