### PR TITLE
Hide login anchor when public registration is disabled

### DIFF
--- a/web/src/components/site/Navigation/MobileCommandBar/MobileCommandBar.tsx
+++ b/web/src/components/site/Navigation/MobileCommandBar/MobileCommandBar.tsx
@@ -18,7 +18,11 @@ import { ContentNavigationList } from "../ContentNavigationList/ContentNavigatio
 
 import { useMobileCommandBar } from "./useMobileCommandBar";
 
-export function MobileCommandBar() {
+type Props = {
+  canRegister?: boolean;
+};
+
+export function MobileCommandBar({ canRegister }: Props) {
   const { isExpanded, onExpand, onClose, account } = useMobileCommandBar();
 
   return (
@@ -48,7 +52,11 @@ export function MobileCommandBar() {
               <SiteIcon borderRadius="md" w="8" h="8" />
             )}
             <HomeAnchor hideLabel size="sm" />
-            {account ? <ComposeAnchor hideLabel size="sm" /> : <LoginAnchor />}
+            {account ? (
+              <ComposeAnchor hideLabel size="sm" />
+            ) : (
+              canRegister && <LoginAnchor />
+            )}
             <LibraryAnchor hideLabel size="sm" />
             <ExpandTrigger onClick={onExpand} />
           </>

--- a/web/src/components/site/Navigation/Navigation.tsx
+++ b/web/src/components/site/Navigation/Navigation.tsx
@@ -2,6 +2,7 @@ import React, { PropsWithChildren } from "react";
 
 import { getServerSession } from "@/auth/server-session";
 import { parseMemberSettings } from "@/lib/settings/member-settings";
+import { allowsPublicRegistration } from "@/lib/settings/registration";
 import { getSettings } from "@/lib/settings/settings-server";
 import { Box } from "@/styled-system/jsx";
 
@@ -25,6 +26,7 @@ export async function Navigation({
   children,
 }: PropsWithChildren<Props>) {
   const globalSettings = await getSettings();
+  const canRegister = allowsPublicRegistration(globalSettings.registration_mode);
   const sessionAccount = await getServerSession();
   const session = sessionAccount
     ? parseMemberSettings(sessionAccount, globalSettings.metadata)
@@ -89,7 +91,7 @@ export async function Navigation({
         </Box>
 
         <Box className={styles["navpill"]}>
-          <MobileCommandBar />
+          <MobileCommandBar canRegister={canRegister} />
         </Box>
       </Box>
     </Box>


### PR DESCRIPTION
Conditionally render the login anchor in the mobile command bar based on whether public registration is enabled in the global settings.

## Summary

This change prevents the login anchor from appearing in the mobile navigation when public registration is disabled, improving UX for instances that don't allow public sign-ups.

## Key Changes

- Added `canRegister` prop to `MobileCommandBar` component to control login anchor visibility
- Updated `Navigation` component to check registration settings and pass `canRegister` flag to `MobileCommandBar`
- Modified the conditional rendering logic to only show `LoginAnchor` when both the user is not logged in AND public registration is enabled

## Implementation Details

- Uses the existing `allowsPublicRegistration()` utility to determine if registration is allowed based on `globalSettings.registration_mode`
- The prop is optional (`canRegister?: boolean`) to maintain backward compatibility
- Login anchor is now hidden when `canRegister` is false, while other navigation elements remain visible

https://claude.ai/code/session_01PJxQbEjTDz5goTRQp49RQy