### PR TITLE
Add RFC 8414 OAuth authorization server metadata endpoint

### DIFF
--- a/app/transports/http/bindings/bindings.go
+++ b/app/transports/http/bindings/bindings.go
@@ -222,6 +222,14 @@ func mount(
 		return c.JSON(http.StatusOK, oauthBinding.OAuthDiscovery(c.Request().Context()))
 	})
 
+	router.GET("/.well-known/oauth-authorization-server", func(c echo.Context) error {
+		if !oauthBinding.oauth.Enabled() {
+			return oauthDisabledError(c.Request().Context())
+		}
+
+		return c.JSON(http.StatusOK, oauthBinding.OAuthAuthorizationServerMetadata(c.Request().Context()))
+	})
+
 	router.Use(
 		requestValidatorMiddleware,
 		openapi.ParameterContext,

--- a/app/transports/http/bindings/oauth.go
+++ b/app/transports/http/bindings/oauth.go
@@ -59,6 +59,34 @@ func (o OAuth) OAuthDiscovery(context.Context) OAuthDiscoveryResponse {
 	}
 }
 
+type OAuthAuthorizationServerMetadata struct {
+	Issuer                            string   `json:"issuer"`
+	AuthorizationEndpoint             string   `json:"authorization_endpoint"`
+	TokenEndpoint                     string   `json:"token_endpoint"`
+	JWKSURI                           string   `json:"jwks_uri,omitempty"`
+	ScopesSupported                   []string `json:"scopes_supported,omitempty"`
+	ResponseTypesSupported            []string `json:"response_types_supported"`
+	GrantTypesSupported               []string `json:"grant_types_supported,omitempty"`
+	CodeChallengeMethodsSupported     []string `json:"code_challenge_methods_supported,omitempty"`
+	DeviceAuthorizationEndpoint       string   `json:"device_authorization_endpoint,omitempty"`
+}
+
+func (o OAuth) OAuthAuthorizationServerMetadata(context.Context) OAuthAuthorizationServerMetadata {
+	discovery := o.oauth.Discovery()
+
+	return OAuthAuthorizationServerMetadata{
+		Issuer:                        discovery.Issuer,
+		AuthorizationEndpoint:         discovery.AuthorizationEndpoint,
+		TokenEndpoint:                 discovery.TokenEndpoint,
+		JWKSURI:                       discovery.JWKSURI,
+		ScopesSupported:               discovery.ScopesSupported,
+		ResponseTypesSupported:        discovery.ResponseTypesSupported,
+		GrantTypesSupported:           discovery.GrantTypesSupported,
+		CodeChallengeMethodsSupported: discovery.CodeChallengeMethodsSupported,
+		DeviceAuthorizationEndpoint:   discovery.DeviceAuthorizationEndpoint,
+	}
+}
+
 func (o OAuth) OAuthJWKS(ctx context.Context, _ openapi.OAuthJWKSRequestObject) (openapi.OAuthJWKSResponseObject, error) {
 	if !o.oauth.Enabled() {
 		return nil, oauthDisabledError(ctx)

--- a/tests/oauth/configuration_test.go
+++ b/tests/oauth/configuration_test.go
@@ -70,6 +70,29 @@ func TestOAuthDisabledConfiguration(t *testing.T) {
 				a.Contains((*body.Metadata)["suggested"], "administrator")
 			})
 
+			t.Run("oauth_authorization_server_metadata_returns_clear_disabled_response", func(t *testing.T) {
+				a := assert.New(t)
+				r := require.New(t)
+
+				req, err := http.NewRequestWithContext(root, http.MethodGet, ts.URL+"/.well-known/oauth-authorization-server", nil)
+				r.NoError(err)
+
+				resp, err := http.DefaultClient.Do(req)
+				r.NoError(err)
+				defer resp.Body.Close()
+
+				var body openapi.APIError
+				r.NoError(json.NewDecoder(resp.Body).Decode(&body))
+				a.Equal(http.StatusNotFound, resp.StatusCode)
+				r.NotNil(body.Type)
+				a.Equal("urn:storyden:problem:not-found", *body.Type)
+				r.NotNil(body.Title)
+				a.Contains(*body.Title, "not enabled")
+				r.NotNil(body.Metadata)
+				a.Equal("oauth_disabled", (*body.Metadata)["code"])
+				a.Contains((*body.Metadata)["suggested"], "administrator")
+			})
+
 			t.Run("jwks_returns_clear_disabled_response", func(t *testing.T) {
 				a := assert.New(t)
 				r := require.New(t)

--- a/tests/oauth/security_hardening_test.go
+++ b/tests/oauth/security_hardening_test.go
@@ -3,6 +3,7 @@ package oauth_test
 import (
 	"context"
 	"encoding/json"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -180,6 +181,34 @@ func TestOAuthSecurityHardeningDiscoveryURLs(t *testing.T) {
 			a.Equal("http://localhost:8000/api/oauth/token", discovery.TokenEndpoint)
 			a.Equal("http://localhost:8000/api/oauth/userinfo", discovery.UserinfoEndpoint)
 			a.Equal("http://localhost:8000/api/oauth/jwks", discovery.JWKSURI)
+
+			req2, err := http.NewRequestWithContext(root, http.MethodGet, ts.URL+"/.well-known/oauth-authorization-server", nil)
+			r.NoError(err)
+			resp2, err := http.DefaultClient.Do(req2)
+			r.NoError(err)
+			defer resp2.Body.Close()
+			r.Equal(http.StatusOK, resp2.StatusCode)
+
+			var metadata struct {
+				Issuer                      string `json:"issuer"`
+				AuthorizationEndpoint       string `json:"authorization_endpoint"`
+				TokenEndpoint               string `json:"token_endpoint"`
+				JWKSURI                     string `json:"jwks_uri"`
+				DeviceAuthorizationEndpoint string `json:"device_authorization_endpoint"`
+			}
+			body2, err := io.ReadAll(resp2.Body)
+			r.NoError(err)
+			r.NoError(json.Unmarshal(body2, &metadata))
+			a.Equal("http://localhost:8000", metadata.Issuer)
+			a.Equal("http://localhost:8000/api/oauth/authorize", metadata.AuthorizationEndpoint)
+			a.Equal("http://localhost:8000/api/oauth/token", metadata.TokenEndpoint)
+			a.Equal("http://localhost:8000/api/oauth/jwks", metadata.JWKSURI)
+			a.Equal("http://localhost:8000/api/oauth/device_authorization", metadata.DeviceAuthorizationEndpoint)
+
+			var rawMetadata map[string]any
+			r.NoError(json.Unmarshal(body2, &rawMetadata))
+			a.NotContains(rawMetadata, "userinfo_endpoint")
+			a.NotContains(rawMetadata, "id_token_signing_alg_values_supported")
 		}))
 	}))
 }


### PR DESCRIPTION
Registers /.well-known/oauth-authorization-server as a sibling to the existing OpenID Connect discovery endpoint. Returns the standard OAuth 2.0 Authorization Server Metadata fields (issuer, endpoints, JWKS URI, supported response types, grant types, PKCE methods) without OIDC-specific fields like userinfo or id_token signing algorithms.

https://claude.ai/code/session_015UA2RDkqq9AQ6cceHCUc6z