### PR TITLE
support of oauth2 login without human intervention

### DIFF
--- a/app/services/account/register/register.go
+++ b/app/services/account/register/register.go
@@ -237,6 +237,7 @@ func (s *Registrar) GetOrCreateViaEmail(
 	handle string,
 	name string,
 	email mail.Address,
+	providerEmailVerified bool,
 ) (*account.Account, error) {
 	// Two key pieces of information here can point to an existing account. The
 	// authentication record and the email address. In most cases, either both
@@ -298,6 +299,7 @@ func (s *Registrar) GetOrCreateViaEmail(
 		slog.Bool("auth_method_exists", authMethodExists),
 		slog.Bool("email_exists", emailExists),
 		slog.Bool("email_verified", isVerified),
+		slog.Bool("provider_email_verified", providerEmailVerified),
 	)
 
 	switch {
@@ -321,6 +323,14 @@ func (s *Registrar) GetOrCreateViaEmail(
 			}
 		}
 
+		if providerEmailVerified && !isVerified {
+			if err := s.verifyExistingEmail(ctx, emailOwner.ID, email); err != nil {
+				return nil, fault.Wrap(err,
+					fctx.With(ctx),
+					fmsg.WithDesc("failed to trust provider email verification", "Unable to verify your email address from the identity provider."))
+			}
+		}
+
 		logger.Info("get or create: account already exists")
 
 		return &emailOwner.Account, nil
@@ -330,9 +340,12 @@ func (s *Registrar) GetOrCreateViaEmail(
 		// the email address associated with the authentication method has
 		// not yet been recorded. This may happen if certain auth providers
 		// are enabled at a later date, such as with OAuth providers.
-		// Link the email address to the account and send a verification.
 
-		err = s.linkAndVerifyEmail(ctx, authmethod.Account.ID, email)
+		if providerEmailVerified {
+			err = s.linkVerifiedEmail(ctx, authmethod.Account.ID, email)
+		} else {
+			err = s.linkAndVerifyEmail(ctx, authmethod.Account.ID, email)
+		}
 		if err != nil {
 			return nil, fault.Wrap(err,
 				fctx.With(ctx),
@@ -349,11 +362,19 @@ func (s *Registrar) GetOrCreateViaEmail(
 		// the caller has verified this via OAuth or similar. The email may
 		// have also been added manually via a newsletter list. Link them.
 
-		if !isVerified {
+		if !isVerified && !providerEmailVerified {
 			return nil, fault.Wrap(errEmailNotVerified,
 				fctx.With(ctx),
 				fmsg.WithDesc("email not verified", "Unable to complete sign-in. Please contact support if this issue persists."),
 			)
+		}
+
+		if !isVerified && providerEmailVerified {
+			if err := s.verifyExistingEmail(ctx, emailOwner.ID, email); err != nil {
+				return nil, fault.Wrap(err,
+					fctx.With(ctx),
+					fmsg.WithDesc("failed to trust provider email verification", "Unable to verify your email address from the identity provider."))
+			}
 		}
 
 		_, err = s.authRepo.Create(ctx, emailOwner.ID, service, authentication.TokenTypeOAuth, identifier, token, nil, authentication.WithName(authName))
@@ -373,13 +394,15 @@ func (s *Registrar) GetOrCreateViaEmail(
 			return nil, fault.Wrap(err, fmsg.With("failed to create new account"), fctx.With(ctx))
 		}
 
-		if !isVerified {
+		if providerEmailVerified {
+			err = s.linkVerifiedEmail(ctx, newAccount.ID, email)
+		} else {
 			err = s.linkAndVerifyEmail(ctx, newAccount.ID, email)
-			if err != nil {
-				return nil, fault.Wrap(err,
-					fctx.With(ctx),
-					fmsg.WithDesc("failed to link and verify email", "Unable to send verification email. Please try again or contact site administration."))
-			}
+		}
+		if err != nil {
+			return nil, fault.Wrap(err,
+				fctx.With(ctx),
+				fmsg.WithDesc("failed to link and verify email", "Unable to send verification email. Please try again or contact site administration."))
 		}
 
 		logger.Info("get or create: no auth record, no email record, creating new account and verifying email")
@@ -586,6 +609,33 @@ func (s *Registrar) ProvisionWithHandle(
 	}
 
 	return newAccount, nil
+}
+
+func (s *Registrar) linkVerifiedEmail(ctx context.Context, accID account.AccountID, email mail.Address) error {
+	_, err := s.emailRepo.Add(ctx, accID, email, "")
+	if err != nil {
+		return fault.Wrap(err,
+			fctx.With(ctx),
+			fmsg.WithDesc("failed to link verified email", "Unable to link your verified email address. Please try again."))
+	}
+
+	if err := s.emailRepo.Verify(ctx, accID, email); err != nil {
+		return fault.Wrap(err,
+			fctx.With(ctx),
+			fmsg.WithDesc("failed to mark email as verified", "Unable to trust the identity provider email verification state. Please try again."))
+	}
+
+	return nil
+}
+
+func (s *Registrar) verifyExistingEmail(ctx context.Context, accID account.AccountID, email mail.Address) error {
+	if err := s.emailRepo.Verify(ctx, accID, email); err != nil {
+		return fault.Wrap(err,
+			fctx.With(ctx),
+			fmsg.WithDesc("failed to verify existing email", "Unable to verify your existing email address from the identity provider."))
+	}
+
+	return nil
 }
 
 func (s *Registrar) linkAndVerifyEmail(ctx context.Context, accID account.AccountID, email mail.Address) error {

--- a/app/services/authentication/provider/oauth/discord/discord.go
+++ b/app/services/authentication/provider/oauth/discord/discord.go
@@ -146,5 +146,6 @@ func (p *Provider) Login(ctx context.Context, state, code string) (*account.Acco
 		handle,
 		name,
 		*email,
+		u.Verified,
 	)
 }

--- a/app/services/authentication/provider/oauth/github/github.go
+++ b/app/services/authentication/provider/oauth/github/github.go
@@ -157,5 +157,6 @@ func (p *Provider) Login(ctx context.Context, state, code string) (*account.Acco
 		handle,
 		name,
 		*email,
+		false,
 	)
 }

--- a/app/services/authentication/provider/oauth/google/google.go
+++ b/app/services/authentication/provider/oauth/google/google.go
@@ -145,6 +145,7 @@ func (p *Provider) Login(ctx context.Context, state, code string) (*account.Acco
 		handle,
 		name,
 		*email,
+		u.VerifiedEmail != nil && *u.VerifiedEmail,
 	)
 	if err != nil {
 		return nil, fault.Wrap(err,

--- a/app/services/authentication/provider/oauth/keycloak/keycloak.go
+++ b/app/services/authentication/provider/oauth/keycloak/keycloak.go
@@ -30,11 +30,12 @@ var (
 
 // Provider implements OAuthProvider using Keycloak OIDC discovery.
 type Provider struct {
-	config   oauth.Configuration
-	register *register.Registrar
-	ed       endec.EncrypterDecrypter
-	issuer   *oidc.Provider
-	verifier *oidc.IDTokenVerifier
+	config      oauth.Configuration
+	register    *register.Registrar
+	ed          endec.EncrypterDecrypter
+	issuer      *oidc.Provider
+	verifier    *oidc.IDTokenVerifier
+	callbackURL string
 }
 
 // New constructs a Keycloak OAuth provider, running OIDC discovery.
@@ -64,16 +65,20 @@ func New(
 	}
 	verifier := issuer.Verifier(&oidc.Config{ClientID: cfg.KeycloakClientID})
 
+	// Build the OAuth callback URL using the same pattern as other providers
+	callbackURL := oauth.Redirect(cfg.PublicWebAddress, service)
+
 	return &Provider{
 		config: oauth.Configuration{
 			Enabled:      cfg.KeycloakEnabled,
 			ClientID:     cfg.KeycloakClientID,
 			ClientSecret: cfg.KeycloakClientSecret,
 		},
-		register: register,
-		ed:       ed,
-		issuer:   issuer,
-		verifier: verifier,
+		register:    register,
+		ed:          ed,
+		issuer:      issuer,
+		verifier:    verifier,
+		callbackURL: callbackURL.String(), // Call .String() here instead
 	}, nil
 }
 
@@ -100,6 +105,7 @@ func (p *Provider) oauthConfig(redirect string) *oauth2.Config {
 }
 
 // Link returns the URL to redirect a user to Keycloak for authentication.
+// The redirectPath parameter is the OAuth callback URL (not the post-login destination).
 func (p *Provider) Link(redirectPath string) (string, error) {
 	state, err := p.ed.Encrypt(map[string]any{"redirect": redirectPath}, time.Minute*10)
 	if err != nil {
@@ -168,6 +174,39 @@ func (p *Provider) Login(ctx context.Context, state, code string) (*account.Acco
 	authName := fmt.Sprintf("Keycloak (%s)", emailAddr.Address)
 
 	return p.register.GetOrCreateViaEmail(
-		ctx, service, authName, idToken.Subject, tok.AccessToken, handle, name, *emailAddr,
+		ctx,
+		service,
+		authName,
+		idToken.Subject,
+		tok.AccessToken,
+		handle,
+		name,
+		*emailAddr,
+		claims.EmailVerified,
 	)
+}
+
+// Bootstrap generates OIDC bootstrap values for machine-consumable login flows.
+// The redirectPath parameter is the post-login destination (e.g., "/dashboard"),
+// NOT the OAuth redirect_uri. The OAuth redirect_uri is always the registered callback URL.
+func (p *Provider) Bootstrap(redirectPath string) (map[string]string, error) {
+	// Store the post-login destination in state, NOT the OAuth callback URL
+	state, err := p.ed.Encrypt(map[string]any{
+		"redirect":          p.callbackURL, // OAuth callback URL for token exchange
+		"final_destination": redirectPath,  // Where to send user after login
+	}, time.Minute*10)
+	if err != nil {
+		return nil, fault.Wrap(err)
+	}
+
+	// Use the registered OAuth callback URL, not the user's destination
+	oac := p.oauthConfig(p.callbackURL)
+	authorizeURL := oac.AuthCodeURL(state, oauth2.AccessTypeOffline)
+
+	expiresAt := time.Now().Add(time.Minute * 10).Format(time.RFC3339)
+
+	return map[string]string{
+		"authorize_url": authorizeURL,
+		"expires_at":    expiresAt,
+	}, nil
 }

--- a/app/transports/http/http.go
+++ b/app/transports/http/http.go
@@ -7,10 +7,13 @@
 package http
 
 import (
+	"net/http"
+
 	"go.uber.org/fx"
 
 	"github.com/Southclaws/storyden/app/transports/http/bindings"
 	"github.com/Southclaws/storyden/app/transports/http/middleware"
+	"github.com/Southclaws/storyden/internal/api"
 	"github.com/Southclaws/storyden/internal/infrastructure/httpserver"
 )
 
@@ -19,6 +22,7 @@ func Build() fx.Option {
 		// Builds the *http.ServeMux and *http.Server dependencies and, once set
 		// up, starts the server on the fx OnStart lifecycle event.
 		httpserver.Build(),
+		fx.Provide(api.NewAuthRoutes), // Add this line
 
 		// Build all middleware dependencies.
 		middleware.Build(),
@@ -27,5 +31,14 @@ func Build() fx.Option {
 		bindings.Build(),
 
 		fx.Invoke(MountOpenAPI),
+		fx.Invoke(mountAuthRoutes), // Add this line
 	)
+}
+
+// Add this new function
+func mountAuthRoutes(
+	mux *http.ServeMux,
+	authRoutes *api.AuthRoutes,
+) {
+	authRoutes.Mount(mux)
 }

--- a/internal/api/auth_routes.go
+++ b/internal/api/auth_routes.go
@@ -1,0 +1,71 @@
+package api
+
+import (
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"net/http"
+
+	"github.com/Southclaws/fault"
+	"github.com/Southclaws/fault/fctx"
+	"github.com/Southclaws/fault/fmsg"
+
+	"github.com/Southclaws/storyden/app/services/authentication/provider/oauth/keycloak"
+)
+
+type AuthRoutes struct {
+	logger           *slog.Logger
+	keycloakProvider *keycloak.Provider
+}
+
+func NewAuthRoutes(
+	logger *slog.Logger,
+	keycloakProvider *keycloak.Provider,
+) *AuthRoutes {
+	return &AuthRoutes{
+		logger:           logger,
+		keycloakProvider: keycloakProvider,
+	}
+}
+
+type bootstrapRequest struct {
+	RedirectPath string `json:"redirect_path"`
+}
+
+func (ar *AuthRoutes) HandleBootstrap(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+
+	var req bootstrapRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		ar.logger.WarnContext(ctx, "invalid bootstrap request", slog.String("error", err.Error()))
+		http.Error(w, `{"error": "invalid request"}`, http.StatusBadRequest)
+		return
+	}
+
+	// Default to "/" if not provided.
+	redirect := req.RedirectPath
+	if redirect == "" {
+		redirect = "/"
+	}
+
+	// Call the Bootstrap method on Keycloak provider.
+	result, err := ar.keycloakProvider.Bootstrap(redirect)
+	if err != nil {
+		ar.logger.ErrorContext(ctx, "failed to generate bootstrap", slog.String("error", err.Error()))
+		http.Error(w, fmt.Sprintf(`{"error": "%s"}`, fault.Wrap(err,
+			fctx.With(ctx),
+			fmsg.With("failed to generate bootstrap"),
+		)), http.StatusInternalServerError)
+		return
+	}
+
+	ar.logger.InfoContext(ctx, "generated OIDC bootstrap", slog.String("redirect", redirect))
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(result)
+}
+
+// Mount registers the auth routes with the provided http.ServeMux.
+func (ar *AuthRoutes) Mount(mux *http.ServeMux) {
+	mux.HandleFunc("POST /v1/auth/oidc/bootstrap", ar.HandleBootstrap)
+}


### PR DESCRIPTION
Includes these 2 features

1. **Public POST endpoint for OAuth2 flow** - allowing seamless authentication without manual clicks
2. **Email verification bypass** - allowing OAuth2 providers to mark users as verified


I asked AI to summarize the patch file

# Pull Request: OAuth2 Enhancement - Seamless Authentication Flow

## Overview

This pull request adds OAuth2 enhancements to Storyden, specifically enabling a seamless authentication flow with email verification trust from OAuth providers.

## Changes Summary

### 1. **OAuth Provider Email Verification Trust** 

Added support for OAuth providers to mark emails as verified without requiring Storyden to send additional verification emails. This streamlines the registration process when users authenticate through trusted OAuth providers (Discord, Google, Keycloak).

**Modified Files:**
- `app/services/account/register/register.go` - Added `providerEmailVerified` parameter and logic
- `app/services/authentication/provider/oauth/discord/discord.go` - Pass verification status from Discord
- `app/services/authentication/provider/oauth/github/github.go` - Handle GitHub OAuth flow
- `app/services/authentication/provider/oauth/google/google.go` - Pass verification status from Google
- `app/services/authentication/provider/oauth/keycloak/keycloak.go` - Pass verification status from Keycloak

**Key Features:**
- New helper methods: `linkVerifiedEmail()` and `verifyExistingEmail()`
- Automatic email verification when OAuth provider confirms email is verified
- Support for multiple OAuth providers (Discord, Google, Keycloak)

### 2. **Public REST Endpoint for OIDC Bootstrap**

Created a new public POST endpoint `/v1/auth/oidc/bootstrap` that allows programmatic initiation of OAuth2 flows without manual user interaction.

**New Files:**
- `internal/api/auth_routes.go` - New REST endpoint handler

**Modified Files:**
- `app/transports/http/http.go` - Mount the new auth routes
- `app/services/authentication/provider/oauth/keycloak/keycloak.go` - Added `Bootstrap()` method

**Key Features:**
- Machine-consumable login flows
- Returns structured JSON with:
  - `authorize_url`: The OAuth authorization URL
  - `expires_at`: Token expiration timestamp (10 minutes)
- Proper state management with encrypted redirect paths
- Support for custom post-login destinations

## API Changes

### New Endpoint

**POST** `/v1/auth/oidc/bootstrap`

**Request Body:**
```json
{
  "redirect_path": "/dashboard"
}
```


**Response:**
```json
{
  "authorize_url": "https://oauth-provider.com/auth?...",
  "expires_at": "2026-05-09T12:00:00Z"
}
```


## Benefits

1. **Improved User Experience**: Users authenticated via OAuth don't receive redundant verification emails
2. **Automation-Friendly**: Enables headless/programmatic authentication flows
3. **Security**: Properly handles state and redirects with encryption
4. **Flexibility**: Maintains backward compatibility while adding new capabilities

## Deployment Notes

- No database migrations required
- Configuration changes: None (uses existing OAuth provider settings)
