### PR TITLE
fix cache invalidation timing for HTTP conditional requests

### DIFF
--- a/app/resources/library/node_cache/revalidate_job.go
+++ b/app/resources/library/node_cache/revalidate_job.go
@@ -12,37 +12,37 @@ import (
 
 func (c *Cache) subscribe(ctx context.Context, bus *pubsub.Bus) error {
 	if _, err := pubsub.Subscribe(ctx, bus, "node_cache.touch_created", func(ctx context.Context, evt *message.EventNodeCreated) error {
-		return c.touch(ctx, eventKey(evt.Slug, xid.ID(evt.ID)))
+		return c.Invalidate(ctx, eventKey(evt.Slug, xid.ID(evt.ID)))
 	}); err != nil {
 		return err
 	}
 
 	if _, err := pubsub.Subscribe(ctx, bus, "node_cache.touch_updated", func(ctx context.Context, evt *message.EventNodeUpdated) error {
-		return c.touch(ctx, eventKey(evt.Slug, xid.ID(evt.ID)))
+		return c.Invalidate(ctx, eventKey(evt.Slug, xid.ID(evt.ID)))
 	}); err != nil {
 		return err
 	}
 
 	if _, err := pubsub.Subscribe(ctx, bus, "node_cache.touch_published", func(ctx context.Context, evt *message.EventNodePublished) error {
-		return c.touch(ctx, eventKey(evt.Slug, xid.ID(evt.ID)))
+		return c.Invalidate(ctx, eventKey(evt.Slug, xid.ID(evt.ID)))
 	}); err != nil {
 		return err
 	}
 
 	if _, err := pubsub.Subscribe(ctx, bus, "node_cache.touch_submitted", func(ctx context.Context, evt *message.EventNodeSubmittedForReview) error {
-		return c.touch(ctx, eventKey(evt.Slug, xid.ID(evt.ID)))
+		return c.Invalidate(ctx, eventKey(evt.Slug, xid.ID(evt.ID)))
 	}); err != nil {
 		return err
 	}
 
 	if _, err := pubsub.Subscribe(ctx, bus, "node_cache.touch_unpublished", func(ctx context.Context, evt *message.EventNodeUnpublished) error {
-		return c.touch(ctx, eventKey(evt.Slug, xid.ID(evt.ID)))
+		return c.Invalidate(ctx, eventKey(evt.Slug, xid.ID(evt.ID)))
 	}); err != nil {
 		return err
 	}
 
 	if _, err := pubsub.Subscribe(ctx, bus, "node_cache.invalidate_deleted", func(ctx context.Context, evt *message.EventNodeDeleted) error {
-		return c.invalidate(ctx, eventKey(evt.Slug, xid.ID(evt.ID)))
+		return c.delete(ctx, eventKey(evt.Slug, xid.ID(evt.ID)))
 	}); err != nil {
 		return err
 	}

--- a/app/resources/post/category_cache/revalidate_job.go
+++ b/app/resources/post/category_cache/revalidate_job.go
@@ -13,13 +13,13 @@ func (c *Cache) subscribe(ctx context.Context, bus *pubsub.Bus) error {
 	}
 
 	if _, err := pubsub.Subscribe(ctx, bus, "category_cache.touch_updated", func(ctx context.Context, evt *message.EventCategoryUpdated) error {
-		return c.touch(ctx, evt.Slug)
+		return c.Invalidate(ctx, evt.Slug)
 	}); err != nil {
 		return err
 	}
 
 	if _, err := pubsub.Subscribe(ctx, bus, "category_cache.drop_deleted", func(ctx context.Context, evt *message.EventCategoryDeleted) error {
-		return c.invalidate(ctx, evt.Slug)
+		return c.delete(ctx, evt.Slug)
 	}); err != nil {
 		return err
 	}

--- a/app/resources/post/post.go
+++ b/app/resources/post/post.go
@@ -48,6 +48,15 @@ type Post struct {
 	IndexedAt opt.Optional[time.Time]
 }
 
+type PostRef struct {
+	ID   ID
+	Root ID
+}
+
+func (p *PostRef) IsThread() bool {
+	return p.ID == p.Root
+}
+
 func (p *Post) GetID() xid.ID                 { return xid.ID(p.ID) }
 func (p *Post) GetKind() datagraph.Kind       { return datagraph.KindPost }
 func (p *Post) GetName() string               { return p.Title }
@@ -114,4 +123,18 @@ func Map(in *ent.Post) (*Post, error) {
 		DeletedAt: opt.NewPtr(in.DeletedAt),
 		IndexedAt: opt.NewPtr(in.IndexedAt),
 	}, nil
+}
+
+func MapRef(in *ent.Post) *PostRef {
+	root := func() ID {
+		if in.RootPostID == nil {
+			return ID(in.ID)
+		}
+		return ID(*in.RootPostID)
+	}()
+
+	return &PostRef{
+		ID:   ID(in.ID),
+		Root: root,
+	}
 }

--- a/app/resources/post/post_querier/querier.go
+++ b/app/resources/post/post_querier/querier.go
@@ -1,0 +1,33 @@
+package post_querier
+
+import (
+	"context"
+
+	"github.com/Southclaws/fault"
+	"github.com/Southclaws/fault/fctx"
+	"github.com/rs/xid"
+
+	"github.com/Southclaws/storyden/app/resources/post"
+	"github.com/Southclaws/storyden/internal/ent"
+	ent_post "github.com/Southclaws/storyden/internal/ent/post"
+)
+
+type Querier struct {
+	db *ent.Client
+}
+
+func New(db *ent.Client) *Querier {
+	return &Querier{db: db}
+}
+
+func (q *Querier) Probe(ctx context.Context, id post.ID) (*post.PostRef, error) {
+	p, err := q.db.Post.
+		Query().
+		Where(ent_post.IDEQ(xid.ID(id))).
+		Only(ctx)
+	if err != nil {
+		return nil, fault.Wrap(err, fctx.With(ctx))
+	}
+
+	return post.MapRef(p), nil
+}

--- a/app/resources/post/reaction/react.go
+++ b/app/resources/post/reaction/react.go
@@ -45,6 +45,7 @@ func Map(in *ent.React) (*React, error) {
 		ID:     ReactID(in.ID),
 		Emoji:  in.Emoji,
 		Author: *acc,
+		target: xid.ID(in.PostID),
 	}, nil
 }
 

--- a/app/resources/post/reply/db.go
+++ b/app/resources/post/reply/db.go
@@ -155,3 +155,15 @@ func (d *database) Delete(ctx context.Context, id post.ID) error {
 
 	return nil
 }
+
+func (d *database) Probe(ctx context.Context, id post.ID) (*ReplyRef, error) {
+	p, err := d.db.Post.
+		Query().
+		Where(ent_post.IDEQ(xid.ID(id))).
+		Only(ctx)
+	if err != nil {
+		return nil, fault.Wrap(err, fctx.With(ctx), ftag.With(ftag.Internal))
+	}
+
+	return MapRef(p)
+}

--- a/app/resources/post/reply/reply.go
+++ b/app/resources/post/reply/reply.go
@@ -31,6 +31,11 @@ type Reply struct {
 	ReplyTo         opt.Optional[post.ID]
 }
 
+type ReplyRef struct {
+	ID         post.ID
+	RootPostID post.ID
+}
+
 func (*Reply) GetResourceName() string { return "post" }
 
 func (r *Reply) GetName() string {
@@ -181,4 +186,18 @@ func Mapper(
 
 		return reply, nil
 	}
+}
+
+func MapRef(m *ent.Post) (*ReplyRef, error) {
+	root := func() xid.ID {
+		if m.RootPostID == nil {
+			return m.ID
+		}
+		return *m.RootPostID
+	}()
+
+	return &ReplyRef{
+		ID:         post.ID(m.ID),
+		RootPostID: post.ID(root),
+	}, nil
 }

--- a/app/resources/post/reply/repo.go
+++ b/app/resources/post/reply/repo.go
@@ -27,6 +27,8 @@ type Repository interface {
 	Update(ctx context.Context, id post.ID, opts ...Option) (*Reply, error)
 	// EditPost(ctx context.Context, authorID, postID string, title *string, body *string) (*Post, error)
 	Delete(ctx context.Context, id post.ID) error
+
+	Probe(ctx context.Context, id post.ID) (*ReplyRef, error)
 }
 
 func WithID(id post.ID) Option {

--- a/app/resources/post/thread/thread.go
+++ b/app/resources/post/thread/thread.go
@@ -42,6 +42,15 @@ type Thread struct {
 	Related     datagraph.ItemList
 }
 
+type ThreadRef struct {
+	post.Post
+	Title       string
+	Slug        string
+	Short       string
+	Pinned      bool
+	LastReplyAt opt.Optional[time.Time]
+}
+
 func (*Thread) GetResourceName() string { return "thread" }
 
 func (t *Thread) GetKind() datagraph.Kind { return datagraph.KindThread }
@@ -166,5 +175,23 @@ func Mapper(
 			Category:    category,
 			Visibility:  visibility.NewVisibilityFromEnt(m.Visibility),
 		}, nil
+	}
+}
+
+func MapRef(m *ent.Post) *ThreadRef {
+	return &ThreadRef{
+		Post: post.Post{
+			ID: post.ID(m.ID),
+
+			CreatedAt: m.CreatedAt,
+			UpdatedAt: m.UpdatedAt,
+			DeletedAt: opt.NewPtr(m.DeletedAt),
+		},
+
+		Title:       m.Title,
+		Slug:        m.Slug,
+		Short:       m.Short,
+		Pinned:      m.Pinned,
+		LastReplyAt: opt.New(m.LastReplyAt),
 	}
 }

--- a/app/resources/post/thread_cache/revalidate_job.go
+++ b/app/resources/post/thread_cache/revalidate_job.go
@@ -14,43 +14,43 @@ func (c *Cache) subscribe(ctx context.Context, bus *pubsub.Bus) error {
 	}
 
 	if _, err := pubsub.Subscribe(ctx, bus, "thread_cache.touch_published", func(ctx context.Context, evt *message.EventThreadPublished) error {
-		return c.touch(ctx, xid.ID(evt.ID))
+		return c.Invalidate(ctx, xid.ID(evt.ID))
 	}); err != nil {
 		return err
 	}
 
 	if _, err := pubsub.Subscribe(ctx, bus, "thread_cache.touch_updated", func(ctx context.Context, evt *message.EventThreadUpdated) error {
-		return c.touch(ctx, xid.ID(evt.ID))
+		return c.Invalidate(ctx, xid.ID(evt.ID))
 	}); err != nil {
 		return err
 	}
 
 	if _, err := pubsub.Subscribe(ctx, bus, "thread_cache.touch_unpublished", func(ctx context.Context, evt *message.EventThreadUnpublished) error {
-		return c.touch(ctx, xid.ID(evt.ID))
+		return c.Invalidate(ctx, xid.ID(evt.ID))
 	}); err != nil {
 		return err
 	}
 
 	if _, err := pubsub.Subscribe(ctx, bus, "thread_cache.drop_deleted", func(ctx context.Context, evt *message.EventThreadDeleted) error {
-		return c.invalidate(ctx, xid.ID(evt.ID))
+		return c.delete(ctx, xid.ID(evt.ID))
 	}); err != nil {
 		return err
 	}
 
 	if _, err := pubsub.Subscribe(ctx, bus, "thread_cache.reply_created", func(ctx context.Context, evt *message.EventThreadReplyCreated) error {
-		return c.touch(ctx, xid.ID(evt.ThreadID))
+		return c.Invalidate(ctx, xid.ID(evt.ThreadID))
 	}); err != nil {
 		return err
 	}
 
 	if _, err := pubsub.Subscribe(ctx, bus, "thread_cache.reply_updated", func(ctx context.Context, evt *message.EventThreadReplyUpdated) error {
-		return c.touch(ctx, xid.ID(evt.ThreadID))
+		return c.Invalidate(ctx, xid.ID(evt.ThreadID))
 	}); err != nil {
 		return err
 	}
 
 	if _, err := pubsub.Subscribe(ctx, bus, "thread_cache.reply_deleted", func(ctx context.Context, evt *message.EventThreadReplyDeleted) error {
-		return c.touch(ctx, xid.ID(evt.ThreadID))
+		return c.Invalidate(ctx, xid.ID(evt.ThreadID))
 	}); err != nil {
 		return err
 	}

--- a/app/resources/post/thread_querier/probe.go
+++ b/app/resources/post/thread_querier/probe.go
@@ -1,0 +1,26 @@
+package thread_querier
+
+import (
+	"context"
+
+	"github.com/Southclaws/fault"
+	"github.com/Southclaws/fault/fctx"
+	"github.com/Southclaws/fault/ftag"
+	"github.com/rs/xid"
+
+	"github.com/Southclaws/storyden/app/resources/post"
+	"github.com/Southclaws/storyden/app/resources/post/thread"
+	ent_post "github.com/Southclaws/storyden/internal/ent/post"
+)
+
+func (q *Querier) Probe(ctx context.Context, id post.ID) (*thread.ThreadRef, error) {
+	p, err := q.db.Post.
+		Query().
+		Where(ent_post.IDEQ(xid.ID(id))).
+		Only(ctx)
+	if err != nil {
+		return nil, fault.Wrap(err, fctx.With(ctx), ftag.With(ftag.Internal))
+	}
+
+	return thread.MapRef(p), nil
+}

--- a/app/resources/profile/profile_cache/cache.go
+++ b/app/resources/profile/profile_cache/cache.go
@@ -7,6 +7,9 @@ import (
 	"github.com/rs/xid"
 	"go.uber.org/fx"
 
+	"github.com/Southclaws/fault"
+	"github.com/Southclaws/fault/fctx"
+	"github.com/Southclaws/fault/fmsg"
 	"github.com/Southclaws/storyden/app/resources/cachecontrol"
 	"github.com/Southclaws/storyden/internal/infrastructure/cache"
 	"github.com/Southclaws/storyden/internal/infrastructure/pubsub"
@@ -58,6 +61,26 @@ func (c *Cache) Store(ctx context.Context, id xid.ID, ts time.Time) error {
 	return c.storeTimestamp(ctx, id, ts)
 }
 
+func (c *Cache) Invalidate(ctx context.Context, id xid.ID) error {
+	now := c.clock().UTC()
+
+	if ts, ok := c.cached(ctx, id); ok {
+		nowTrunc := now.Truncate(time.Second)
+		tsTrunc := ts.Truncate(time.Second)
+
+		if !nowTrunc.After(tsTrunc) {
+			now = tsTrunc.Add(time.Second)
+		}
+	}
+
+	err := c.storeTimestamp(ctx, id, now)
+	if err != nil {
+		return fault.Wrap(err, fctx.With(ctx), fmsg.With("failed to invalidate cache for profile"))
+	}
+
+	return nil
+}
+
 func (c *Cache) cacheKey(id xid.ID) string {
 	return cachePrefix + id.String()
 }
@@ -87,8 +110,4 @@ func (c *Cache) cached(ctx context.Context, id xid.ID) (*time.Time, bool) {
 
 func (c *Cache) storeTimestamp(ctx context.Context, id xid.ID, ts time.Time) error {
 	return c.store.Set(ctx, c.cacheKey(id), ts.UTC().Format(storeTimeFmt), cacheTTL)
-}
-
-func (c *Cache) touch(ctx context.Context, id xid.ID) error {
-	return c.storeTimestamp(ctx, id, c.clock().UTC())
 }

--- a/app/resources/profile/profile_cache/revalidate_job.go
+++ b/app/resources/profile/profile_cache/revalidate_job.go
@@ -15,7 +15,7 @@ func (c *Cache) subscribe(ctx context.Context, bus *pubsub.Bus) error {
 	}
 
 	if _, err := pubsub.Subscribe(ctx, bus, "profile_cache.touch_updated", func(ctx context.Context, evt *message.EventAccountUpdated) error {
-		return c.touch(ctx, xid.ID(evt.ID))
+		return c.Invalidate(ctx, xid.ID(evt.ID))
 	}); err != nil {
 		return err
 	}

--- a/app/resources/resources.go
+++ b/app/resources/resources.go
@@ -40,6 +40,7 @@ import (
 	"github.com/Southclaws/storyden/app/resources/link/link_writer"
 	"github.com/Southclaws/storyden/app/resources/post/category"
 	"github.com/Southclaws/storyden/app/resources/post/category_cache"
+	"github.com/Southclaws/storyden/app/resources/post/post_querier"
 	"github.com/Southclaws/storyden/app/resources/post/post_read_state"
 	"github.com/Southclaws/storyden/app/resources/post/post_search"
 	"github.com/Southclaws/storyden/app/resources/post/post_writer"
@@ -91,6 +92,7 @@ func Build() fx.Option {
 			reaction.New,
 			like_querier.New,
 			like_writer.New,
+			post_querier.New,
 			post_search.New,
 			post_writer.New,
 			post_read_state.New,

--- a/app/services/library/node_mutate/mutate.go
+++ b/app/services/library/node_mutate/mutate.go
@@ -9,6 +9,7 @@ import (
 	"github.com/Southclaws/storyden/app/resources/asset"
 	"github.com/Southclaws/storyden/app/resources/datagraph"
 	"github.com/Southclaws/storyden/app/resources/library"
+	"github.com/Southclaws/storyden/app/resources/library/node_cache"
 	"github.com/Southclaws/storyden/app/resources/library/node_children"
 	"github.com/Southclaws/storyden/app/resources/library/node_properties"
 	"github.com/Southclaws/storyden/app/resources/library/node_querier"
@@ -54,6 +55,7 @@ type Manager struct {
 	nc           *node_children.Writer
 	fetcher      *fetcher.Fetcher
 	summariser   generative.Summariser
+	cache        *node_cache.Cache
 	bus          *pubsub.Bus
 }
 
@@ -69,6 +71,7 @@ func New(
 	nc *node_children.Writer,
 	fetcher *fetcher.Fetcher,
 	summariser generative.Summariser,
+	cache *node_cache.Cache,
 	bus *pubsub.Bus,
 ) *Manager {
 	return &Manager{
@@ -83,6 +86,7 @@ func New(
 		nc:           nc,
 		fetcher:      fetcher,
 		summariser:   summariser,
+		cache:        cache,
 		bus:          bus,
 	}
 }

--- a/app/services/library/node_mutate/update.go
+++ b/app/services/library/node_mutate/update.go
@@ -34,6 +34,10 @@ func (s *Manager) Update(ctx context.Context, qk library.QueryKey, p Partial) (*
 		return nil, fault.Wrap(err, fctx.With(ctx))
 	}
 
+	if err := s.cache.Invalidate(ctx, n.GetSlug()); err != nil {
+		return nil, fault.Wrap(err, fctx.With(ctx))
+	}
+
 	oldVisibility := n.Visibility
 
 	pre, err := s.preMutation(ctx, p, opt.NewPtr(n))

--- a/app/services/like/post_liker/liker.go
+++ b/app/services/like/post_liker/liker.go
@@ -3,30 +3,49 @@ package post_liker
 import (
 	"context"
 
+	"github.com/rs/xid"
+
 	"github.com/Southclaws/storyden/app/resources/account"
 	"github.com/Southclaws/storyden/app/resources/like/like_writer"
 	"github.com/Southclaws/storyden/app/resources/message"
 	"github.com/Southclaws/storyden/app/resources/post"
+	"github.com/Southclaws/storyden/app/resources/post/post_querier"
+	"github.com/Southclaws/storyden/app/resources/post/thread_cache"
 	"github.com/Southclaws/storyden/internal/infrastructure/pubsub"
 )
 
 type PostLiker struct {
-	likeWriter *like_writer.LikeWriter
-	bus        *pubsub.Bus
+	likeWriter  *like_writer.LikeWriter
+	postQuerier *post_querier.Querier
+	bus         *pubsub.Bus
+	cache       *thread_cache.Cache
 }
 
 func New(
 	likeWriter *like_writer.LikeWriter,
+	postQuerier *post_querier.Querier,
 	bus *pubsub.Bus,
+	cache *thread_cache.Cache,
 ) *PostLiker {
 	return &PostLiker{
-		likeWriter: likeWriter,
-		bus:        bus,
+		likeWriter:  likeWriter,
+		postQuerier: postQuerier,
+		bus:         bus,
+		cache:       cache,
 	}
 }
 
 func (l *PostLiker) AddPostLike(ctx context.Context, accountID account.AccountID, postID post.ID) error {
-	err := l.likeWriter.AddPostLike(ctx, accountID, postID)
+	postRef, err := l.postQuerier.Probe(ctx, postID)
+	if err != nil {
+		return err
+	}
+
+	if err := l.cache.Invalidate(ctx, xid.ID(postRef.Root)); err != nil {
+		return err
+	}
+
+	err = l.likeWriter.AddPostLike(ctx, accountID, postID)
 	if err != nil {
 		return err
 	}
@@ -39,7 +58,16 @@ func (l *PostLiker) AddPostLike(ctx context.Context, accountID account.AccountID
 }
 
 func (l *PostLiker) RemovePostLike(ctx context.Context, accountID account.AccountID, postID post.ID) error {
-	err := l.likeWriter.RemovePostLike(ctx, accountID, postID)
+	postRef, err := l.postQuerier.Probe(ctx, postID)
+	if err != nil {
+		return err
+	}
+
+	if err := l.cache.Invalidate(ctx, xid.ID(postRef.Root)); err != nil {
+		return err
+	}
+
+	err = l.likeWriter.RemovePostLike(ctx, accountID, postID)
 	if err != nil {
 		return err
 	}

--- a/app/services/react_manager/reactions.go
+++ b/app/services/react_manager/reactions.go
@@ -5,12 +5,15 @@ import (
 
 	"github.com/Southclaws/fault"
 	"github.com/Southclaws/fault/fctx"
+	"github.com/Southclaws/fault/ftag"
 	"github.com/rs/xid"
 
 	"github.com/Southclaws/storyden/app/resources/account/account_querier"
 	"github.com/Southclaws/storyden/app/resources/message"
 	"github.com/Southclaws/storyden/app/resources/post"
+	"github.com/Southclaws/storyden/app/resources/post/post_querier"
 	"github.com/Southclaws/storyden/app/resources/post/reaction"
+	"github.com/Southclaws/storyden/app/resources/post/thread_cache"
 	"github.com/Southclaws/storyden/app/services/authentication/session"
 	"github.com/Southclaws/storyden/internal/infrastructure/pubsub"
 )
@@ -19,26 +22,41 @@ type Reactor struct {
 	accountQuerier *account_querier.Querier
 	reactWriter    *reaction.Writer
 	reactReader    *reaction.Querier
+	postQuerier    *post_querier.Querier
 	bus            *pubsub.Bus
+	cache          *thread_cache.Cache
 }
 
 func New(
 	accountQuerier *account_querier.Querier,
 	reactWriter *reaction.Writer,
 	reactReader *reaction.Querier,
+	postQuerier *post_querier.Querier,
 	bus *pubsub.Bus,
+	cache *thread_cache.Cache,
 ) *Reactor {
 	return &Reactor{
 		accountQuerier: accountQuerier,
 		reactWriter:    reactWriter,
 		reactReader:    reactReader,
+		postQuerier:    postQuerier,
 		bus:            bus,
+		cache:          cache,
 	}
 }
 
 func (s *Reactor) Add(ctx context.Context, postID post.ID, emoji string) (*reaction.React, error) {
 	accountID, err := session.GetAccountID(ctx)
 	if err != nil {
+		return nil, fault.Wrap(err, fctx.With(ctx))
+	}
+
+	pref, err := s.postQuerier.Probe(ctx, postID)
+	if err != nil {
+		return nil, fault.Wrap(err, fctx.With(ctx))
+	}
+
+	if err := s.cache.Invalidate(ctx, xid.ID(pref.Root)); err != nil {
 		return nil, fault.Wrap(err, fctx.With(ctx))
 	}
 
@@ -65,6 +83,9 @@ func (s *Reactor) Remove(ctx context.Context, reactID reaction.ReactID) error {
 
 	reac, err := s.reactReader.Get(ctx, reactID)
 	if err != nil {
+		if ftag.Get(err) == ftag.NotFound {
+			return nil
+		}
 		return fault.Wrap(err, fctx.With(ctx))
 	}
 
@@ -78,6 +99,15 @@ func (s *Reactor) Remove(ctx context.Context, reactID reaction.ReactID) error {
 	}
 
 	targetID := post.ID(reac.Target())
+
+	pref, err := s.postQuerier.Probe(ctx, targetID)
+	if err != nil {
+		return fault.Wrap(err, fctx.With(ctx))
+	}
+
+	if err := s.cache.Invalidate(ctx, xid.ID(pref.Root)); err != nil {
+		return fault.Wrap(err, fctx.With(ctx))
+	}
 
 	err = s.reactWriter.Remove(ctx, accountID, reactID)
 	if err != nil {

--- a/app/services/reply/service.go
+++ b/app/services/reply/service.go
@@ -12,6 +12,7 @@ import (
 	"github.com/Southclaws/storyden/app/resources/datagraph"
 	"github.com/Southclaws/storyden/app/resources/post"
 	"github.com/Southclaws/storyden/app/resources/post/reply"
+	"github.com/Southclaws/storyden/app/resources/post/thread_cache"
 	"github.com/Southclaws/storyden/app/services/link/fetcher"
 	"github.com/Southclaws/storyden/app/services/moderation/content_policy"
 	"github.com/Southclaws/storyden/app/services/reply/reply_notify"
@@ -56,24 +57,27 @@ func Build() fx.Option {
 
 type service struct {
 	accountQuery *account_querier.Querier
-	post_repo    reply.Repository
+	replyRepo    reply.Repository
 	fetcher      *fetcher.Fetcher
 	bus          *pubsub.Bus
 	cpm          *content_policy.Manager
+	cache        *thread_cache.Cache
 }
 
 func New(
 	accountQuery *account_querier.Querier,
-	post_repo reply.Repository,
+	replyRepo reply.Repository,
 	fetcher *fetcher.Fetcher,
 	bus *pubsub.Bus,
 	cpm *content_policy.Manager,
+	cache *thread_cache.Cache,
 ) Service {
 	return &service{
 		accountQuery: accountQuery,
-		post_repo:    post_repo,
+		replyRepo:    replyRepo,
 		fetcher:      fetcher,
 		bus:          bus,
 		cpm:          cpm,
+		cache:        cache,
 	}
 }

--- a/app/services/thread/create.go
+++ b/app/services/thread/create.go
@@ -70,6 +70,10 @@ func (s *service) Create(ctx context.Context,
 		return nil, fault.Wrap(err, fctx.With(ctx), fmsg.With("failed to create thread"))
 	}
 
+	if err := s.cache.Invalidate(ctx, xid.ID(thr.ID)); err != nil {
+		return nil, fault.Wrap(err, fctx.With(ctx))
+	}
+
 	if thr.Visibility == visibility.VisibilityPublished {
 		s.bus.Publish(ctx, &message.EventThreadPublished{
 			ID: thr.ID,

--- a/app/services/thread/delete.go
+++ b/app/services/thread/delete.go
@@ -6,6 +6,7 @@ import (
 	"github.com/Southclaws/fault"
 	"github.com/Southclaws/fault/fctx"
 	"github.com/Southclaws/fault/fmsg"
+	"github.com/rs/xid"
 
 	"github.com/Southclaws/storyden/app/resources/account"
 	"github.com/Southclaws/storyden/app/resources/message"
@@ -34,6 +35,10 @@ func (s *service) Delete(ctx context.Context, id post.ID) error {
 	}
 
 	if err := s.authoriseThreadDelete(ctx, acc, thr); err != nil {
+		return fault.Wrap(err, fctx.With(ctx))
+	}
+
+	if err := s.cache.Invalidate(ctx, xid.ID(id)); err != nil {
 		return fault.Wrap(err, fctx.With(ctx))
 	}
 

--- a/app/services/thread/service.go
+++ b/app/services/thread/service.go
@@ -16,6 +16,7 @@ import (
 	"github.com/Southclaws/storyden/app/resources/pagination"
 	"github.com/Southclaws/storyden/app/resources/post"
 	"github.com/Southclaws/storyden/app/resources/post/thread"
+	"github.com/Southclaws/storyden/app/resources/post/thread_cache"
 	"github.com/Southclaws/storyden/app/resources/post/thread_querier"
 	"github.com/Southclaws/storyden/app/resources/post/thread_writer"
 	"github.com/Southclaws/storyden/app/resources/tag/tag_ref"
@@ -96,6 +97,7 @@ type service struct {
 	bus           *pubsub.Bus
 	mentioner     *mentioner.Mentioner
 	cpm           *content_policy.Manager
+	cache         *thread_cache.Cache
 }
 
 func New(
@@ -110,6 +112,7 @@ func New(
 	bus *pubsub.Bus,
 	mentioner *mentioner.Mentioner,
 	cpm *content_policy.Manager,
+	cache *thread_cache.Cache,
 ) Service {
 	return &service{
 		ins: ins.Build(),
@@ -123,5 +126,6 @@ func New(
 		bus:           bus,
 		mentioner:     mentioner,
 		cpm:           cpm,
+		cache:         cache,
 	}
 }

--- a/app/services/thread/update.go
+++ b/app/services/thread/update.go
@@ -82,6 +82,10 @@ func (s *service) Update(ctx context.Context, threadID post.ID, partial Partial)
 		}
 	}
 
+	if err := s.cache.Invalidate(ctx, xid.ID(threadID)); err != nil {
+		return nil, fault.Wrap(err, fctx.With(ctx))
+	}
+
 	thr, err = s.threadWriter.Update(ctx, threadID, opts...)
 	if err != nil {
 		return nil, fault.Wrap(err, fctx.With(ctx))

--- a/app/transports/http/middleware/chaos/chaos.go
+++ b/app/transports/http/middleware/chaos/chaos.go
@@ -17,7 +17,7 @@ type Middleware struct {
 
 func New(cfg config.Config) *Middleware {
 	return &Middleware{
-		enabled:  cfg.DevChaosFailRate > 0 || cfg.DevChaosSlowMode == 0,
+		enabled:  cfg.DevChaosFailRate > 0 || cfg.DevChaosSlowMode > 0 || cfg.DevChaosSlowModeQueue > 0,
 		failRate: cfg.DevChaosFailRate,
 		slowMode: cfg.DevChaosSlowMode,
 	}

--- a/home/content/docs/operation/configuration.mdx
+++ b/home/content/docs/operation/configuration.mdx
@@ -86,6 +86,17 @@ A value between 0 and 1 which simulates failed requests.
 
 This will add a random failure to all requests. This is useful for testing how the client handles "internal server error" responses.
 
+### `DEV_CHAOS_SLOW_MODE_QUEUE`
+
+<table>
+<tr><td>type</td><td>duration (e.g. 1h, 1m, 1s)</td></tr>
+<tr><td>default</td><td>none</td></tr>
+</table>
+
+Simulates slow message delivery in the internal message queue.
+
+This will add a random delay between zero and this value to all messages in the internal message queue. This is useful for testing how the client handles delayed message processing.
+
 ## Core configuration
 
 Configuration settings for core functionality, pretty much all of these will need to be configured for production installations, excepting perhaps `LISTEN_ADDR`.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -63,6 +63,12 @@ type Config struct {
 	   This will add a random failure to all requests. This is useful for testing how the client handles "internal server error" responses.
 	*/
 	DevChaosFailRate float64 `envconfig:"DEV_CHAOS_FAIL_RATE"`
+	/*
+	   Simulates slow message delivery in the internal message queue.
+
+	   This will add a random delay between zero and this value to all messages in the internal message queue. This is useful for testing how the client handles delayed message processing.
+	*/
+	DevChaosSlowModeQueue time.Duration `envconfig:"DEV_CHAOS_SLOW_MODE_QUEUE"`
 
 	// -
 	// Core configuration

--- a/internal/config/config.yaml
+++ b/internal/config/config.yaml
@@ -55,6 +55,14 @@
 
         This will add a random delay between zero and this value to all requests. This is useful for testing how the client handles slow responses.
 
+    - env: "DEV_CHAOS_SLOW_MODE_QUEUE"
+      name: DevChaosSlowModeQueue
+      type: time.Duration
+      description: |-
+        Simulates slow message delivery in the internal message queue.
+
+        This will add a random delay between zero and this value to all messages in the internal message queue. This is useful for testing how the client handles delayed message processing.
+
     - env: "DEV_CHAOS_FAIL_RATE"
       name: DevChaosFailRate
       type: float64

--- a/internal/config/version.go
+++ b/internal/config/version.go
@@ -1,4 +1,4 @@
 package config
 
 // Version is set at compile time with ldflags.
-var Version = "v1.25.11-canary"
+var Version = "v1.25.12-canary"

--- a/internal/infrastructure/pubsub/bus.go
+++ b/internal/infrastructure/pubsub/bus.go
@@ -58,6 +58,7 @@ func newBus(
 
 	router.AddMiddleware(middleware.Recoverer)
 	router.AddMiddleware(newSessionContextMiddleware(l))
+	router.AddMiddleware(newChaosDelayMiddleware(cfg.DevChaosSlowModeQueue, l))
 
 	poisonQueue, err := middleware.PoisonQueue(pub, "poison_queue")
 	if err != nil {

--- a/internal/infrastructure/pubsub/middleware_test.go
+++ b/internal/infrastructure/pubsub/middleware_test.go
@@ -1,0 +1,90 @@
+package pubsub
+
+import (
+	"log/slog"
+	"testing"
+	"time"
+
+	"github.com/ThreeDotsLabs/watermill/message"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestChaosDelayMiddleware_ZeroDelay(t *testing.T) {
+	logger := slog.Default()
+	handlerCalled := false
+
+	mockHandler := func(msg *message.Message) ([]*message.Message, error) {
+		handlerCalled = true
+		return nil, nil
+	}
+
+	middleware := newChaosDelayMiddleware(0, logger)
+	wrappedHandler := middleware(mockHandler)
+
+	msg := message.NewMessage("test-uuid", []byte("test payload"))
+
+	start := time.Now()
+	_, err := wrappedHandler(msg)
+	elapsed := time.Since(start)
+
+	require.NoError(t, err)
+	assert.True(t, handlerCalled)
+	assert.Less(t, elapsed, 10*time.Millisecond)
+}
+
+func TestChaosDelayMiddleware_WithDelay(t *testing.T) {
+	logger := slog.Default()
+	handlerCalled := false
+
+	mockHandler := func(msg *message.Message) ([]*message.Message, error) {
+		handlerCalled = true
+		return nil, nil
+	}
+
+	maxDelay := 100 * time.Millisecond
+	middleware := newChaosDelayMiddleware(maxDelay, logger)
+	wrappedHandler := middleware(mockHandler)
+
+	msg := message.NewMessage("test-uuid", []byte("test payload"))
+	msg.Metadata.Set("name", "TestEvent")
+
+	start := time.Now()
+	_, err := wrappedHandler(msg)
+	elapsed := time.Since(start)
+
+	require.NoError(t, err)
+	assert.True(t, handlerCalled)
+	assert.LessOrEqual(t, elapsed, maxDelay+10*time.Millisecond)
+}
+
+func TestChaosDelayMiddleware_MultipleCalls(t *testing.T) {
+	logger := slog.Default()
+	callCount := 0
+
+	mockHandler := func(msg *message.Message) ([]*message.Message, error) {
+		callCount++
+		return nil, nil
+	}
+
+	maxDelay := 50 * time.Millisecond
+	middleware := newChaosDelayMiddleware(maxDelay, logger)
+	wrappedHandler := middleware(mockHandler)
+
+	msg1 := message.NewMessage("test-uuid-1", []byte("test payload 1"))
+	msg1.Metadata.Set("name", "TestEvent1")
+
+	msg2 := message.NewMessage("test-uuid-2", []byte("test payload 2"))
+	msg2.Metadata.Set("name", "TestEvent2")
+
+	start := time.Now()
+	_, err1 := wrappedHandler(msg1)
+	_, err2 := wrappedHandler(msg2)
+	elapsed := time.Since(start)
+
+	require.NoError(t, err1)
+	require.NoError(t, err2)
+	assert.Equal(t, 2, callCount)
+
+	assert.LessOrEqual(t, elapsed, 2*maxDelay+20*time.Millisecond)
+}

--- a/tests/account/profile_cache_test.go
+++ b/tests/account/profile_cache_test.go
@@ -65,9 +65,6 @@ func TestAccountCacheWithEmailOperations(t *testing.T) {
 			}, session)
 			tests.Ok(t, err, addEmail)
 
-			// Wait for the cache update event to be processed via pubsub
-			time.Sleep(200 * time.Millisecond)
-
 			// Now cache should be populated with timestamp from when email was added
 			cachedValue1, err := cacheStore.Get(root, cacheKey)
 			r.NoError(err, "cache value should exist after email added")
@@ -91,9 +88,6 @@ func TestAccountCacheWithEmailOperations(t *testing.T) {
 			// Remove the email
 			removeEmail, err := cl.AccountEmailRemoveWithResponse(root, addEmail.JSON200.Id, session)
 			tests.Ok(t, err, removeEmail)
-
-			// Wait for the cache update event to be processed
-			time.Sleep(200 * time.Millisecond)
 
 			// Cache should be updated with a newer timestamp
 			cachedValue2, err := cacheStore.Get(root, cacheKey)
@@ -147,9 +141,6 @@ func TestAccountCacheWithProfileUpdate(t *testing.T) {
 			}, session)
 			tests.Ok(t, err, updateResp)
 
-			// Wait for the cache update event to be processed
-			time.Sleep(200 * time.Millisecond)
-
 			// Cache should now be populated
 			cachedValue1, err := cacheStore.Get(root, cacheKey)
 			r.NoError(err, "cache value should exist after profile update")
@@ -166,8 +157,6 @@ func TestAccountCacheWithProfileUpdate(t *testing.T) {
 				Bio: &newBio2,
 			}, session)
 			tests.Ok(t, err, updateResp2)
-
-			time.Sleep(200 * time.Millisecond)
 
 			cachedValue2, err := cacheStore.Get(root, cacheKey)
 			r.NoError(err, "cache value should still exist after second profile update")

--- a/tests/library/node_cache_test.go
+++ b/tests/library/node_cache_test.go
@@ -1,0 +1,126 @@
+package library_test
+
+import (
+	"context"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/fx"
+
+	"github.com/Southclaws/storyden/app/resources/account/account_writer"
+	"github.com/Southclaws/storyden/app/resources/library/node_cache"
+	"github.com/Southclaws/storyden/app/resources/seed"
+	"github.com/Southclaws/storyden/app/transports/http/openapi"
+	"github.com/Southclaws/storyden/internal/infrastructure/cache"
+	"github.com/Southclaws/storyden/internal/integration"
+	"github.com/Southclaws/storyden/internal/integration/e2e"
+	"github.com/Southclaws/storyden/tests"
+)
+
+func TestNodeCacheWithUpdate(t *testing.T) {
+	t.Parallel()
+
+	integration.Test(t, nil, e2e.Setup(), fx.Invoke(func(
+		lc fx.Lifecycle,
+		root context.Context,
+		cl *openapi.ClientWithResponses,
+		sh *e2e.SessionHelper,
+		aw *account_writer.Writer,
+		cacheStore cache.Store,
+		nodeCache *node_cache.Cache,
+	) {
+		lc.Append(fx.StartHook(func() {
+			r := require.New(t)
+			a := assert.New(t)
+
+			ctx, _ := e2e.WithAccount(root, aw, seed.Account_001_Odin)
+			session := sh.WithSession(ctx)
+
+			visibility := openapi.Published
+			name := "cache-test-node-" + uuid.NewString()
+			slug := name
+
+			nodeCreate, err := cl.NodeCreateWithResponse(ctx, openapi.NodeInitialProps{
+				Name:       name,
+				Slug:       &slug,
+				Visibility: &visibility,
+			}, session)
+			tests.Ok(t, err, nodeCreate)
+			a.Equal(name, nodeCreate.JSON200.Name)
+
+			nodeGet1, err := cl.NodeGetWithResponse(ctx, slug, &openapi.NodeGetParams{})
+			tests.Ok(t, err, nodeGet1)
+
+			lastModified1Header := nodeGet1.HTTPResponse.Header.Get("Last-Modified")
+			r.NotEmpty(lastModified1Header, "Last-Modified header should be present")
+
+			lastModified1, err := time.Parse(time.RFC1123, lastModified1Header)
+			r.NoError(err, "Last-Modified header should be parseable")
+
+			cacheKey := "node:last-modified:" + slug
+			cachedValue1, err := cacheStore.Get(ctx, cacheKey)
+			r.NoError(err, "cache value should exist")
+			cachedTime1, err := time.Parse(time.RFC3339Nano, cachedValue1)
+			r.NoError(err, "cached time should be parseable")
+
+			time.Sleep(10 * time.Millisecond)
+
+			nodeGet304, err := cl.NodeGetWithResponse(ctx, slug, &openapi.NodeGetParams{}, func(ctx context.Context, req *http.Request) error {
+				req.Header.Set("If-Modified-Since", lastModified1Header)
+				return nil
+			})
+			tests.Status(t, err, nodeGet304, 304)
+			a.Nil(nodeGet304.JSON200, "304 response should have no body")
+
+			newName := "updated-cache-test-node-" + uuid.NewString()
+			nodeUpdate, err := cl.NodeUpdateWithResponse(ctx, slug, openapi.NodeMutableProps{
+				Name: &newName,
+			}, session)
+			tests.Ok(t, err, nodeUpdate)
+			a.Equal(newName, nodeUpdate.JSON200.Name)
+
+			cachedValue2, err := cacheStore.Get(ctx, cacheKey)
+			r.NoError(err, "cache value should still exist after update")
+			cachedTime2, err := time.Parse(time.RFC3339Nano, cachedValue2)
+			r.NoError(err, "cached time should be parseable")
+
+			a.True(cachedTime2.After(cachedTime1),
+				"cache should be updated IMMEDIATELY after node update (cachedTime1: %v, cachedTime2: %v)", cachedTime1, cachedTime2)
+
+			nodeGet2, err := cl.NodeGetWithResponse(ctx, slug, &openapi.NodeGetParams{})
+			tests.Ok(t, err, nodeGet2)
+			a.Equal(newName, nodeGet2.JSON200.Name)
+
+			lastModified2Header := nodeGet2.HTTPResponse.Header.Get("Last-Modified")
+			r.NotEmpty(lastModified2Header, "Last-Modified header should be present")
+
+			lastModified2, err := time.Parse(time.RFC1123, lastModified2Header)
+			r.NoError(err, "Last-Modified header should be parseable")
+
+			a.True(lastModified2.After(lastModified1) || lastModified2.Equal(lastModified1),
+				"Last-Modified header should be updated or equal after update")
+
+			lastModifiedFromCache := nodeCache.LastModified(ctx, slug)
+			r.NotNil(lastModifiedFromCache, "node cache should return last modified time")
+			a.True(lastModifiedFromCache.Equal(cachedTime2) || lastModifiedFromCache.After(cachedTime2),
+				"cache last modified should match the cached value")
+
+			nodeGetAfterUpdate, err := cl.NodeGetWithResponse(ctx, slug, &openapi.NodeGetParams{}, func(ctx context.Context, req *http.Request) error {
+				req.Header.Set("If-Modified-Since", lastModified1Header)
+				return nil
+			})
+			if nodeGetAfterUpdate.HTTPResponse.StatusCode == 304 {
+				t.Logf("Got 304 - cache timestamps: before=%v, after=%v, last-modified header=%s",
+					cachedTime1, cachedTime2, lastModified1Header)
+				t.Logf("New Last-Modified header: %s", nodeGetAfterUpdate.HTTPResponse.Header.Get("Last-Modified"))
+			}
+			tests.Ok(t, err, nodeGetAfterUpdate)
+			r.NotNil(nodeGetAfterUpdate.JSON200, "should return 200 with body after cache invalidation")
+			a.Equal(newName, nodeGetAfterUpdate.JSON200.Name)
+		}))
+	}))
+}


### PR DESCRIPTION
the cache invalidation was happening async via pubsub which caused race
conditions where conditional requests would return 304 even after data
changed. now cache invalidation is synchronous and happens BEFORE the
mutation in the service layer.
also fixed a bug where invalidation within the same second would not
trigger a cache miss because HTTP Last-Modified headers only have second
precision. Invalidate() now bumps the timestamp forward if it would
truncate to the same second.
also added a utility config to help simulate slow queues (which was the cause of the core issue)