### PR TITLE
Refine AI content generation prompts for summaries and titles

### DIFF
--- a/app/services/generative/summary.go
+++ b/app/services/generative/summary.go
@@ -12,17 +12,35 @@ import (
 )
 
 var SummarisePrompt = template.Must(template.New("").Parse(`
-Write a short few paragraphs that are somewhat engaging but remaining relatively neutral in tone in the style of a wikipedia introduction based on the specified content. Focus on providing unique insights and interesting details while keeping the tone conversational and approachable. Imagine this will be read by someone browsing a directory or knowledgebase.
+Write a brief, concise summary of the following content in 2-3 short sentences, never exceeding one paragraph. This summary serves as a starting point for curators who will write their own descriptions later - it should just provide enough context to remind them what this content is about.
 
-Be aware that the input to this may include broken HTML and other artifacts from the web and due to the nature of web scraping, there may be parts that do not make sense.
+Keep the tone neutral and factual, similar to a Wikipedia introduction. Focus on what the subject IS, not why it's interesting or what makes it special.
 
-- Ignore any HTML tags, malformed content, or text that does not contribute meaningfully to the main topic.
-- Based on the clear and coherent sections of the input, write short but engaging paragraphs. If the input lacks meaningful context, produce a neutral placeholder.
-- If the input content is too fragmented or lacks sufficient context to produce a coherent response, produce a neutral placeholder.
-- Do not describe the appearance of the input (e.g., broken HTML or artifacts). Instead, infer the main idea or purpose and expand on it creatively.
-- If key parts of the content are missing or ambiguous, use creativity to fill gaps while maintaining relevance to the topic.
+The input may include a URL and Original Title which should help you understand the context, followed by the actual content. The content may also include broken HTML and other web scraping artifacts.
 
-Output Format: Provide the output as a correctly formatted HTML document, but do not include any markdown tags around the output, you are free to use basic HTML formatting tags for emphasis, lists and headings. However, do not include the content title as a <h1> tag at the top. Start with a paragraph block immediately.
+Guidelines:
+- Maximum 2-3 sentences, always in a single paragraph
+- Use URL and Original Title as context clues but don't reference them directly in the summary
+- Focus on factual description of what the subject is
+- Avoid promotional or marketing language
+- Ignore HTML tags, malformed content, or irrelevant fragments
+- If content is too fragmented, produce a simple neutral description based on URL/title
+- Do NOT be creative or fill in gaps - stick to what's clearly stated
+- Do NOT use phrases like "this article discusses" or "this page is about"
+
+Output Format: Plain HTML paragraph tag(s) only. Start immediately with <p> tag. No headings, no multiple paragraphs, no markdown.
+
+<example>
+URL: https://selfh.st/
+Original Title: Selfh.st - Modern Self-Hosting Made Easy
+
+Content:
+Selfh.st is a modern self-hosting platform that makes it easy to deploy applications...
+
+Good output: <p>Selfh.st is a self-hosting platform for deploying applications. It provides tools for managing and running containerized services.</p>
+
+Bad output: <p>Selfh.st is an innovative and exciting new platform that revolutionizes the way we think about self-hosting.</p><p>With its modern approach and user-friendly interface, it makes deployment easier than ever before.</p><p>Whether you're a beginner or an expert, you'll find something to love.</p>
+</example>
 
 Content:
 

--- a/app/services/generative/title.go
+++ b/app/services/generative/title.go
@@ -5,20 +5,110 @@ import (
 	"html/template"
 	"strings"
 
-	"github.com/Southclaws/dt"
 	"github.com/Southclaws/fault"
 	"github.com/Southclaws/fault/fctx"
 
 	"github.com/Southclaws/storyden/app/resources/datagraph"
+	"github.com/Southclaws/storyden/internal/infrastructure/ai"
 )
 
-var TitlePrompt = template.Must(template.New("").Parse(`
-Generate 1 to 3 concise and genuine title suggestions for the following content. Titles should feel natural, not overly stylized or pushy, and suitable for diverse content types. Limit each title to 60 characters. Respond with only the titles, separated by newlines.
+var TitlePrompt = template.Must(template.New("").Parse(`Generate 1 to 3 concise title suggestions for the following content. These titles will be used as page titles AND in URL slugs, so they must be URL-friendly and focus on the primary SUBJECT of the content, not descriptive topics or commentary.
+
+Guidelines:
+- If a URL is provided, extract the brand/product/subject name from the domain or path (e.g., "thedesignsystem.guide" → "Design System Guide")
+- If an Original Title is provided, use it as a strong signal but simplify and clean it up (remove marketing language, "the ultimate", etc.)
+- Focus on the main subject, entity, or thing being discussed (e.g., "React Hooks" not "Understanding React Hooks")
+- Keep titles simple, direct, and factual
+- Avoid creative or promotional language
+- Limit to 60 characters maximum
+- Prefer nouns and noun phrases over verb phrases
+- Avoid question formats unless the content is explicitly a question
+- Remove unnecessary articles (a, an, the) when they don't add clarity
+
+<example>
+URL: https://thedesignsystem.guide/
+Original Title: The Design System Guide - Learn Design Systems
+
+Content:
+A comprehensive resource for learning design systems, covering everything from design tokens to component libraries...
+
+Good titles:
+- Design System Guide
+- Design Systems Resource
+- Design System Learning
+
+Bad titles:
+- The Ultimate Design System Guide
+- Learn Everything About Design Systems
+- Complete Design System Tutorial
+</example>
+
+<example>
+URL: https://selfh.st/
+Original Title: Selfh.st - Modern Self-Hosting Made Easy
+
+Content:
+Selfh.st is a modern self-hosting platform that makes it easy to deploy applications...
+
+Good titles:
+- Selfh.st
+- Selfh.st Platform
+- Self-Hosting Platform
+
+Bad titles:
+- Modern Self-Hosting Made Easy
+- The Future of Self-Hosting
+- Revolutionary Self-Hosting Platform
+</example>
+
+<example>
+Content: "I've been working with Docker for a while now and wanted to share some best practices I've learned about container optimization and layer caching..."
+
+Good titles:
+- Docker Container Optimization
+- Container Layer Caching
+- Docker Best Practices
+
+Bad titles:
+- How I Learned to Optimize Docker Containers
+- My Journey with Docker: Tips and Tricks
+- Everything You Need to Know About Docker
+</example>
+
+<example>
+Content: "Here's my implementation of a binary search tree in Go with some interesting performance characteristics..."
+Good titles:
+- Binary Search Tree in Go
+- Go BST Implementation
+- Binary Search Tree Performance
+
+Bad titles:
+- How to Build a Binary Search Tree
+- My Take on Binary Search Trees
+- The Ultimate Guide to BST in Go
+</example>
+
+<example>
+Content: "What's the best way to handle authentication in a Next.js application? I'm trying to decide between NextAuth and custom JWT..."
+Good titles:
+- Next.js Authentication Options
+- NextAuth vs Custom JWT
+- Next.js Auth Implementation
+
+Bad titles:
+- Choosing the Right Authentication for Your Next.js App
+- A Deep Dive into Next.js Authentication
+- Which Auth Solution Should You Use?
+</example>
 
 Content:
 
 {{ .Content }}
 `))
+
+type SuggestTitleResultSchema struct {
+	Titles []string `json:"titles" jsonschema:"title=Titles,description=List of suggested titles,items=string"`
+}
 
 func (g *generator) SuggestTitle(ctx context.Context, content datagraph.Content) ([]string, error) {
 	template := strings.Builder{}
@@ -29,16 +119,10 @@ func (g *generator) SuggestTitle(ctx context.Context, content datagraph.Content)
 		return nil, fault.Wrap(err, fctx.With(ctx))
 	}
 
-	result, err := g.prompter.Prompt(ctx, template.String())
+	result, err := ai.PromptObject(ctx, g.prompter, "Suggest titles for content", template.String(), SuggestTitleResultSchema{})
 	if err != nil {
 		return nil, fault.Wrap(err, fctx.With(ctx))
 	}
 
-	titles := strings.Split(result.Answer, "\n")
-
-	trimmed := dt.Map(titles, strings.TrimSpace)
-
-	filtered := dt.Filter(trimmed, func(s string) bool { return len(s) > 0 })
-
-	return filtered, nil
+	return result.Titles, nil
 }

--- a/web/src/components/library/CreatePageFromURL/import.ts
+++ b/web/src/components/library/CreatePageFromURL/import.ts
@@ -104,16 +104,23 @@ export async function* importFromURLGenerator({
       // The slug isn't actually used by the backend lol...
       const tempSlug = `temp-${Date.now()}`;
 
+      // Enhance the content with metadata for better AI suggestions
+      const enhancedContent = `URL: ${url}
+Original Title: ${title || "N/A"}
+
+Content:
+${description}`;
+
       try {
         const [tag_suggestions, title_suggestion, content_suggestion] =
           await Promise.all([
-            nodeGenerateTags(tempSlug, { content: description })
+            nodeGenerateTags(tempSlug, { content: enhancedContent })
               .then((r) => r.tags)
               .catch(() => undefined),
-            nodeGenerateTitle(tempSlug, { content: description })
+            nodeGenerateTitle(tempSlug, { content: enhancedContent })
               .then((r) => r.title)
               .catch(() => undefined),
-            nodeGenerateContent(tempSlug, { content: description })
+            nodeGenerateContent(tempSlug, { content: enhancedContent })
               .then((r) => r.content)
               .catch(() => undefined),
           ]);


### PR DESCRIPTION
Enhance the clarity and effectiveness of prompts used for generating summaries and titles, ensuring they focus on factual descriptions and maintain a neutral tone. Update the content processing to include metadata for improved AI suggestions.

fixes #549