### PR TITLE
Library page revalidation improvements and fixes

### DIFF
--- a/app/resources/library/node_cache/revalidate_job.go
+++ b/app/resources/library/node_cache/revalidate_job.go
@@ -12,37 +12,37 @@ import (
 
 func (c *Cache) subscribe(ctx context.Context, bus *pubsub.Bus) error {
 	if _, err := pubsub.Subscribe(ctx, bus, "node_cache.touch_created", func(ctx context.Context, evt *message.EventNodeCreated) error {
-		return c.touch(ctx, eventKey(evt.Mark, xid.ID(evt.ID)))
+		return c.touch(ctx, eventKey(evt.Slug, xid.ID(evt.ID)))
 	}); err != nil {
 		return err
 	}
 
 	if _, err := pubsub.Subscribe(ctx, bus, "node_cache.touch_updated", func(ctx context.Context, evt *message.EventNodeUpdated) error {
-		return c.touch(ctx, eventKey(evt.Mark, xid.ID(evt.ID)))
+		return c.touch(ctx, eventKey(evt.Slug, xid.ID(evt.ID)))
 	}); err != nil {
 		return err
 	}
 
 	if _, err := pubsub.Subscribe(ctx, bus, "node_cache.touch_published", func(ctx context.Context, evt *message.EventNodePublished) error {
-		return c.touch(ctx, eventKey(evt.Mark, xid.ID(evt.ID)))
+		return c.touch(ctx, eventKey(evt.Slug, xid.ID(evt.ID)))
 	}); err != nil {
 		return err
 	}
 
 	if _, err := pubsub.Subscribe(ctx, bus, "node_cache.touch_submitted", func(ctx context.Context, evt *message.EventNodeSubmittedForReview) error {
-		return c.touch(ctx, eventKey(evt.Mark, xid.ID(evt.ID)))
+		return c.touch(ctx, eventKey(evt.Slug, xid.ID(evt.ID)))
 	}); err != nil {
 		return err
 	}
 
 	if _, err := pubsub.Subscribe(ctx, bus, "node_cache.touch_unpublished", func(ctx context.Context, evt *message.EventNodeUnpublished) error {
-		return c.touch(ctx, eventKey(evt.Mark, xid.ID(evt.ID)))
+		return c.touch(ctx, eventKey(evt.Slug, xid.ID(evt.ID)))
 	}); err != nil {
 		return err
 	}
 
 	if _, err := pubsub.Subscribe(ctx, bus, "node_cache.invalidate_deleted", func(ctx context.Context, evt *message.EventNodeDeleted) error {
-		return c.invalidate(ctx, eventKey(evt.Mark, xid.ID(evt.ID)))
+		return c.invalidate(ctx, eventKey(evt.Slug, xid.ID(evt.ID)))
 	}); err != nil {
 		return err
 	}

--- a/app/resources/message/message_types.go
+++ b/app/resources/message/message_types.go
@@ -111,32 +111,32 @@ type CommandReplyDeindex struct {
 
 type EventNodeCreated struct {
 	ID   library.NodeID
-	Mark string
+	Slug string
 }
 
 type EventNodeUpdated struct {
 	ID   library.NodeID
-	Mark string
+	Slug string
 }
 
 type EventNodeDeleted struct {
 	ID   library.NodeID
-	Mark string
+	Slug string
 }
 
 type EventNodePublished struct {
 	ID   library.NodeID
-	Mark string
+	Slug string
 }
 
 type EventNodeSubmittedForReview struct {
 	ID   library.NodeID
-	Mark string
+	Slug string
 }
 
 type EventNodeUnpublished struct {
 	ID   library.NodeID
-	Mark string
+	Slug string
 }
 
 type CommandNodeIndex struct {

--- a/app/services/library/node_mutate/create.go
+++ b/app/services/library/node_mutate/create.go
@@ -62,13 +62,13 @@ func (s *Manager) Create(ctx context.Context,
 
 	s.bus.Publish(ctx, &message.EventNodeCreated{
 		ID:   library.NodeID(n.Mark.ID()),
-		Mark: n.Mark.String(),
+		Slug: n.GetSlug(),
 	})
 
 	if p.Visibility.OrZero() == visibility.VisibilityPublished {
 		s.bus.Publish(ctx, &message.EventNodePublished{
 			ID:   library.NodeID(n.Mark.ID()),
-			Mark: n.Mark.String(),
+			Slug: n.GetSlug(),
 		})
 	}
 

--- a/app/services/library/node_mutate/delete.go
+++ b/app/services/library/node_mutate/delete.go
@@ -56,7 +56,7 @@ func (s *Manager) Delete(ctx context.Context, qk library.QueryKey, d DeleteOptio
 
 	s.bus.Publish(ctx, &message.EventNodeDeleted{
 		ID:   library.NodeID(n.GetID()),
-		Mark: n.Mark.String(),
+		Slug: n.GetSlug(),
 	})
 
 	return destination.Ptr(), nil

--- a/app/services/library/node_mutate/update.go
+++ b/app/services/library/node_mutate/update.go
@@ -58,7 +58,7 @@ func (s *Manager) Update(ctx context.Context, qk library.QueryKey, p Partial) (*
 	// Emit update event
 	s.bus.Publish(ctx, &message.EventNodeUpdated{
 		ID:   library.NodeID(n.Mark.ID()),
-		Mark: n.Mark.String(),
+		Slug: n.GetSlug(),
 	})
 
 	// Emit visibility transition events
@@ -67,20 +67,20 @@ func (s *Manager) Update(ctx context.Context, qk library.QueryKey, p Partial) (*
 		case visibility.VisibilityPublished:
 			s.bus.Publish(ctx, &message.EventNodePublished{
 				ID:   library.NodeID(n.Mark.ID()),
-				Mark: n.Mark.String(),
+				Slug: n.GetSlug(),
 			})
 
 		case visibility.VisibilityReview:
 			s.bus.Publish(ctx, &message.EventNodeSubmittedForReview{
 				ID:   library.NodeID(n.Mark.ID()),
-				Mark: n.Mark.String(),
+				Slug: n.GetSlug(),
 			})
 
 		case visibility.VisibilityUnlisted, visibility.VisibilityDraft, visibility.VisibilityReview:
 			if oldVisibility == visibility.VisibilityPublished {
 				s.bus.Publish(ctx, &message.EventNodeUnpublished{
 					ID:   library.NodeID(n.Mark.ID()),
-					Mark: n.Mark.String(),
+					Slug: n.GetSlug(),
 				})
 			}
 		}

--- a/app/services/library/node_visibility/visibility.go
+++ b/app/services/library/node_visibility/visibility.go
@@ -84,18 +84,18 @@ func (m *Controller) ChangeVisibility(ctx context.Context, qk library.QueryKey, 
 		case visibility.VisibilityPublished:
 			m.bus.Publish(ctx, &message.EventNodePublished{
 				ID:   library.NodeID(n.Mark.ID()),
-				Mark: n.Mark.String(),
+				Slug: n.GetSlug(),
 			})
 		case visibility.VisibilityReview:
 			m.bus.Publish(ctx, &message.EventNodeSubmittedForReview{
 				ID:   library.NodeID(n.Mark.ID()),
-				Mark: n.Mark.String(),
+				Slug: n.GetSlug(),
 			})
 		case visibility.VisibilityUnlisted, visibility.VisibilityDraft:
 			if oldVisibility == visibility.VisibilityPublished {
 				m.bus.Publish(ctx, &message.EventNodeUnpublished{
 					ID:   library.NodeID(n.Mark.ID()),
-					Mark: n.Mark.String(),
+					Slug: n.GetSlug(),
 				})
 			}
 		}

--- a/app/services/library/nodetree/nodetree.go
+++ b/app/services/library/nodetree/nodetree.go
@@ -113,7 +113,7 @@ func (s *service) Move(ctx context.Context, child library.QueryKey, parent libra
 
 	s.bus.Publish(ctx, &message.EventNodeUpdated{
 		ID:   library.NodeID(cnode.Mark.ID()),
-		Mark: cnode.Mark.String(),
+		Slug: cnode.GetSlug(),
 	})
 
 	return cnode, nil
@@ -159,7 +159,7 @@ func (s *service) Sever(ctx context.Context, child library.QueryKey, parent libr
 
 	s.bus.Publish(ctx, &message.EventNodeUpdated{
 		ID:   library.NodeID(result.Mark.ID()),
-		Mark: result.Mark.String(),
+		Slug: result.GetSlug(),
 	})
 
 	return result, nil

--- a/app/services/library/nodetree/position.go
+++ b/app/services/library/nodetree/position.go
@@ -118,7 +118,7 @@ func (p *Position) Move(ctx context.Context, nm library.QueryKey, opts Options) 
 
 		p.bus.Publish(ctx, &message.EventNodeUpdated{
 			ID:   library.NodeID(n.Mark.ID()),
-			Mark: n.Mark.String(),
+			Slug: n.GetSlug(),
 		})
 
 		return n, nil
@@ -132,7 +132,7 @@ func (p *Position) Move(ctx context.Context, nm library.QueryKey, opts Options) 
 
 		p.bus.Publish(ctx, &message.EventNodeUpdated{
 			ID:   library.NodeID(n.Mark.ID()),
-			Mark: n.Mark.String(),
+			Slug: n.GetSlug(),
 		})
 
 		return n, nil
@@ -146,7 +146,7 @@ func (p *Position) Move(ctx context.Context, nm library.QueryKey, opts Options) 
 
 		p.bus.Publish(ctx, &message.EventNodeUpdated{
 			ID:   library.NodeID(n.Mark.ID()),
-			Mark: n.Mark.String(),
+			Slug: n.GetSlug(),
 		})
 
 		return n, nil

--- a/web/src/components/library/Breadcrumbs.tsx
+++ b/web/src/components/library/Breadcrumbs.tsx
@@ -47,14 +47,6 @@ export const Breadcrumbs_ = (
   const paths = isEditing ? uniquePaths.slice(0, -1) : uniquePaths;
   const current = last(paths);
 
-  console.log("Breadcrumbs render:", {
-    libraryPath,
-    uniquePaths,
-    paths,
-    current,
-    isEditing,
-  });
-
   return (
     <HStack
       w="full"

--- a/web/src/screens/library/LibraryPageScreen/Context.tsx
+++ b/web/src/screens/library/LibraryPageScreen/Context.tsx
@@ -33,6 +33,7 @@ type LibraryPageContext = {
   initialChildren?: NodeListResult;
   store: NodeStoreAPI;
   saving: boolean;
+  revalidate: () => void;
 };
 
 const Context = createContext<LibraryPageContext | null>(null);
@@ -99,7 +100,7 @@ export function LibraryPageProvider({
 
             const operations = entries(collapsed);
 
-            console.log("Updating child nodes", operations);
+            console.debug("Updating child nodes", operations);
 
             await Promise.all(
               operations.map(([childNodeID, child]) =>
@@ -188,6 +189,7 @@ export function LibraryPageProvider({
         initialChildren: childNodes,
         store: storeRef.current,
         saving,
+        revalidate,
       }}
     >
       {children}

--- a/web/src/screens/library/LibraryPageScreen/LibraryPageControls.tsx
+++ b/web/src/screens/library/LibraryPageScreen/LibraryPageControls.tsx
@@ -22,6 +22,9 @@ function useLibraryPageControls() {
   const slug = useWatch((s) => s.draft.slug);
   const visibility = useWatch((s) => s.draft.visibility);
 
+  // Ensure the final item is the real slug, not the cached copy
+  const updatedLibraryPath = [...libraryPath.slice(0, -1), slug];
+
   const { isAllowedToEdit } = useLibraryPagePermissions();
   const { editing } = useEditState();
 
@@ -36,7 +39,7 @@ function useLibraryPageControls() {
   }
 
   return {
-    libraryPath,
+    libraryPath: updatedLibraryPath,
     draft,
     slug,
     isSlugInvalid,

--- a/web/src/screens/library/LibraryPageScreen/useEditState.ts
+++ b/web/src/screens/library/LibraryPageScreen/useEditState.ts
@@ -10,13 +10,14 @@ export function useEditState() {
     clearOnDefault: true,
   });
 
-  const { saving } = useLibraryPageContext();
+  const { saving, revalidate } = useLibraryPageContext();
 
   const { isAllowedToEdit } = useLibraryPagePermissions();
 
   function handleToggleEditMode() {
     if (editing) {
       setEditing(false);
+      revalidate();
     } else {
       if (!isAllowedToEdit) return;
 


### PR DESCRIPTION
always cache nodes by slug, remove page revalidation during edit mode, fix breadcrumb slug stale state.

fixes #550