### PR TITLE
Editor tools on iOS Safari

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -15,6 +15,7 @@
     "@ark-ui/react": "5.26.2",
     "@dnd-kit/core": "^6.3.1",
     "@dnd-kit/sortable": "^10.0.0",
+    "@floating-ui/react": "^0.27.16",
     "@heroicons/react": "^2.2.0",
     "@hookform/resolvers": "^4.1.3",
     "@simplewebauthn/browser": "^10.0.0",

--- a/web/src/components/content/ComposerTools.tsx
+++ b/web/src/components/content/ComposerTools.tsx
@@ -1,10 +1,24 @@
+import { autoUpdate } from "@floating-ui/react";
 import { motion } from "framer-motion";
-import { PropsWithChildren, useEffect, useRef, useState } from "react";
+import {
+  PropsWithChildren,
+  useEffect,
+  useLayoutEffect,
+  useRef,
+  useState,
+} from "react";
 
 import { IconButton } from "@/components/ui/icon-button";
 import { Box, HStack, styled } from "@/styled-system/jsx";
 
 import { Spinner } from "../ui/Spinner";
+
+// NOTE: Should match the MD breakpoint in `panda.config.ts`.
+const MD_BREAKPOINT = 768;
+
+// NOTE: Desktop is more because we have to make space for the navigation bar.
+const MOBILE_TOP_OFFSET = 16;
+const DESKTOP_TOP_OFFSET = 80;
 
 type Props = {
   enabled: boolean;
@@ -64,12 +78,66 @@ export function ComposerTools({
     }, 650);
   };
 
+  // The anchor is the absolutely positioned container. This is fixed to its
+  // parent and does not move relative to the viewport. It acts as the position
+  // anchor as the user scrolls, it may be out of view or within the viewport.
+  const anchorRef = useRef<HTMLDivElement>(null);
+  // The floating element is the menu itself, this is where we essentially build
+  // our own "position: sticky" behavior by calculating the anchor's position
+  // relative to the viewport scroll position and bound its position to the Y
+  // dimension of the anchor. The anchor is height=full, so fills the textarea.
+  const floatingRef = useRef<HTMLDivElement>(null);
+
+  useLayoutEffect(() => {
+    if (!enabled) return;
+    if (!anchorRef.current || !floatingRef.current) return;
+
+    const updatePosition = () => {
+      if (!anchorRef.current || !floatingRef.current) return;
+
+      const anchorRect = anchorRef.current.getBoundingClientRect();
+      const floatingRect = floatingRef.current.getBoundingClientRect();
+
+      // TODO: Use a resize observer to handle viewport size changes, memoise.
+      const isMobile = window.innerWidth < MD_BREAKPOINT;
+      const navbarOffset = isMobile ? MOBILE_TOP_OFFSET : DESKTOP_TOP_OFFSET;
+
+      // The desired Y position in the viewport for the floating menu.
+      const desiredViewportY = navbarOffset;
+      const anchorTop = anchorRect.top;
+      const floatingHeight = floatingRect.height;
+
+      // Calculate how far the anchor is from the desired viewport Y position.
+      // Clamp to zero so the floating menu doesn't go above the anchor.
+      const anchorRelativeY = Math.max(0, desiredViewportY - anchorTop);
+
+      // maxY is the maximum Y offset the floating menu can have within the
+      // anchor, so it doesn't overflow past the bottom of the anchor.
+      const maxY = anchorRect.height - floatingHeight;
+
+      // Constrain the floating menu's Y position so it stays within the
+      // anchor's bounds. This ensures the menu is always visible and doesn't
+      // overflow, even if the anchor is small.
+      const constrainedY = Math.min(anchorRelativeY, maxY);
+
+      Object.assign(floatingRef.current.style, {
+        top: `${constrainedY}px`,
+      });
+    };
+
+    updatePosition();
+
+    return autoUpdate(anchorRef.current, floatingRef.current, updatePosition);
+  }, [enabled]);
+
   if (!enabled) {
     return null;
   }
 
   return (
     <Box
+      ref={anchorRef}
+      className="composer-tools__anchor"
       position="absolute"
       height="full"
       width="full"
@@ -78,8 +146,9 @@ export function ComposerTools({
       pointerEvents="none"
     >
       <Box
-        position="sticky"
-        top={{ base: "safeTop", md: "20" }}
+        ref={floatingRef}
+        className="composer-tools__sticky-container"
+        position="absolute"
         width="full"
         display="flex"
         justifyContent="flex-end"
@@ -87,6 +156,7 @@ export function ComposerTools({
         pointerEvents="none"
       >
         <Box
+          className="composer-tools__hover-trigger"
           opacity={isExpanded ? "full" : "5"}
           onPointerEnter={handlePointerEnter}
           onPointerLeave={handlePointerLeave}
@@ -99,8 +169,9 @@ export function ComposerTools({
           p="1"
           maxWidth="full"
         >
-          <HStack gap="2">
+          <HStack gap="2" className="composer-tools__expanding-stack">
             <motion.div
+              className="composer-tools__animated-reveal"
               animate={
                 isExpanded
                   ? { width: "auto" }
@@ -110,10 +181,14 @@ export function ComposerTools({
               style={{ overflow: "hidden", display: "flex", gap: "8px" }}
             >
               {isWorking && (
-                <HStack gap="1">
+                <HStack gap="1" className="composer-tools__working-status">
                   <Spinner size="sm" />
                   {workingCount > 1 && (
-                    <styled.span fontSize="xs" color="fg.muted">
+                    <styled.span
+                      className="composer-tools__working-status-count"
+                      fontSize="xs"
+                      color="fg.muted"
+                    >
                       {workingCount}
                     </styled.span>
                   )}
@@ -121,6 +196,7 @@ export function ComposerTools({
               )}
 
               <div
+                className="composer-tools__children-container"
                 style={{
                   visibility: isExpanded ? "visible" : "hidden",
                   width: isExpanded ? "auto" : 0,
@@ -133,6 +209,7 @@ export function ComposerTools({
             </motion.div>
 
             <IconButton
+              className="composer-tools__expand-button"
               type="button"
               variant="ghost"
               size="xs"

--- a/web/yarn.lock
+++ b/web/yarn.lock
@@ -1659,13 +1659,39 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@floating-ui/dom@npm:1.7.4":
+"@floating-ui/dom@npm:1.7.4, @floating-ui/dom@npm:^1.7.4":
   version: 1.7.4
   resolution: "@floating-ui/dom@npm:1.7.4"
   dependencies:
     "@floating-ui/core": "npm:^1.7.3"
     "@floating-ui/utils": "npm:^0.2.10"
   checksum: 10c0/da6166c25f9b0729caa9f498685a73a0e28251613b35d27db8de8014bc9d045158a23c092b405321a3d67c2064909b6e2a7e6c1c9cc0f62967dca5779f5aef30
+  languageName: node
+  linkType: hard
+
+"@floating-ui/react-dom@npm:^2.1.6":
+  version: 2.1.6
+  resolution: "@floating-ui/react-dom@npm:2.1.6"
+  dependencies:
+    "@floating-ui/dom": "npm:^1.7.4"
+  peerDependencies:
+    react: ">=16.8.0"
+    react-dom: ">=16.8.0"
+  checksum: 10c0/6654834a8e73ecbdbc6cad2ad8f7abc698ac7c1800ded4d61113525c591c03d2e3b59d3cf9205859221465ea38c87af4f9e6e204703c5b7a7e85332d1eef2e18
+  languageName: node
+  linkType: hard
+
+"@floating-ui/react@npm:^0.27.16":
+  version: 0.27.16
+  resolution: "@floating-ui/react@npm:0.27.16"
+  dependencies:
+    "@floating-ui/react-dom": "npm:^2.1.6"
+    "@floating-ui/utils": "npm:^0.2.10"
+    tabbable: "npm:^6.0.0"
+  peerDependencies:
+    react: ">=17.0.0"
+    react-dom: ">=17.0.0"
+  checksum: 10c0/a026266d8875e69de1ac1e1a00588660c8ee299c1e7d067c5c5fd1d69a46fd10acff5dd6cb66c3fe40a3347b443234309ba95f5b33d49059d0cda121f558f566
   languageName: node
   linkType: hard
 
@@ -13122,6 +13148,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"tabbable@npm:^6.0.0":
+  version: 6.3.0
+  resolution: "tabbable@npm:6.3.0"
+  checksum: 10c0/57ba019d29b5cfa0c862248883bcec0e6d29d8f156ba52a1f425e7cfeca4a0fc701ab8d035c4c86ddf74ecdbd0e9f454a88d9b55d924a51f444038e9cd14d7a0
+  languageName: node
+  linkType: hard
+
 "table@npm:6.9.0":
   version: 6.9.0
   resolution: "table@npm:6.9.0"
@@ -14032,6 +14065,7 @@ __metadata:
     "@ark-ui/react": "npm:5.26.2"
     "@dnd-kit/core": "npm:^6.3.1"
     "@dnd-kit/sortable": "npm:^10.0.0"
+    "@floating-ui/react": "npm:^0.27.16"
     "@heroicons/react": "npm:^2.2.0"
     "@hookform/resolvers": "npm:^4.1.3"
     "@pandacss/dev": "npm:^1.4.3"


### PR DESCRIPTION
classic safari...

so the sticky container that keeps the editor tools around while you edit longer threads/pages obviously doesn't work on ~~internet explorer 6~~ safari because the cracked apple engineers shifted the viewport up and calculate positioning based on the virtual viewport (layout viewport) not the visible viewport. So this floating button just goes off screen instead of correctly moving along with the viewport top.

The viewport top is actually not at the top of the viewport when the keyboard is visible, a similar issue was caused with vh units, which lead to dvh units being spec'd to solve this.

Unsure how to solve this yet.

sane browsers:

<img width="505" height="162" alt="image" src="https://github.com/user-attachments/assets/9c5dae32-1f25-4791-a33c-5ae4f785127f" />

netscape navigator 26:

<img width="630" height="254" alt="image" src="https://github.com/user-attachments/assets/b8e57078-3904-413e-9ff4-c50d773b3089" />
