### PR TITLE
Improve password reset token validation error messaging

### DIFF
--- a/app/services/authentication/provider/password/password_reset/token.go
+++ b/app/services/authentication/provider/password/password_reset/token.go
@@ -7,6 +7,7 @@ import (
 	"github.com/Southclaws/fault"
 	"github.com/Southclaws/fault/fctx"
 	"github.com/Southclaws/fault/fmsg"
+	"github.com/Southclaws/fault/ftag"
 	"github.com/Southclaws/storyden/app/resources/account"
 	"github.com/Southclaws/storyden/internal/infrastructure/endec"
 	"github.com/rs/xid"
@@ -45,7 +46,11 @@ func (r *TokenProvider) GetResetToken(ctx context.Context, accountID account.Acc
 func (r *TokenProvider) Validate(ctx context.Context, tokenString string) (account.AccountID, error) {
 	token, err := r.endec.Decrypt(tokenString)
 	if err != nil {
-		return account.AccountID{}, fault.Wrap(err, fctx.With(ctx), fmsg.With("failed to decrypt token"))
+		return account.AccountID{}, fault.Wrap(err,
+			fctx.With(ctx),
+			ftag.With(ftag.Unauthenticated),
+			fmsg.WithDesc("failed to decrypt token", "Your password reset link has expired or is invalid. Please request a new one."),
+		)
 	}
 
 	rawID, ok := token[accountIDKey]


### PR DESCRIPTION
## Summary

Enhanced error handling in password reset token validation to provide better user-facing error messages and proper error categorization.

## Changes

- Added `ftag` import from the fault library for error tagging
- Updated `Validate` method in `TokenProvider` to:
  - Tag decryption errors with `ftag.Unauthenticated` for proper HTTP status code mapping
  - Replace generic error message with user-friendly description: "Your password reset link has expired or is invalid. Please request a new one."
  - Improved error formatting with multi-line fault wrapping for better readability

## Implementation Details

The error now properly communicates to users why their password reset attempt failed while maintaining security by not exposing internal implementation details. The `Unauthenticated` tag ensures the error is translated to an appropriate HTTP 401 response rather than a generic 500 error.

https://claude.ai/code/session_01MoZT3vCcH82RPLn9sV2ih3