### PR TITLE
feat(oauth): add Client ID Metadata Document (CIMD) support

### DIFF
--- a/app/services/authentication/oauth/authorize.go
+++ b/app/services/authentication/oauth/authorize.go
@@ -6,6 +6,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/Southclaws/fault"
+	"github.com/Southclaws/fault/fctx"
 	"github.com/Southclaws/opt"
 
 	"github.com/Southclaws/storyden/app/resources/account"
@@ -58,10 +60,14 @@ func (s *Service) Authorise(ctx context.Context, input AuthoriseRequest) (*Autho
 		return nil, oauthError("access_denied", "Account is not permitted to authorise OAuth clients"), nil
 	}
 
-	cl, err := s.clients.GetClientByClientID(ctx, input.ClientID)
+	cl, oauthErr, err := s.resolveClient(ctx, input.ClientID)
 	if err != nil {
-		return nil, oauthError("invalid_client", "Client not found"), nil
+		return nil, nil, fault.Wrap(err, fctx.With(ctx))
 	}
+	if oauthErr != nil {
+		return nil, oauthErr, err
+	}
+
 	if !contains(cl.AllowedGrants, GrantTypeAuthorizationCode) {
 		return nil, oauthError("unauthorized_client", "Client is not authorized for authorization_code grant"), nil
 	}

--- a/app/services/authentication/oauth/cimd.go
+++ b/app/services/authentication/oauth/cimd.go
@@ -1,0 +1,589 @@
+package oauth
+
+import (
+	"context"
+	"crypto/tls"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/netip"
+	"net/url"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/Southclaws/fault"
+	"github.com/Southclaws/fault/ftag"
+	"github.com/Southclaws/opt"
+
+	"github.com/Southclaws/storyden/app/resources/oauth"
+	"github.com/Southclaws/storyden/app/resources/oauth/oauth_writer"
+	"github.com/Southclaws/storyden/app/resources/rbac"
+)
+
+var (
+	cimdFetchTimeout           = 10 * time.Second
+	cimdMaxResponseBytes int64 = 5 * 1024
+	cimdDefaultCacheTTL        = 5 * time.Minute
+	cimdMaxCacheTTL            = time.Hour
+	cimdMaxCacheEntries        = 4096
+)
+
+var cimdDisallowedPrefixes = []netip.Prefix{
+	netip.MustParsePrefix("10.0.0.0/8"),
+	netip.MustParsePrefix("100.64.0.0/10"),
+	netip.MustParsePrefix("127.0.0.0/8"),
+	netip.MustParsePrefix("169.254.0.0/16"),
+	netip.MustParsePrefix("172.16.0.0/12"),
+	netip.MustParsePrefix("192.168.0.0/16"),
+	netip.MustParsePrefix("::1/128"),
+	netip.MustParsePrefix("fc00::/7"),
+	netip.MustParsePrefix("fe80::/10"),
+}
+
+var cimdLookupNetIP = net.DefaultResolver.LookupNetIP
+
+// cimdPrivilegedScopes are permission scopes that grant administrative or
+// moderation capabilities. They are never granted to CIMD clients unless the
+// server explicitly opts in via OAUTH_CIMD_ALLOW_PRIVILEGED_SCOPES.
+var cimdPrivilegedScopes = map[string]struct{}{
+	rbac.PermissionAdministrator.String():         {},
+	rbac.PermissionManageSettings.String():        {},
+	rbac.PermissionManageAccounts.String():        {},
+	rbac.PermissionManageRoles.String():           {},
+	rbac.PermissionManageReports.String():         {},
+	rbac.PermissionManageWarnings.String():        {},
+	rbac.PermissionManageSuspensions.String():     {},
+	rbac.PermissionViewAccounts.String():          {},
+	rbac.PermissionViewModerationNotes.String():   {},
+	rbac.PermissionManageModerationNotes.String(): {},
+	rbac.PermissionUseOauthClients.String():       {},
+	rbac.PermissionUsePersonalAccessKeys.String(): {},
+}
+
+// cimdDefaultAllowedPermissionScopes is the conservative read-only allowlist
+// used when the deployment does not configure OAUTH_CIMD_ALLOWED_SCOPES.
+var cimdDefaultAllowedPermissionScopes = []string{
+	rbac.PermissionReadPublishedThreads.String(),
+	rbac.PermissionReadPublishedLibrary.String(),
+	rbac.PermissionListProfiles.String(),
+	rbac.PermissionReadProfile.String(),
+	rbac.PermissionListCollections.String(),
+	rbac.PermissionReadCollection.String(),
+}
+
+// clientMetadataDocument mirrors the JSON document hosted at a CIMD client_id URL.
+type clientMetadataDocument struct {
+	ClientID                string   `json:"client_id"`
+	ClientName              string   `json:"client_name"`
+	RedirectURIs            []string `json:"redirect_uris"`
+	GrantTypes              []string `json:"grant_types"`
+	ResponseTypes           []string `json:"response_types"`
+	Scope                   string   `json:"scope"`
+	TokenEndpointAuthMethod string   `json:"token_endpoint_auth_method"`
+	ClientSecret            string   `json:"client_secret"`
+	ClientSecretExpiresAt   int64    `json:"client_secret_expires_at"`
+	LogoURI                 string   `json:"logo_uri"`
+	ClientURI               string   `json:"client_uri"`
+	TOSURI                  string   `json:"tos_uri"`
+	PolicyURI               string   `json:"policy_uri"`
+	JWKSURI                 string   `json:"jwks_uri"`
+}
+
+type cimdCache struct {
+	mu      sync.Mutex
+	entries map[string]time.Time
+}
+
+func newCIMDCache() *cimdCache {
+	return &cimdCache{entries: map[string]time.Time{}}
+}
+
+func (c *cimdCache) fresh(key string) bool {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	exp, ok := c.entries[key]
+	if !ok {
+		return false
+	}
+	if time.Now().After(exp) {
+		delete(c.entries, key)
+		return false
+	}
+	return true
+}
+
+func (c *cimdCache) store(key string, ttl time.Duration) {
+	if ttl <= 0 {
+		c.invalidate(key)
+		return
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.entries[key] = time.Now().Add(ttl)
+	if len(c.entries) > cimdMaxCacheEntries {
+		for k := range c.entries {
+			delete(c.entries, k)
+			break
+		}
+	}
+}
+
+func (c *cimdCache) invalidate(key string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	delete(c.entries, key)
+}
+
+func (s *Service) cimdEnabled() bool {
+	return s.Enabled() && s.cfg.OAuthClientIDMetadataDocumentEnabled
+}
+
+func (s *Service) cimdAllowInsecure() bool {
+	return s.cfg.OAuthCIMDAllowInsecureFetch
+}
+
+// isCIMDClientID reports whether a client_id should be treated as a Client ID
+// Metadata Document URL rather than a locally registered client identifier.
+func isCIMDClientID(clientID string) bool {
+	u, err := url.Parse(clientID)
+	if err != nil {
+		return false
+	}
+	scheme := strings.ToLower(u.Scheme)
+	return (scheme == "https" || scheme == "http") && u.Host != ""
+}
+
+func (s *Service) resolveClient(ctx context.Context, clientID string) (*oauth.Client, *Error, error) {
+	// CIMD client IDs (https/https URLs) are always resolved through the CIMD
+	// path when the feature is enabled. This ensures the in-memory cimdCache
+	// freshness check + potential re-fetch + upsert happens, so that updates
+	// to the hosted metadata document (new redirect_uris, grants, scopes, name)
+	// are observed instead of being permanently stuck at the first-seen DB
+	// snapshot. The DB row is treated as a durable cache of the last snapshot.
+	// When the feature is disabled we fall back to plain DB lookup so that any
+	// previously created CIMD snapshots continue to work as ordinary clients.
+	if isCIMDClientID(clientID) && s.cimdEnabled() {
+		return s.resolveCIMDClient(ctx, clientID)
+	}
+
+	cl, err := s.clients.GetClientByClientID(ctx, clientID)
+	if err == nil {
+		return cl, nil, nil
+	}
+
+	if ftag.Get(err) != ftag.NotFound {
+		return cl, nil, err
+	}
+
+	return nil, oauthError("invalid_client", "Client not found"), nil
+}
+
+func (s *Service) resolveCIMDClient(ctx context.Context, rawURL string) (*oauth.Client, *Error, error) {
+	if !s.cimdEnabled() {
+		return nil, oauthError("unauthorized_client", "CIMD is not enabled"), nil
+	}
+
+	u, err := s.parseCIMDClientID(rawURL)
+	if err != nil {
+		return nil, oauthError("invalid_client", fmt.Sprintf("Invalid CIMD client ID: '%s' %v", rawURL, err)), nil
+	}
+
+	if s.cimdCache.fresh(rawURL) {
+		if cl, err := s.clients.GetClientByClientID(ctx, rawURL); err == nil {
+			return cl, nil, nil
+		}
+		s.cimdCache.invalidate(rawURL)
+	}
+
+	doc, ttl, oauthErr := s.fetchClientMetadata(ctx, u)
+	if oauthErr != nil {
+		s.cimdCache.invalidate(rawURL)
+		return nil, oauthErr, nil
+	}
+
+	if err := validateClientMetadata(doc, u.String()); err != nil {
+		s.cimdCache.invalidate(rawURL)
+		return nil, oauthError("invalid_client", "Invalid CIMD client metadata"), nil
+	}
+
+	allowedScopes := s.cimdAllowedScopes(doc.Scope)
+	allowedGrants := cimdAllowedGrants(doc, allowedScopes)
+
+	cl, err := s.upsertCIMDClient(ctx, rawURL, doc, allowedScopes, allowedGrants)
+	if err != nil {
+		s.cimdCache.invalidate(rawURL)
+		return nil, nil, err
+	}
+
+	s.cimdCache.store(rawURL, ttl)
+
+	return cl, nil, nil
+}
+
+func (s *Service) parseCIMDClientID(rawURL string) (*url.URL, error) {
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		return nil, err
+	}
+
+	scheme := strings.ToLower(u.Scheme)
+	if scheme != "https" {
+		if !(s.cimdAllowInsecure() && scheme == "http") {
+			return nil, fault.New("cimd client_id must use https")
+		}
+	}
+	if u.Host == "" {
+		return nil, fault.New("cimd client_id host is required")
+	}
+	if u.User != nil {
+		return nil, fault.New("cimd client_id must not include user info")
+	}
+	if u.Fragment != "" {
+		return nil, fault.New("cimd client_id must not include a fragment")
+	}
+	if u.Path == "" || u.Path == "/" {
+		return nil, fault.New("cimd client_id must contain a path")
+	}
+	for _, seg := range strings.Split(u.EscapedPath(), "/") {
+		if seg == "." || seg == ".." {
+			return nil, fault.New("cimd client_id must not contain dot segments")
+		}
+	}
+	// Query strings are allowed (some providers such as ChatGPT encode hints
+	// such as ?token_endpoint_auth_method=none directly in the client_id URL).
+	// The full URL (including query) is used both for fetching the metadata
+	// document and as the canonical client identifier (the document's
+	// "client_id" value must match it per the CIMD draft).
+	if !s.cimdAllowInsecure() && cimdIsDisallowedHost(u.Hostname()) {
+		return nil, fault.New("cimd client_id host is not allowed")
+	}
+
+	return u, nil
+}
+
+func (s *Service) fetchClientMetadata(ctx context.Context, u *url.URL) (*clientMetadataDocument, time.Duration, *Error) {
+	allowInsecure := s.cimdAllowInsecure()
+
+	if !allowInsecure {
+		if err := cimdPrevalidateHost(ctx, u.Hostname()); err != nil {
+			return nil, 0, oauthError("invalid_client", "CIMD client host is not allowed")
+		}
+	}
+
+	client := &http.Client{
+		Timeout: cimdFetchTimeout,
+		Transport: &http.Transport{
+			Proxy: nil,
+			DialContext: func(dialCtx context.Context, network, address string) (net.Conn, error) {
+				host, _, err := net.SplitHostPort(address)
+				if err != nil {
+					host = address
+				}
+				if !allowInsecure {
+					if err := cimdValidateResolvedHost(dialCtx, host); err != nil {
+						return nil, err
+					}
+				}
+				return (&net.Dialer{Timeout: cimdFetchTimeout}).DialContext(dialCtx, network, address)
+			},
+			TLSClientConfig: &tls.Config{InsecureSkipVerify: allowInsecure},
+		},
+		CheckRedirect: func(*http.Request, []*http.Request) error {
+			return fault.New("cimd metadata fetch must not follow redirects")
+		},
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u.String(), nil)
+	if err != nil {
+		return nil, 0, oauthError("invalid_client", "Failed to create request for CIMD client metadata")
+	}
+	req.Header.Set("Accept", "application/json")
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, 0, oauthError("invalid_client", "Failed to fetch CIMD client metadata")
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, 0, oauthError("invalid_client", "Failed to fetch CIMD client metadata")
+	}
+	if !cimdIsJSONContentType(resp.Header.Get("Content-Type")) {
+		return nil, 0, oauthError("invalid_client", "CIMD client metadata is not JSON")
+	}
+
+	body, err := cimdReadAllBounded(resp.Body, cimdMaxResponseBytes)
+	if err != nil {
+		return nil, 0, oauthError("invalid_client", "Failed to read CIMD client metadata")
+	}
+
+	var doc clientMetadataDocument
+	if err := json.Unmarshal(body, &doc); err != nil {
+		return nil, 0, oauthError("invalid_client", "Failed to parse CIMD client metadata")
+	}
+
+	return &doc, cimdCacheTTL(resp.Header), nil
+}
+
+func validateClientMetadata(doc *clientMetadataDocument, docURL string) error {
+	if strings.TrimSpace(doc.ClientID) != docURL {
+		return fault.New("cimd document client_id does not match its URL")
+	}
+	if len(doc.RedirectURIs) == 0 {
+		return fault.New("cimd document must declare at least one redirect_uri")
+	}
+	for _, ru := range doc.RedirectURIs {
+		if err := validateDCRRedirectURI(ru); err != nil {
+			return fault.New("cimd document redirect_uri is invalid")
+		}
+	}
+	if doc.TokenEndpointAuthMethod != "" && doc.TokenEndpointAuthMethod != "none" {
+		return fault.New("cimd document token_endpoint_auth_method must be none")
+	}
+	if doc.ClientSecret != "" || doc.ClientSecretExpiresAt != 0 {
+		return fault.New("cimd document must not contain client_secret")
+	}
+	return nil
+}
+
+func (s *Service) cimdAllowedScopes(docScope string) []string {
+	allow := s.cimdScopeAllowSet()
+
+	requested := splitScope(docScope)
+	if len(requested) == 0 {
+		// No declared scope: default to the standard OIDC scopes the server allows.
+		requested = []string{"openid", "profile", "email", "offline_access"}
+	}
+
+	out := []string{}
+	seen := map[string]struct{}{}
+	for _, sc := range requested {
+		if _, ok := allow[sc]; !ok {
+			continue
+		}
+		if _, dup := seen[sc]; dup {
+			continue
+		}
+		seen[sc] = struct{}{}
+		out = append(out, sc)
+	}
+
+	return out
+}
+
+func (s *Service) cimdScopeAllowSet() map[string]struct{} {
+	allow := map[string]struct{}{
+		"openid":         {},
+		"profile":        {},
+		"email":          {},
+		"offline_access": {},
+	}
+
+	configured := s.cfg.OAuthCIMDAllowedScopes
+	if len(configured) == 0 {
+		configured = cimdDefaultAllowedPermissionScopes
+	}
+
+	for _, sc := range configured {
+		sc = strings.TrimSpace(sc)
+		if sc == "" {
+			continue
+		}
+		if cimdIsPrivilegedScope(sc) && !s.cfg.OAuthCIMDAllowPrivilegedScopes {
+			continue
+		}
+		allow[sc] = struct{}{}
+	}
+
+	return allow
+}
+
+func cimdIsPrivilegedScope(scope string) bool {
+	_, ok := cimdPrivilegedScopes[scope]
+	return ok
+}
+
+func cimdAllowedGrants(doc *clientMetadataDocument, allowedScopes []string) []string {
+	grants := []string{GrantTypeAuthorizationCode}
+
+	if contains(allowedScopes, "offline_access") && cimdDocAllowsRefresh(doc) {
+		grants = append(grants, GrantTypeRefreshToken)
+	}
+
+	return grants
+}
+
+func cimdDocAllowsRefresh(doc *clientMetadataDocument) bool {
+	if len(doc.GrantTypes) == 0 {
+		return true
+	}
+	return contains(doc.GrantTypes, GrantTypeRefreshToken)
+}
+
+func (s *Service) upsertCIMDClient(ctx context.Context, rawURL string, doc *clientMetadataDocument, scopes, grants []string) (*oauth.Client, error) {
+	name := strings.TrimSpace(doc.ClientName)
+	if name == "" {
+		name = rawURL
+	}
+
+	if existing, err := s.clients.GetClientByClientID(ctx, rawURL); err == nil {
+		return s.tokens.UpdateClient(ctx, existing.ID, oauth_writer.ClientUpdate{
+			Name:          opt.New(name),
+			ScopePolicy:   opt.New(oauth.ScopePolicyExplicit),
+			RedirectURIs:  opt.New(doc.RedirectURIs),
+			AllowedScopes: opt.New(scopes),
+			AllowedGrants: opt.New(grants),
+		})
+	}
+
+	cl, err := s.tokens.CreateClient(ctx, oauth_writer.ClientCreate{
+		ClientID:      rawURL,
+		Name:          name,
+		Type:          oauth.ClientTypePublic,
+		ScopePolicy:   opt.New(oauth.ScopePolicyExplicit),
+		RedirectURIs:  doc.RedirectURIs,
+		AllowedScopes: scopes,
+		AllowedGrants: grants,
+	})
+	if err != nil {
+		// A concurrent authorize may have created the row first; fall back to it.
+		if existing, getErr := s.clients.GetClientByClientID(ctx, rawURL); getErr == nil {
+			return existing, nil
+		}
+		return nil, err
+	}
+
+	return cl, nil
+}
+
+func cimdReadAllBounded(r io.Reader, maxBytes int64) ([]byte, error) {
+	b, err := io.ReadAll(io.LimitReader(r, maxBytes+1))
+	if err != nil {
+		return nil, err
+	}
+	if int64(len(b)) > maxBytes {
+		return nil, fault.New("cimd metadata document exceeds maximum size")
+	}
+	return b, nil
+}
+
+func cimdIsJSONContentType(value string) bool {
+	if value == "" {
+		return false
+	}
+	mediaType := strings.ToLower(strings.TrimSpace(strings.SplitN(value, ";", 2)[0]))
+	return mediaType == "application/json" || strings.HasSuffix(mediaType, "+json")
+}
+
+func cimdCacheTTL(h http.Header) time.Duration {
+	cc := strings.ToLower(h.Get("Cache-Control"))
+	if strings.Contains(cc, "no-store") || strings.Contains(cc, "no-cache") {
+		return 0
+	}
+
+	for _, directive := range strings.Split(cc, ",") {
+		directive = strings.TrimSpace(directive)
+		if !strings.HasPrefix(directive, "max-age=") {
+			continue
+		}
+		seconds, err := strconv.Atoi(strings.TrimPrefix(directive, "max-age="))
+		if err != nil || seconds <= 0 {
+			return 0
+		}
+		ttl := time.Duration(seconds) * time.Second
+		if ttl > cimdMaxCacheTTL {
+			ttl = cimdMaxCacheTTL
+		}
+		return ttl
+	}
+
+	return cimdDefaultCacheTTL
+}
+
+func cimdIsDisallowedHost(host string) bool {
+	host = strings.TrimSpace(strings.ToLower(host))
+	if host == "" {
+		return true
+	}
+	if host == "localhost" || strings.HasSuffix(host, ".localhost") {
+		return true
+	}
+
+	addr, err := netip.ParseAddr(host)
+	if err != nil {
+		return false
+	}
+	return cimdIsDisallowedAddr(addr)
+}
+
+func cimdIsDisallowedAddr(addr netip.Addr) bool {
+	addr = addr.Unmap()
+	if addr.IsLoopback() || addr.IsLinkLocalMulticast() || addr.IsLinkLocalUnicast() || addr.IsMulticast() || addr.IsUnspecified() {
+		return true
+	}
+	for _, prefix := range cimdDisallowedPrefixes {
+		if prefix.Contains(addr) {
+			return true
+		}
+	}
+	return false
+}
+
+func cimdValidateResolvedHost(ctx context.Context, host string) error {
+	host = strings.TrimSpace(host)
+	if host == "" {
+		return fault.New("cimd metadata host is required")
+	}
+	if cimdIsDisallowedHost(host) {
+		return fault.New("cimd metadata host is not allowed")
+	}
+
+	if _, err := netip.ParseAddr(host); err == nil {
+		return nil
+	}
+
+	addrs, err := cimdLookupNetIP(ctx, "ip", host)
+	if err != nil {
+		return fault.Wrap(err)
+	}
+	if len(addrs) == 0 {
+		return fault.New("cimd metadata host did not resolve to any addresses")
+	}
+	for _, addr := range addrs {
+		if cimdIsDisallowedAddr(addr) {
+			return fault.New("cimd metadata host resolves to a disallowed address")
+		}
+	}
+
+	return nil
+}
+
+func cimdPrevalidateHost(ctx context.Context, host string) error {
+	host = strings.TrimSpace(host)
+	if host == "" {
+		return fault.New("cimd metadata host is required")
+	}
+	if cimdIsDisallowedHost(host) {
+		return fault.New("cimd metadata host is not allowed")
+	}
+	if _, err := netip.ParseAddr(host); err == nil {
+		return nil
+	}
+	addrs, err := cimdLookupNetIP(ctx, "ip", host)
+	if err != nil {
+		return fault.Wrap(err)
+	}
+	if len(addrs) == 0 {
+		return fault.New("cimd metadata host did not resolve to any addresses")
+	}
+	for _, addr := range addrs {
+		if cimdIsDisallowedAddr(addr) {
+			return fault.New("cimd metadata host resolves to a disallowed address")
+		}
+	}
+	return nil
+}

--- a/app/services/authentication/oauth/cimd_test.go
+++ b/app/services/authentication/oauth/cimd_test.go
@@ -1,0 +1,445 @@
+package oauth
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"net/netip"
+	"strconv"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/Southclaws/storyden/app/resources/rbac"
+	"github.com/Southclaws/storyden/internal/config"
+)
+
+func insecureCIMDService(t *testing.T) *Service {
+	t.Helper()
+	return &Service{
+		cfg: config.Config{
+			OAuthEnabled:                         true,
+			OAuthClientIDMetadataDocumentEnabled: true,
+			OAuthCIMDAllowInsecureFetch:          true,
+		},
+		cimdCache: newCIMDCache(),
+	}
+}
+
+func TestIsCIMDClientID(t *testing.T) {
+	t.Parallel()
+
+	assert.True(t, isCIMDClientID("https://client.example/metadata.json"))
+	assert.True(t, isCIMDClientID("http://client.example/metadata.json"))
+	assert.False(t, isCIMDClientID("sdoak_abc123"))
+	assert.False(t, isCIMDClientID("storyden-cli"))
+	assert.False(t, isCIMDClientID(""))
+}
+
+func TestParseCIMDClientIDRejectsInsecureAndPrivate(t *testing.T) {
+	t.Parallel()
+
+	s := &Service{cfg: config.Config{OAuthEnabled: true, OAuthClientIDMetadataDocumentEnabled: true}, cimdCache: newCIMDCache()}
+
+	_, err := s.parseCIMDClientID("http://client.example/metadata.json")
+	assert.Error(t, err, "http must be rejected when insecure fetch is disabled")
+
+	_, err = s.parseCIMDClientID("https://127.0.0.1/metadata.json")
+	assert.Error(t, err, "loopback must be rejected")
+
+	_, err = s.parseCIMDClientID("https://localhost/metadata.json")
+	assert.Error(t, err, "localhost must be rejected")
+
+	_, err = s.parseCIMDClientID("https://169.254.169.254/latest/meta-data")
+	assert.Error(t, err, "link-local metadata endpoint must be rejected")
+
+	_, err = s.parseCIMDClientID("https://10.0.0.5/metadata.json")
+	assert.Error(t, err, "private range must be rejected")
+
+	_, err = s.parseCIMDClientID("https://user:pass@client.example/metadata.json")
+	assert.Error(t, err, "userinfo must be rejected")
+
+	_, err = s.parseCIMDClientID("https://client.example")
+	assert.Error(t, err, "no path must be rejected")
+
+	_, err = s.parseCIMDClientID("https://client.example/")
+	assert.Error(t, err, "root path must be rejected")
+
+	_, err = s.parseCIMDClientID("https://client.example/../secret.json")
+	assert.Error(t, err, "dot dot segment must be rejected")
+
+	_, err = s.parseCIMDClientID("https://client.example/./meta")
+	assert.Error(t, err, "dot segment must be rejected")
+
+	// Query strings are now supported (e.g. providers embedding hints such as
+	// ?token_endpoint_auth_method=none in the client_id URL itself).
+	u, err := s.parseCIMDClientID("https://client.example/meta?x=1&token_endpoint_auth_method=none")
+	require.NoError(t, err)
+	assert.Equal(t, "client.example", u.Hostname())
+	assert.Equal(t, "x=1&token_endpoint_auth_method=none", u.RawQuery)
+
+	u, err = s.parseCIMDClientID("https://client.example/metadata.json")
+	require.NoError(t, err)
+	assert.Equal(t, "client.example", u.Hostname())
+}
+
+func TestValidateClientMetadata(t *testing.T) {
+	t.Parallel()
+
+	const id = "https://client.example/metadata.json"
+
+	require.NoError(t, validateClientMetadata(&clientMetadataDocument{
+		ClientID:     id,
+		RedirectURIs: []string{"https://client.example/callback"},
+	}, id))
+
+	assert.Error(t, validateClientMetadata(&clientMetadataDocument{
+		ClientID:     "https://evil.example/other",
+		RedirectURIs: []string{"https://client.example/callback"},
+	}, id), "client_id must match URL")
+
+	assert.Error(t, validateClientMetadata(&clientMetadataDocument{
+		ClientID:     id,
+		RedirectURIs: []string{},
+	}, id), "redirect_uris required")
+
+	assert.Error(t, validateClientMetadata(&clientMetadataDocument{
+		ClientID:     id,
+		RedirectURIs: []string{"http://client.example/callback"},
+	}, id), "non-loopback http redirect rejected")
+
+	assert.Error(t, validateClientMetadata(&clientMetadataDocument{
+		ClientID:                id,
+		RedirectURIs:            []string{"https://client.example/cb"},
+		TokenEndpointAuthMethod: "client_secret_post",
+	}, id), "secret auth method rejected")
+
+	assert.Error(t, validateClientMetadata(&clientMetadataDocument{
+		ClientID:     id,
+		RedirectURIs: []string{"https://client.example/cb"},
+		ClientSecret: "s3cr3t",
+	}, id), "client_secret prop rejected")
+
+	assert.Error(t, validateClientMetadata(&clientMetadataDocument{
+		ClientID:     id,
+		RedirectURIs: []string{"https://client.example/cb#frag"},
+	}, id), "fragment redirect rejected")
+
+	assert.Error(t, validateClientMetadata(&clientMetadataDocument{
+		ClientID:     id,
+		RedirectURIs: []string{"https://client.example/*"},
+	}, id), "wildcard redirect rejected")
+}
+
+func TestParseCIMDClientIDAllowsQueryStringsAndChatGPTStyle(t *testing.T) {
+	t.Parallel()
+
+	s := insecureCIMDService(t)
+
+	// Exact style seen in production from ChatGPT connectors.
+	chatgpt := "https://chatgpt.com/oauth/ehPHP71Uhmkc/client.json?token_endpoint_auth_method=none"
+	u, err := s.parseCIMDClientID(chatgpt)
+	require.NoError(t, err)
+	assert.Equal(t, "chatgpt.com", u.Hostname())
+	assert.Equal(t, "/oauth/ehPHP71Uhmkc/client.json", u.Path)
+	assert.Equal(t, "token_endpoint_auth_method=none", u.RawQuery)
+
+	// The document served at that URL must declare the *same* client_id (incl. query)
+	// for the match in validateClientMetadata to succeed.
+	docURLWithQuery := chatgpt
+	require.NoError(t, validateClientMetadata(&clientMetadataDocument{
+		ClientID:     docURLWithQuery,
+		RedirectURIs: []string{"https://client.example/callback"},
+	}, docURLWithQuery))
+
+	// Mismatch (doc omits the query part) must still be rejected.
+	assert.Error(t, validateClientMetadata(&clientMetadataDocument{
+		ClientID:     "https://chatgpt.com/oauth/ehPHP71Uhmkc/client.json",
+		RedirectURIs: []string{"https://client.example/callback"},
+	}, docURLWithQuery), "client_id in doc must match the full presented client_id incl. query")
+}
+
+func TestCIMDAllowedScopes(t *testing.T) {
+	t.Parallel()
+
+	s := &Service{cfg: config.Config{}}
+
+	// Standard scopes always allowed; conservative read perms allowed; unknown dropped.
+	got := s.cimdAllowedScopes("openid profile " + rbac.PermissionReadPublishedThreads.String() + " NONEXISTENT_SCOPE")
+	assert.Contains(t, got, "openid")
+	assert.Contains(t, got, "profile")
+	assert.Contains(t, got, rbac.PermissionReadPublishedThreads.String())
+	assert.NotContains(t, got, "NONEXISTENT_SCOPE")
+
+	// Admin/privileged scopes dropped by default.
+	got = s.cimdAllowedScopes(rbac.PermissionAdministrator.String() + " " + rbac.PermissionManageRoles.String())
+	assert.NotContains(t, got, rbac.PermissionAdministrator.String())
+	assert.NotContains(t, got, rbac.PermissionManageRoles.String())
+
+	// Write perm not in conservative default allowlist is dropped.
+	got = s.cimdAllowedScopes(rbac.PermissionCreatePost.String())
+	assert.NotContains(t, got, rbac.PermissionCreatePost.String())
+
+	// Explicit allowlist permits a configured non-privileged scope.
+	s = &Service{cfg: config.Config{OAuthCIMDAllowedScopes: []string{rbac.PermissionCreatePost.String()}}}
+	got = s.cimdAllowedScopes(rbac.PermissionCreatePost.String())
+	assert.Contains(t, got, rbac.PermissionCreatePost.String())
+
+	// Privileged scope only via explicit allowlist + opt-in flag.
+	s = &Service{cfg: config.Config{OAuthCIMDAllowedScopes: []string{rbac.PermissionAdministrator.String()}}}
+	assert.NotContains(t, s.cimdAllowedScopes(rbac.PermissionAdministrator.String()), rbac.PermissionAdministrator.String())
+	s.cfg.OAuthCIMDAllowPrivilegedScopes = true
+	assert.Contains(t, s.cimdAllowedScopes(rbac.PermissionAdministrator.String()), rbac.PermissionAdministrator.String())
+}
+
+func TestCIMDAllowedGrants(t *testing.T) {
+	t.Parallel()
+
+	grants := cimdAllowedGrants(&clientMetadataDocument{}, []string{"openid", "offline_access"})
+	assert.Contains(t, grants, GrantTypeAuthorizationCode)
+	assert.Contains(t, grants, GrantTypeRefreshToken)
+
+	grants = cimdAllowedGrants(&clientMetadataDocument{GrantTypes: []string{GrantTypeAuthorizationCode}}, []string{"openid", "offline_access"})
+	assert.Contains(t, grants, GrantTypeAuthorizationCode)
+	assert.NotContains(t, grants, GrantTypeRefreshToken, "refresh excluded when doc omits it")
+
+	grants = cimdAllowedGrants(&clientMetadataDocument{}, []string{"openid"})
+	assert.NotContains(t, grants, GrantTypeRefreshToken, "no refresh without offline_access")
+}
+
+func TestFetchClientMetadataRejectsNonJSON(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/html")
+		_, _ = w.Write([]byte("<html></html>"))
+	}))
+	defer srv.Close()
+
+	s := insecureCIMDService(t)
+	docURL := srv.URL + "/m.json"
+	u, err := s.parseCIMDClientID(docURL)
+	require.NoError(t, err)
+
+	_, _, oauthErr := s.fetchClientMetadata(context.Background(), u)
+	require.NotNil(t, oauthErr)
+	assert.Equal(t, "invalid_client", oauthErr.Code)
+}
+
+func TestFetchClientMetadataRejectsOversized(t *testing.T) {
+	original := cimdMaxResponseBytes
+	cimdMaxResponseBytes = 512
+	defer func() { cimdMaxResponseBytes = original }()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"padding":"` + strings.Repeat("x", 4096) + `"}`))
+	}))
+	defer srv.Close()
+
+	s := insecureCIMDService(t)
+	docURL := srv.URL + "/m.json"
+	u, err := s.parseCIMDClientID(docURL)
+	require.NoError(t, err)
+
+	_, _, oauthErr := s.fetchClientMetadata(context.Background(), u)
+	require.NotNil(t, oauthErr)
+	assert.Equal(t, "invalid_client", oauthErr.Code)
+}
+
+func TestFetchClientMetadataTimesOut(t *testing.T) {
+	original := cimdFetchTimeout
+	cimdFetchTimeout = 100 * time.Millisecond
+	defer func() { cimdFetchTimeout = original }()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		time.Sleep(500 * time.Millisecond)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{}`))
+	}))
+	defer srv.Close()
+
+	s := insecureCIMDService(t)
+	docURL := srv.URL + "/m.json"
+	u, err := s.parseCIMDClientID(docURL)
+	require.NoError(t, err)
+
+	_, _, oauthErr := s.fetchClientMetadata(context.Background(), u)
+	require.NotNil(t, oauthErr)
+	assert.Equal(t, "invalid_client", oauthErr.Code)
+}
+
+func TestFetchClientMetadataDoesNotFollowRedirects(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Redirect(w, &http.Request{}, "https://other.example/elsewhere", http.StatusFound)
+	}))
+	defer srv.Close()
+
+	s := insecureCIMDService(t)
+	docURL := srv.URL + "/m.json"
+	u, err := s.parseCIMDClientID(docURL)
+	require.NoError(t, err)
+
+	_, _, oauthErr := s.fetchClientMetadata(context.Background(), u)
+	require.NotNil(t, oauthErr)
+	assert.Equal(t, "invalid_client", oauthErr.Code)
+}
+
+func TestFetchClientMetadataParsesValidDocument(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"client_name":"Example","redirect_uris":["https://client.example/cb"]}`))
+	}))
+	defer srv.Close()
+
+	s := insecureCIMDService(t)
+	docURL := srv.URL + "/m.json"
+	u, err := s.parseCIMDClientID(docURL)
+	require.NoError(t, err)
+
+	doc, ttl, oauthErr := s.fetchClientMetadata(context.Background(), u)
+	require.Nil(t, oauthErr)
+	require.NotNil(t, doc)
+	assert.Equal(t, "Example", doc.ClientName)
+	assert.Equal(t, []string{"https://client.example/cb"}, doc.RedirectURIs)
+	assert.Equal(t, cimdDefaultCacheTTL, ttl)
+}
+
+func TestCIMDCacheTTL(t *testing.T) {
+	t.Parallel()
+
+	assert.Equal(t, cimdDefaultCacheTTL, cimdCacheTTL(http.Header{}))
+	assert.Equal(t, time.Duration(0), cimdCacheTTL(http.Header{"Cache-Control": []string{"no-store"}}))
+	assert.Equal(t, 30*time.Second, cimdCacheTTL(http.Header{"Cache-Control": []string{"max-age=30"}}))
+	assert.Equal(t, cimdMaxCacheTTL, cimdCacheTTL(http.Header{"Cache-Control": []string{"max-age=99999"}}))
+}
+
+func TestParseCIMDClientIDRejectsSection3(t *testing.T) {
+	t.Parallel()
+
+	s := &Service{cfg: config.Config{OAuthEnabled: true, OAuthClientIDMetadataDocumentEnabled: true}, cimdCache: newCIMDCache()}
+
+	cases := []string{
+		"https://client.example",
+		"https://client.example/",
+		"https://client.example/../x",
+		"https://client.example/./x",
+		"https://client.example/x#f",
+	}
+	for _, c := range cases {
+		_, err := s.parseCIMDClientID(c)
+		assert.Error(t, err, c)
+	}
+
+	// Queries are permitted (and preserved) as part of the client_id identifier.
+	u, err := s.parseCIMDClientID("https://client.example/x?y=1&foo=bar")
+	require.NoError(t, err)
+	assert.Equal(t, "y=1&foo=bar", u.RawQuery)
+}
+
+func TestValidateClientMetadataRejectsAuthAndSecret(t *testing.T) {
+	t.Parallel()
+
+	id := "https://client.example/m.json"
+	err := validateClientMetadata(&clientMetadataDocument{
+		ClientID:                id,
+		RedirectURIs:            []string{"https://client.example/cb"},
+		TokenEndpointAuthMethod: "private_key_jwt",
+	}, id)
+	assert.Error(t, err)
+
+	err = validateClientMetadata(&clientMetadataDocument{
+		ClientID:              id,
+		RedirectURIs:          []string{"https://client.example/cb"},
+		ClientSecret:          "foo",
+		ClientSecretExpiresAt: 123,
+	}, id)
+	assert.Error(t, err)
+}
+
+func TestFetchRespectsDefault5kLimit(t *testing.T) {
+	t.Parallel()
+
+	// default is now 5k; oversized test server returns >5k
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"pad":"` + strings.Repeat("x", 6000) + `"}`))
+	}))
+	defer srv.Close()
+
+	s := insecureCIMDService(t)
+	docURL := srv.URL + "/m.json"
+	u, err := s.parseCIMDClientID(docURL)
+	require.NoError(t, err)
+
+	_, _, oauthErr := s.fetchClientMetadata(context.Background(), u)
+	require.NotNil(t, oauthErr)
+}
+
+func TestResolveClientPrefersPreRegistered(t *testing.T) {
+	t.Parallel()
+
+	assert.False(t, isCIMDClientID("storyden-cli"))
+}
+
+func TestCIMDCacheBounded(t *testing.T) {
+	t.Parallel()
+
+	c := newCIMDCache()
+	for i := 0; i < cimdMaxCacheEntries+10; i++ {
+		c.store("k"+strconv.Itoa(i), time.Hour)
+	}
+	assert.LessOrEqual(t, len(c.entries), cimdMaxCacheEntries)
+}
+
+func TestPrevalidateAndLookupOverride(t *testing.T) {
+	original := cimdLookupNetIP
+	defer func() { cimdLookupNetIP = original }()
+
+	cimdLookupNetIP = func(ctx context.Context, _ string, host string) ([]netip.Addr, error) {
+		if host == "evil.example" {
+			return []netip.Addr{netip.MustParseAddr("10.0.0.1")}, nil
+		}
+		return []netip.Addr{netip.MustParseAddr("1.2.3.4")}, nil
+	}
+
+	svc := &Service{cfg: config.Config{OAuthEnabled: true, OAuthClientIDMetadataDocumentEnabled: true}, cimdCache: newCIMDCache()}
+	// hostname not statically disallowed; prevalidate (called in fetch) will use the override and reject bad addrs
+	u, err := svc.parseCIMDClientID("https://good.example/m.json")
+	require.NoError(t, err)
+	_ = u
+}
+
+func TestConcurrentCIMDFetch(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		time.Sleep(20 * time.Millisecond)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"redirect_uris":["https://c/cb"]}`))
+	}))
+	defer srv.Close()
+
+	s := insecureCIMDService(t)
+	docURL := srv.URL + "/m.json"
+	u, _ := s.parseCIMDClientID(docURL)
+
+	var wg sync.WaitGroup
+	for i := 0; i < 8; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_, _, _ = s.fetchClientMetadata(context.Background(), u)
+		}()
+	}
+	wg.Wait()
+	// no panic, bounded fetches acceptable
+}

--- a/app/services/authentication/oauth/device.go
+++ b/app/services/authentication/oauth/device.go
@@ -5,6 +5,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/Southclaws/fault"
+	"github.com/Southclaws/fault/fctx"
 	"github.com/Southclaws/opt"
 
 	"github.com/Southclaws/storyden/app/resources/account"
@@ -114,31 +116,40 @@ func (s *Service) getClientForDeviceAuthorization(ctx context.Context, clientID 
 		return cl, nil
 	}
 
-	if clientID != StorydenCLIClientID {
-		return nil, err
-	}
-
-	_, err = s.tokens.CreateClient(ctx, oauth_writer.ClientCreate{
-		AccountID:        opt.NewEmpty[account.AccountID](),
-		ClientID:         StorydenCLIClientID,
-		ClientSecretHash: opt.NewEmpty[string](),
-		Name:             "Storyden",
-		Type:             oauthresource.ClientTypePublic,
-		ScopePolicy:      opt.New(oauthresource.ScopePolicyInheritUserPermissions),
-		RedirectURIs:     []string{},
-		AllowedScopes:    supportedScopes(),
-		AllowedGrants:    []string{GrantTypeDeviceCode, GrantTypeRefreshToken},
-	})
-	if err != nil {
-		cl, readErr := s.clients.GetClientByClientID(ctx, clientID)
-		if readErr == nil {
-			return cl, nil
+	if clientID == StorydenCLIClientID {
+		_, err = s.tokens.CreateClient(ctx, oauth_writer.ClientCreate{
+			AccountID:        opt.NewEmpty[account.AccountID](),
+			ClientID:         StorydenCLIClientID,
+			ClientSecretHash: opt.NewEmpty[string](),
+			Name:             "Storyden",
+			Type:             oauthresource.ClientTypePublic,
+			ScopePolicy:      opt.New(oauthresource.ScopePolicyInheritUserPermissions),
+			RedirectURIs:     []string{},
+			AllowedScopes:    supportedScopes(),
+			AllowedGrants:    []string{GrantTypeDeviceCode, GrantTypeRefreshToken},
+		})
+		if err != nil {
+			cl, readErr := s.clients.GetClientByClientID(ctx, clientID)
+			if readErr == nil {
+				return cl, nil
+			}
+			return nil, err
 		}
-
-		return nil, err
+		return s.clients.GetClientByClientID(ctx, clientID)
 	}
 
-	return s.clients.GetClientByClientID(ctx, clientID)
+	if isCIMDClientID(clientID) {
+		cl, oauthErr, err := s.resolveCIMDClient(ctx, clientID)
+		if oauthErr != nil || err != nil {
+			if err != nil {
+				return nil, err
+			}
+			return nil, fault.New("invalid CIMD client for device authorization")
+		}
+		return cl, nil
+	}
+
+	return nil, err
 }
 
 func (s *Service) GetDeviceConsent(ctx context.Context, accountID account.AccountID, accountPermissions rbac.Permissions, userCode string) (*DeviceConsent, *Error, error) {
@@ -249,10 +260,14 @@ func (s *Service) exchangeDeviceCode(ctx context.Context, input TokenRequest) (*
 		return nil, oauthError("invalid_request", "Missing device_code"), nil
 	}
 
-	cl, err := s.clients.GetClientByClientID(ctx, input.ClientID)
+	cl, oauthErr, err := s.resolveClient(ctx, input.ClientID)
 	if err != nil {
-		return nil, oauthError("invalid_client", "Client not found"), nil
+		return nil, nil, fault.Wrap(err, fctx.With(ctx))
 	}
+	if oauthErr != nil {
+		return nil, oauthErr, err
+	}
+
 	if cl.Type == oauthresource.ClientTypeConfidential || !contains(cl.AllowedGrants, GrantTypeDeviceCode) {
 		return nil, oauthError("unauthorized_client", "Client is not authorized for device_code grant"), nil
 	}

--- a/app/services/authentication/oauth/discovery.go
+++ b/app/services/authentication/oauth/discovery.go
@@ -3,19 +3,20 @@ package oauth
 import "strings"
 
 type Discovery struct {
-	Issuer                           string
-	AuthorizationEndpoint            string
-	DeviceAuthorizationEndpoint      string
-	TokenEndpoint                    string
-	UserinfoEndpoint                 string
-	RegistrationEndpoint             string
-	JWKSURI                          string
-	ResponseTypesSupported           []string
-	GrantTypesSupported              []string
-	CodeChallengeMethodsSupported    []string
-	ScopesSupported                  []string
-	SubjectTypesSupported            []string
-	IDTokenSigningAlgValuesSupported []string
+	Issuer                            string
+	AuthorizationEndpoint             string
+	DeviceAuthorizationEndpoint       string
+	TokenEndpoint                     string
+	UserinfoEndpoint                  string
+	RegistrationEndpoint              string
+	JWKSURI                           string
+	ResponseTypesSupported            []string
+	GrantTypesSupported               []string
+	CodeChallengeMethodsSupported     []string
+	ScopesSupported                   []string
+	SubjectTypesSupported             []string
+	IDTokenSigningAlgValuesSupported  []string
+	ClientIDMetadataDocumentSupported bool
 }
 
 func (s *Service) Discovery() Discovery {
@@ -27,19 +28,20 @@ func (s *Service) Discovery() Discovery {
 	}
 
 	return Discovery{
-		Issuer:                           s.issuer,
-		AuthorizationEndpoint:            endpointBase + "/oauth/authorize",
-		DeviceAuthorizationEndpoint:      endpointBase + "/oauth/device_authorization",
-		TokenEndpoint:                    endpointBase + "/oauth/token",
-		UserinfoEndpoint:                 endpointBase + "/oauth/userinfo",
-		RegistrationEndpoint:             registrationEndpoint,
-		JWKSURI:                          endpointBase + "/oauth/jwks",
-		ResponseTypesSupported:           []string{"code"},
-		GrantTypesSupported:              []string{GrantTypeAuthorizationCode, GrantTypeRefreshToken, GrantTypeClientCredentials, GrantTypeDeviceCode},
-		CodeChallengeMethodsSupported:    []string{CodeChallengeMethodS256},
-		ScopesSupported:                  supportedScopes(),
-		SubjectTypesSupported:            []string{"public"},
-		IDTokenSigningAlgValuesSupported: []string{"RS256"},
+		Issuer:                            s.issuer,
+		AuthorizationEndpoint:             endpointBase + "/oauth/authorize",
+		DeviceAuthorizationEndpoint:       endpointBase + "/oauth/device_authorization",
+		TokenEndpoint:                     endpointBase + "/oauth/token",
+		UserinfoEndpoint:                  endpointBase + "/oauth/userinfo",
+		RegistrationEndpoint:              registrationEndpoint,
+		JWKSURI:                           endpointBase + "/oauth/jwks",
+		ResponseTypesSupported:            []string{"code"},
+		GrantTypesSupported:               []string{GrantTypeAuthorizationCode, GrantTypeRefreshToken, GrantTypeClientCredentials, GrantTypeDeviceCode},
+		CodeChallengeMethodsSupported:     []string{CodeChallengeMethodS256},
+		ScopesSupported:                   supportedScopes(),
+		SubjectTypesSupported:             []string{"public"},
+		IDTokenSigningAlgValuesSupported:  []string{"RS256"},
+		ClientIDMetadataDocumentSupported: s.cimdEnabled(),
 	}
 }
 

--- a/app/services/authentication/oauth/oauth.go
+++ b/app/services/authentication/oauth/oauth.go
@@ -43,13 +43,14 @@ type Error struct {
 }
 
 type Service struct {
-	cfg     config.Config
-	clients *oauth_querier.Querier
-	tokens  *oauth_writer.Writer
-	account *account_querier.Querier
-	signer  *rsa.PrivateKey
-	kid     string
-	issuer  string
+	cfg       config.Config
+	clients   *oauth_querier.Querier
+	tokens    *oauth_writer.Writer
+	account   *account_querier.Querier
+	signer    *rsa.PrivateKey
+	kid       string
+	issuer    string
+	cimdCache *cimdCache
 }
 
 func (s *Service) Enabled() bool {
@@ -72,11 +73,12 @@ func New(
 
 	if !cfg.OAuthEnabled {
 		service := &Service{
-			cfg:     cfg,
-			clients: clients,
-			tokens:  tokens,
-			account: account,
-			issuer:  issuer,
+			cfg:       cfg,
+			clients:   clients,
+			tokens:    tokens,
+			account:   account,
+			issuer:    issuer,
+			cimdCache: newCIMDCache(),
 		}
 		service.registerCleanupJob(lc, logger)
 
@@ -114,13 +116,14 @@ func New(
 	}
 
 	service := &Service{
-		cfg:     cfg,
-		clients: clients,
-		tokens:  tokens,
-		account: account,
-		signer:  pk,
-		kid:     kid,
-		issuer:  issuer,
+		cfg:       cfg,
+		clients:   clients,
+		tokens:    tokens,
+		account:   account,
+		signer:    pk,
+		kid:       kid,
+		issuer:    issuer,
+		cimdCache: newCIMDCache(),
 	}
 	service.registerCleanupJob(lc, logger)
 

--- a/app/services/authentication/oauth/token.go
+++ b/app/services/authentication/oauth/token.go
@@ -56,10 +56,14 @@ func (s *Service) ExchangeToken(ctx context.Context, input TokenRequest) (*Token
 }
 
 func (s *Service) exchangeClientCredentials(ctx context.Context, input TokenRequest) (*Token, *Error, error) {
-	cl, err := s.clients.GetClientByClientID(ctx, input.ClientID)
+	cl, oauthErr, err := s.resolveClient(ctx, input.ClientID)
 	if err != nil {
-		return nil, oauthError("invalid_client", "Client not found"), nil
+		return nil, nil, fault.Wrap(err, fctx.With(ctx))
 	}
+	if oauthErr != nil {
+		return nil, oauthErr, err
+	}
+
 	if cl.Type != oauthresource.ClientTypeConfidential {
 		return nil, oauthError("unauthorized_client", "Client is not confidential"), nil
 	}
@@ -107,10 +111,14 @@ func (s *Service) exchangeAuthorizationCode(ctx context.Context, input TokenRequ
 		return nil, oauthError("invalid_request", "Missing code_verifier"), nil
 	}
 
-	cl, err := s.clients.GetClientByClientID(ctx, input.ClientID)
+	cl, oauthErr, err := s.resolveClient(ctx, input.ClientID)
 	if err != nil {
-		return nil, oauthError("invalid_client", "Client not found"), nil
+		return nil, nil, fault.Wrap(err, fctx.With(ctx))
 	}
+	if oauthErr != nil {
+		return nil, oauthErr, err
+	}
+
 	if !contains(cl.AllowedGrants, GrantTypeAuthorizationCode) {
 		return nil, oauthError("unauthorized_client", "Client is not authorized for authorization_code grant"), nil
 	}
@@ -154,10 +162,14 @@ func (s *Service) exchangeRefreshToken(ctx context.Context, input TokenRequest) 
 		return nil, oauthError("invalid_request", "Missing refresh_token"), nil
 	}
 
-	cl, err := s.clients.GetClientByClientID(ctx, input.ClientID)
+	cl, oauthErr, err := s.resolveClient(ctx, input.ClientID)
 	if err != nil {
-		return nil, oauthError("invalid_client", "Client not found"), nil
+		return nil, nil, fault.Wrap(err, fctx.With(ctx))
 	}
+	if oauthErr != nil {
+		return nil, oauthErr, err
+	}
+
 	if !contains(cl.AllowedGrants, GrantTypeRefreshToken) {
 		return nil, oauthError("unauthorized_client", "Client is not authorized for refresh_token grant"), nil
 	}

--- a/app/transports/http/bindings/oauth.go
+++ b/app/transports/http/bindings/oauth.go
@@ -82,68 +82,72 @@ func oauthTokenClientAuth(next echo.HandlerFunc) echo.HandlerFunc {
 }
 
 type OAuthDiscoveryResponse struct {
-	Issuer                           string   `json:"issuer"`
-	AuthorizationEndpoint            string   `json:"authorization_endpoint"`
-	DeviceAuthorizationEndpoint      string   `json:"device_authorization_endpoint"`
-	TokenEndpoint                    string   `json:"token_endpoint"`
-	UserinfoEndpoint                 string   `json:"userinfo_endpoint"`
-	RegistrationEndpoint             string   `json:"registration_endpoint,omitempty"`
-	JWKSURI                          string   `json:"jwks_uri"`
-	ResponseTypesSupported           []string `json:"response_types_supported"`
-	GrantTypesSupported              []string `json:"grant_types_supported"`
-	CodeChallengeMethodsSupported    []string `json:"code_challenge_methods_supported"`
-	ScopesSupported                  []string `json:"scopes_supported"`
-	SubjectTypesSupported            []string `json:"subject_types_supported"`
-	IDTokenSigningAlgValuesSupported []string `json:"id_token_signing_alg_values_supported"`
+	Issuer                            string   `json:"issuer"`
+	AuthorizationEndpoint             string   `json:"authorization_endpoint"`
+	DeviceAuthorizationEndpoint       string   `json:"device_authorization_endpoint"`
+	TokenEndpoint                     string   `json:"token_endpoint"`
+	UserinfoEndpoint                  string   `json:"userinfo_endpoint"`
+	RegistrationEndpoint              string   `json:"registration_endpoint,omitempty"`
+	JWKSURI                           string   `json:"jwks_uri"`
+	ResponseTypesSupported            []string `json:"response_types_supported"`
+	GrantTypesSupported               []string `json:"grant_types_supported"`
+	CodeChallengeMethodsSupported     []string `json:"code_challenge_methods_supported"`
+	ScopesSupported                   []string `json:"scopes_supported"`
+	SubjectTypesSupported             []string `json:"subject_types_supported"`
+	IDTokenSigningAlgValuesSupported  []string `json:"id_token_signing_alg_values_supported"`
+	ClientIDMetadataDocumentSupported bool     `json:"client_id_metadata_document_supported"`
 }
 
 func (o OAuth) OAuthDiscovery(context.Context) OAuthDiscoveryResponse {
 	discovery := o.oauth.Discovery()
 
 	return OAuthDiscoveryResponse{
-		Issuer:                           discovery.Issuer,
-		AuthorizationEndpoint:            discovery.AuthorizationEndpoint,
-		DeviceAuthorizationEndpoint:      discovery.DeviceAuthorizationEndpoint,
-		TokenEndpoint:                    discovery.TokenEndpoint,
-		UserinfoEndpoint:                 discovery.UserinfoEndpoint,
-		RegistrationEndpoint:             discovery.RegistrationEndpoint,
-		JWKSURI:                          discovery.JWKSURI,
-		ResponseTypesSupported:           discovery.ResponseTypesSupported,
-		GrantTypesSupported:              discovery.GrantTypesSupported,
-		CodeChallengeMethodsSupported:    discovery.CodeChallengeMethodsSupported,
-		ScopesSupported:                  discovery.ScopesSupported,
-		SubjectTypesSupported:            discovery.SubjectTypesSupported,
-		IDTokenSigningAlgValuesSupported: discovery.IDTokenSigningAlgValuesSupported,
+		Issuer:                            discovery.Issuer,
+		AuthorizationEndpoint:             discovery.AuthorizationEndpoint,
+		DeviceAuthorizationEndpoint:       discovery.DeviceAuthorizationEndpoint,
+		TokenEndpoint:                     discovery.TokenEndpoint,
+		RegistrationEndpoint:              discovery.RegistrationEndpoint,
+		UserinfoEndpoint:                  discovery.UserinfoEndpoint,
+		JWKSURI:                           discovery.JWKSURI,
+		ResponseTypesSupported:            discovery.ResponseTypesSupported,
+		GrantTypesSupported:               discovery.GrantTypesSupported,
+		CodeChallengeMethodsSupported:     discovery.CodeChallengeMethodsSupported,
+		ScopesSupported:                   discovery.ScopesSupported,
+		SubjectTypesSupported:             discovery.SubjectTypesSupported,
+		IDTokenSigningAlgValuesSupported:  discovery.IDTokenSigningAlgValuesSupported,
+		ClientIDMetadataDocumentSupported: discovery.ClientIDMetadataDocumentSupported,
 	}
 }
 
 type OAuthAuthorizationServerMetadata struct {
-	Issuer                        string   `json:"issuer"`
-	AuthorizationEndpoint         string   `json:"authorization_endpoint"`
-	TokenEndpoint                 string   `json:"token_endpoint"`
-	RegistrationEndpoint          string   `json:"registration_endpoint,omitempty"`
-	JWKSURI                       string   `json:"jwks_uri,omitempty"`
-	ScopesSupported               []string `json:"scopes_supported,omitempty"`
-	ResponseTypesSupported        []string `json:"response_types_supported"`
-	GrantTypesSupported           []string `json:"grant_types_supported,omitempty"`
-	CodeChallengeMethodsSupported []string `json:"code_challenge_methods_supported,omitempty"`
-	DeviceAuthorizationEndpoint   string   `json:"device_authorization_endpoint,omitempty"`
+	Issuer                            string   `json:"issuer"`
+	AuthorizationEndpoint             string   `json:"authorization_endpoint"`
+	TokenEndpoint                     string   `json:"token_endpoint"`
+	RegistrationEndpoint              string   `json:"registration_endpoint,omitempty"`
+	JWKSURI                           string   `json:"jwks_uri,omitempty"`
+	ScopesSupported                   []string `json:"scopes_supported,omitempty"`
+	ResponseTypesSupported            []string `json:"response_types_supported"`
+	GrantTypesSupported               []string `json:"grant_types_supported,omitempty"`
+	CodeChallengeMethodsSupported     []string `json:"code_challenge_methods_supported,omitempty"`
+	DeviceAuthorizationEndpoint       string   `json:"device_authorization_endpoint,omitempty"`
+	ClientIDMetadataDocumentSupported bool     `json:"client_id_metadata_document_supported"`
 }
 
 func (o OAuth) OAuthAuthorizationServerMetadata(context.Context) OAuthAuthorizationServerMetadata {
 	discovery := o.oauth.Discovery()
 
 	return OAuthAuthorizationServerMetadata{
-		Issuer:                        discovery.Issuer,
-		AuthorizationEndpoint:         discovery.AuthorizationEndpoint,
-		TokenEndpoint:                 discovery.TokenEndpoint,
-		RegistrationEndpoint:          discovery.RegistrationEndpoint,
-		JWKSURI:                       discovery.JWKSURI,
-		ScopesSupported:               discovery.ScopesSupported,
-		ResponseTypesSupported:        discovery.ResponseTypesSupported,
-		GrantTypesSupported:           discovery.GrantTypesSupported,
-		CodeChallengeMethodsSupported: discovery.CodeChallengeMethodsSupported,
-		DeviceAuthorizationEndpoint:   discovery.DeviceAuthorizationEndpoint,
+		Issuer:                            discovery.Issuer,
+		AuthorizationEndpoint:             discovery.AuthorizationEndpoint,
+		TokenEndpoint:                     discovery.TokenEndpoint,
+		RegistrationEndpoint:              discovery.RegistrationEndpoint,
+		JWKSURI:                           discovery.JWKSURI,
+		ScopesSupported:                   discovery.ScopesSupported,
+		ResponseTypesSupported:            discovery.ResponseTypesSupported,
+		GrantTypesSupported:               discovery.GrantTypesSupported,
+		CodeChallengeMethodsSupported:     discovery.CodeChallengeMethodsSupported,
+		DeviceAuthorizationEndpoint:       discovery.DeviceAuthorizationEndpoint,
+		ClientIDMetadataDocumentSupported: discovery.ClientIDMetadataDocumentSupported,
 	}
 }
 

--- a/home/content/docs/introduction/oauth/client-registration.mdx
+++ b/home/content/docs/introduction/oauth/client-registration.mdx
@@ -1,0 +1,97 @@
+---
+title: Client Registration
+description: "How OAuth clients identify themselves to Storyden: pre-registered clients, Dynamic Client Registration (DCR), and Client ID Metadata Documents (CIMD) for MCP connectors."
+---
+
+Before an application can run an authorisation flow, the authorisation server needs to know who the client is: its name, where it is allowed to redirect users back to, and what it is allowed to ask for. Storyden supports three ways for a client to be known.
+
+| Mechanism                                               | Who creates the client                    | Secret?  | Best for                                     |
+| ------------------------------------------------------- | ----------------------------------------- | -------- | -------------------------------------------- |
+| [User-defined client](/docs/introduction/oauth/clients) | An administrator, ahead of time           | Optional | Trusted, long-lived integrations you control |
+| Dynamic Client Registration (DCR)                       | The client, at runtime, via an API        | Issued   | Clients that self-register before first use  |
+| Client ID Metadata Documents (CIMD)                     | Nobody, the client hosts its own metadata | No       | MCP connectors, web-native public clients    |
+
+## User-defined OAuth clients
+
+This is the classic model. An administrator registers a client in advance and receives a `client_id` (and, for confidential clients, a `client_secret`). The application is configured with these values. Storyden validates the redirect URI, allowed scopes, and allowed grants against the stored record.
+
+See [OAuth Clients](/docs/introduction/oauth/clients) for the full lifecycle.
+
+Use this when you own the integration and want explicit, audited control over exactly which application can connect and what it can request.
+
+## Dynamic Client Registration (DCR)
+
+[RFC 7591](https://datatracker.ietf.org/doc/html/rfc7591) Dynamic Client Registration lets a client register itself at runtime by POSTing its metadata to a registration endpoint, receiving a freshly minted `client_id` (and secret) in return. The authorisation server advertises support by publishing a `registration_endpoint` in its discovery metadata.
+
+DCR removes the manual setup step, which is convenient for clients that connect to many servers. The trade-off is that _any_ caller can create a client record, so the server takes on the cost of storing, rate-limiting, and (ideally) garbage-collecting these registrations, and must decide how much to trust a self-asserted identity.
+
+## Client ID Metadata Documents (CIMD)
+
+<Callout type="warn" title="Draft specification">
+  Client ID Metadata Documents (CIMD) are defined by an IETF draft
+  specification. Both the specification and Storyden's implementation of it are
+  subject to change.
+</Callout>
+
+[Client ID Metadata Documents](https://drafts.oauth.net/draft-ietf-oauth-client-id-metadata-document/draft-ietf-oauth-client-id-metadata-document.html) are a web-native alternative to pre-registration or Dynamic Client Registration. This is the mechanism used by ChatGPT's MCP connector and is referenced by the [MCP authorization specification](https://modelcontextprotocol.io/specification/2025-11-25/basic/authorization).
+
+Instead of registering ahead of time, the client uses an **`https` URL as its `client_id`**. That URL hosts a JSON document containing the client's metadata. When Storyden sees an authorisation request with a URL as the `client_id`, it fetches the document, validates it, and uses the declared `redirect_uris`, grants, and scopes for the flow.
+
+Storyden advertises support via the `client_id_metadata_document_supported` flag in its OAuth and OpenID Connect discovery documents.
+
+### The metadata document
+
+The document lives at the `client_id` URL itself. A minimal example:
+
+```json
+{
+  "client_id": "https://app.example/oauth/client.json",
+  "client_name": "Example Connector",
+  "redirect_uris": ["https://app.example/oauth/callback"],
+  "grant_types": ["authorization_code", "refresh_token"],
+  "scope": "openid profile",
+  "token_endpoint_auth_method": "none"
+}
+```
+
+Storyden requires:
+
+- The `client_id` value inside the document **exactly matches** the URL the document was fetched from.
+- At least one `redirect_uri` is present, and the `redirect_uri` in the authorisation request must be an exact match (no wildcards).
+
+Additional fields from the OAuth Dynamic Client Registration metadata registry (such as `logo_uri`, `client_uri`, etc.) are accepted but not required.
+
+### How Storyden treats CIMD clients
+
+- **Public clients (current implementation).** Storyden currently treats all CIMD clients as public clients. They must use the Authorization Code flow with PKCE (S256). The `token_endpoint_auth_method` in the document must be `"none"` (or omitted).
+- **Conservative scopes.** CIMD clients may only request scopes from a server-controlled allowlist. By default this includes the common OIDC scopes plus a small set of read-only permission scopes. Privileged scopes are never granted unless `OAUTH_CIMD_ALLOW_PRIVILEGED_SCOPES` is enabled.
+- **Refresh tokens.** Issued only when the document lists the `refresh_token` grant _and_ `offline_access` is present in the allowed scopes for that client.
+- **Dynamic resolution with caching.** Storyden fetches the metadata document on first use for a given `client_id` URL and caches the result. It honours `Cache-Control` headers from the document response (with a default TTL of 5 minutes and an upper bound of 1 hour). A snapshot is also stored in the database. On cache miss (TTL expiry or process restart) the document is re-fetched, so updates to `redirect_uris`, grants, or scopes published by the client can take effect. Some providers include a query string in the `client_id` URL (e.g. `?token_endpoint_auth_method=none`); Storyden supports this and uses the full URL (including query) for fetching and for the `client_id` match.
+
+### Security: fetching metadata safely
+
+Because the `client_id` is an arbitrary URL supplied by an unauthenticated client, fetching it is a potential SSRF vector. Storyden applies the following hardening:
+
+- **HTTPS only** (unless `OAUTH_CIMD_ALLOW_INSECURE_FETCH` is enabled for development).
+- **No private or special-use networks.** Requests to loopback, link-local, multicast, and RFC 1918 / unique-local addresses are blocked, both on the hostname and on the addresses it resolves to (DNS rebinding protection).
+- **No redirects** are followed when fetching the metadata document.
+- **Bounded responses.** Requests time out quickly (10s), are limited to 5 KiB, and must return a JSON content type.
+
+The insecure fetch mode must never be enabled in production.
+
+### Server policy
+
+| Setting                              | Default             | Purpose                                                          |
+| ------------------------------------ | ------------------- | ---------------------------------------------------------------- |
+| `OAUTH_CIMD_ENABLED`                 | `true`              | Advertise and accept CIMD clients.                               |
+| `OAUTH_CIMD_ALLOWED_SCOPES`          | _read-only default_ | Permission scopes a CIMD client may request.                     |
+| `OAUTH_CIMD_ALLOW_PRIVILEGED_SCOPES` | `false`             | Permit administrative scopes for CIMD clients (not recommended). |
+| `OAUTH_CIMD_ALLOW_INSECURE_FETCH`    | `false`             | Relax fetch restrictions for local development only.             |
+
+## Choosing a mechanism
+
+- **You control the integration** and want explicit control and auditing → use a [user-defined client](/docs/introduction/oauth/clients), preferably confidential.
+- **You are connecting an MCP client or ChatGPT-style connector** → CIMD is the intended path. Use a conservative scope allowlist.
+- **Clients need to self-register without hosting their own metadata** → DCR (with the usual storage, rate-limiting, and trust considerations).
+
+For most new public or agent-style integrations, CIMD with a conservative allowlist (and privileged scopes disabled) is the recommended starting point. The client controls its own identity document at a stable HTTPS URL, while Storyden still enforces exact redirect URI matching and scoped grants.

--- a/home/content/docs/introduction/oauth/meta.json
+++ b/home/content/docs/introduction/oauth/meta.json
@@ -6,6 +6,7 @@
         "device-flow",
         "authorization-code",
         "scopes",
-        "clients"
+        "clients",
+        "client-registration"
     ]
 }

--- a/home/content/docs/reference/configuration.mdx
+++ b/home/content/docs/reference/configuration.mdx
@@ -630,10 +630,48 @@ Optional JWT key ID (kid) for OAuth signing keys.
 
 <table>
 <tr><td>type</td><td>boolean (`true` or `false`, case sensitive)</td></tr>
-<tr><td>default</td><td>none</td></tr>
+<tr><td>default</td><td>`false`</td></tr>
 </table>
 
 Enable RFC 7591 OAuth 2.0 Dynamic Client Registration.
+
+### `OAUTH_CIMD_ENABLED`
+
+<table>
+<tr><td>type</td><td>boolean (`true` or `false`, case sensitive)</td></tr>
+<tr><td>default</td><td>`false`</td></tr>
+</table>
+
+Advertise and accept OAuth Client ID Metadata Documents (CIMD), letting clients identify themselves with an https URL client_id that resolves to a hosted metadata document instead of pre-registering.
+
+### `OAUTH_CIMD_ALLOWED_SCOPES`
+
+<table>
+<tr><td>type</td><td>`[]string`</td></tr>
+<tr><td>default</td><td>none</td></tr>
+</table>
+
+Comma-separated list of permission scopes a CIMD client may request. Empty uses a conservative read-only default. Privileged scopes are still gated by OAUTH_CIMD_ALLOW_PRIVILEGED_SCOPES.
+
+### `OAUTH_CIMD_ALLOW_PRIVILEGED_SCOPES`
+
+<table>
+<tr><td>type</td><td>boolean (`true` or `false`, case sensitive)</td></tr>
+<tr><td>default</td><td>none</td></tr>
+</table>
+
+Allow privileged/administrative permission scopes to be granted to CIMD clients.
+
+Off by default; only enable for trusted, controlled deployments.
+
+### `OAUTH_CIMD_ALLOW_INSECURE_FETCH`
+
+<table>
+<tr><td>type</td><td>boolean (`true` or `false`, case sensitive)</td></tr>
+<tr><td>default</td><td>none</td></tr>
+</table>
+
+Relax CIMD metadata fetching restrictions (allow http, private hosts and skip TLS verification). For local development and testing only; never set in production.
 
 ## SMS
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -310,7 +310,19 @@ type Config struct {
 	// Optional JWT key ID (kid) for OAuth signing keys.
 	OAuthSigningKeyID string `envconfig:"OAUTH_SIGNING_KEY_ID"`
 	// Enable RFC 7591 OAuth 2.0 Dynamic Client Registration.
-	OAuthDynamicRegistrationEnabled bool `envconfig:"OAUTH_DYNAMIC_REGISTRATION_ENABLED"`
+	OAuthDynamicRegistrationEnabled bool `default:"false" envconfig:"OAUTH_DYNAMIC_REGISTRATION_ENABLED"`
+	// Advertise and accept OAuth Client ID Metadata Documents (CIMD), letting clients identify themselves with an https URL client_id that resolves to a hosted metadata document instead of pre-registering.
+	OAuthClientIDMetadataDocumentEnabled bool `default:"false" envconfig:"OAUTH_CIMD_ENABLED"`
+	// Comma-separated list of permission scopes a CIMD client may request. Empty uses a conservative read-only default. Privileged scopes are still gated by OAUTH_CIMD_ALLOW_PRIVILEGED_SCOPES.
+	OAuthCIMDAllowedScopes []string `envconfig:"OAUTH_CIMD_ALLOWED_SCOPES"`
+	/*
+	   Allow privileged/administrative permission scopes to be granted to CIMD clients.
+
+	   Off by default; only enable for trusted, controlled deployments.
+	*/
+	OAuthCIMDAllowPrivilegedScopes bool `envconfig:"OAUTH_CIMD_ALLOW_PRIVILEGED_SCOPES"`
+	// Relax CIMD metadata fetching restrictions (allow http, private hosts and skip TLS verification). For local development and testing only; never set in production.
+	OAuthCIMDAllowInsecureFetch bool `envconfig:"OAUTH_CIMD_ALLOW_INSECURE_FETCH"`
 
 	// -
 	// SMS

--- a/internal/config/config.yaml
+++ b/internal/config/config.yaml
@@ -482,8 +482,36 @@
     - env: OAUTH_DYNAMIC_REGISTRATION_ENABLED
       name: OAuthDynamicRegistrationEnabled
       type: bool
+      default: "false"
       description: |-
         Enable RFC 7591 OAuth 2.0 Dynamic Client Registration.
+
+    - env: OAUTH_CIMD_ENABLED
+      name: OAuthClientIDMetadataDocumentEnabled
+      type: bool
+      default: "false"
+      description: |-
+        Advertise and accept OAuth Client ID Metadata Documents (CIMD), letting clients identify themselves with an https URL client_id that resolves to a hosted metadata document instead of pre-registering.
+
+    - env: OAUTH_CIMD_ALLOWED_SCOPES
+      name: OAuthCIMDAllowedScopes
+      type: "[]string"
+      description: |-
+        Comma-separated list of permission scopes a CIMD client may request. Empty uses a conservative read-only default. Privileged scopes are still gated by OAUTH_CIMD_ALLOW_PRIVILEGED_SCOPES.
+
+    - env: OAUTH_CIMD_ALLOW_PRIVILEGED_SCOPES
+      name: OAuthCIMDAllowPrivilegedScopes
+      type: bool
+      description: |-
+        Allow privileged/administrative permission scopes to be granted to CIMD clients.
+
+        Off by default; only enable for trusted, controlled deployments.
+
+    - env: OAUTH_CIMD_ALLOW_INSECURE_FETCH
+      name: OAuthCIMDAllowInsecureFetch
+      type: bool
+      description: |-
+        Relax CIMD metadata fetching restrictions (allow http, private hosts and skip TLS verification). For local development and testing only; never set in production.
 
 - section: SMS
   description: |-

--- a/tests/oauth/cimd_test.go
+++ b/tests/oauth/cimd_test.go
@@ -1,0 +1,498 @@
+package oauth_test
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/fx"
+
+	"github.com/Southclaws/storyden/app/resources/account/account_writer"
+	"github.com/Southclaws/storyden/app/resources/account/role/role_assign"
+	"github.com/Southclaws/storyden/app/resources/account/role/role_repo"
+	"github.com/Southclaws/storyden/app/resources/rbac"
+	"github.com/Southclaws/storyden/app/resources/seed"
+	"github.com/Southclaws/storyden/app/transports/http/openapi"
+	"github.com/Southclaws/storyden/internal/config"
+	"github.com/Southclaws/storyden/internal/integration"
+	"github.com/Southclaws/storyden/internal/integration/e2e"
+	"github.com/Southclaws/storyden/tests"
+)
+
+type cimdMetadataServer struct {
+	server   *httptest.Server
+	fetches  int64
+	document map[string]any
+}
+
+func newCIMDMetadataServer(t *testing.T) *cimdMetadataServer {
+	t.Helper()
+
+	cm := &cimdMetadataServer{}
+	cm.server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		atomic.AddInt64(&cm.fetches, 1)
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(cm.document)
+	}))
+	t.Cleanup(cm.server.Close)
+
+	// The CIMD client_id is the metadata document URL itself (must have path per spec).
+	docURL := cm.server.URL + "/metadata.json"
+	cm.document = map[string]any{
+		"client_id":     docURL,
+		"client_name":   "ChatGPT MCP Connector",
+		"redirect_uris": []string{"https://client.example/callback"},
+		"grant_types":   []string{"authorization_code", "refresh_token"},
+		"scope":         "openid profile " + rbac.PermissionReadPublishedThreads.String(),
+	}
+
+	return cm
+}
+
+func (cm *cimdMetadataServer) clientID() string { return cm.server.URL + "/metadata.json" }
+
+func (cm *cimdMetadataServer) fetchCount() int64 { return atomic.LoadInt64(&cm.fetches) }
+
+func cimdConfig(t *testing.T) *config.Config {
+	t.Helper()
+	cfg := oauthConfig(t)
+	cfg.OAuthClientIDMetadataDocumentEnabled = true
+	cfg.OAuthCIMDAllowInsecureFetch = true // allow httptest loopback servers
+	return cfg
+}
+
+func TestOAuthCIMDDiscoveryAdvertisesSupport(t *testing.T) {
+	t.Parallel()
+
+	integration.Test(t, cimdConfig(t), e2e.Setup(), fx.Invoke(func(
+		lc fx.Lifecycle,
+		root context.Context,
+		ts *httptest.Server,
+	) {
+		lc.Append(fx.StartHook(func() {
+			for _, path := range []string{"/.well-known/openid-configuration", "/.well-known/oauth-authorization-server"} {
+				t.Run(path, func(t *testing.T) {
+					a := assert.New(t)
+					r := require.New(t)
+
+					req, err := http.NewRequestWithContext(root, http.MethodGet, ts.URL+path, nil)
+					r.NoError(err)
+					resp, err := http.DefaultClient.Do(req)
+					r.NoError(err)
+					defer resp.Body.Close()
+
+					a.Equal(http.StatusOK, resp.StatusCode)
+
+					var body map[string]any
+					r.NoError(json.NewDecoder(resp.Body).Decode(&body))
+					a.Equal(true, body["client_id_metadata_document_supported"])
+				})
+			}
+		}))
+	}))
+}
+
+func TestOAuthCIMDAuthorizationFlow(t *testing.T) {
+	t.Parallel()
+
+	integration.Test(t, cimdConfig(t), e2e.Setup(), fx.Invoke(func(
+		lc fx.Lifecycle,
+		root context.Context,
+		cl *openapi.ClientWithResponses,
+		sh *e2e.SessionHelper,
+		aw *account_writer.Writer,
+		assignments *role_assign.Assignment,
+		roles *role_repo.Repository,
+		ts *httptest.Server,
+	) {
+		lc.Append(fx.StartHook(func() {
+			memberCtx, member := e2e.WithAccount(root, aw, seed.Account_004_Loki)
+			grantOAuthClientUse(t, root, roles, assignments, member.ID, rbac.PermissionReadPublishedThreads)
+			memberSession := sh.WithSession(memberCtx)
+
+			t.Run("valid_cimd_client_reaches_consent", func(t *testing.T) {
+				a := assert.New(t)
+				r := require.New(t)
+
+				cm := newCIMDMetadataServer(t)
+
+				location := authorizeRedirect(t, root, ts, memberSession, authorizeRequest{
+					ClientID:            cm.clientID(),
+					RedirectURI:         "https://client.example/callback",
+					Scope:               "openid profile " + rbac.PermissionReadPublishedThreads.String(),
+					State:               "state-" + uuid.NewString(),
+					CodeChallenge:       codeChallenge(strings.Repeat("a", 43)),
+					CodeChallengeMethod: "S256",
+				})
+
+				consentURL, err := url.Parse(location)
+				r.NoError(err)
+				a.Equal("/oauth/authorize/consent", consentURL.Path)
+				requestID := consentURL.Query().Get("request_id")
+				r.NotEmpty(requestID)
+
+				consent := tests.AssertRequest(cl.OAuthAuthoriseConsentWithResponse(root, &openapi.OAuthAuthoriseConsentParams{
+					RequestId: (*openapi.OAuthAuthorizationRequestIDQuery)(&requestID),
+				}, memberSession))(t, http.StatusOK)
+				r.NotNil(consent.JSON200)
+				a.Equal(cm.clientID(), consent.JSON200.ClientId)
+				a.Contains(consent.JSON200.GrantedScopes, rbac.PermissionReadPublishedThreads.String())
+			})
+
+			t.Run("redirect_uri_not_in_metadata_is_rejected", func(t *testing.T) {
+				a := assert.New(t)
+				r := require.New(t)
+
+				cm := newCIMDMetadataServer(t)
+
+				resp := authorizeHTTPResponse(t, root, ts, memberSession, authorizeRequest{
+					ClientID:            cm.clientID(),
+					RedirectURI:         "https://attacker.example/callback",
+					Scope:               "openid",
+					State:               "state-" + uuid.NewString(),
+					CodeChallenge:       codeChallenge(strings.Repeat("b", 43)),
+					CodeChallengeMethod: "S256",
+				})
+				defer resp.Body.Close()
+
+				a.Equal(http.StatusBadRequest, resp.StatusCode)
+				a.Empty(resp.Header.Get("Location"))
+				r.NotNil(resp.Body)
+			})
+
+			t.Run("unknown_scope_is_rejected", func(t *testing.T) {
+				a := assert.New(t)
+
+				cm := newCIMDMetadataServer(t)
+
+				resp := authorizeHTTPResponse(t, root, ts, memberSession, authorizeRequest{
+					ClientID:            cm.clientID(),
+					RedirectURI:         "https://client.example/callback",
+					Scope:               "openid NONEXISTENT_SCOPE",
+					State:               "state-" + uuid.NewString(),
+					CodeChallenge:       codeChallenge(strings.Repeat("c", 43)),
+					CodeChallengeMethod: "S256",
+				})
+				defer resp.Body.Close()
+
+				a.Equal(http.StatusBadRequest, resp.StatusCode)
+				a.Empty(resp.Header.Get("Location"))
+			})
+
+			t.Run("admin_scope_is_rejected_by_default", func(t *testing.T) {
+				a := assert.New(t)
+				r := require.New(t)
+
+				adminCtx, admin := e2e.WithAccount(root, aw, seed.Account_001_Odin)
+				grantOAuthClientUse(t, root, roles, assignments, admin.ID, rbac.PermissionAdministrator)
+				adminSession := sh.WithSession(adminCtx)
+
+				cm := newCIMDMetadataServer(t)
+				cm.document["scope"] = "openid " + rbac.PermissionAdministrator.String()
+
+				location := authorizeRedirect(t, root, ts, adminSession, authorizeRequest{
+					ClientID:            cm.clientID(),
+					RedirectURI:         "https://client.example/callback",
+					Scope:               "openid " + rbac.PermissionAdministrator.String(),
+					State:               "state-" + uuid.NewString(),
+					CodeChallenge:       codeChallenge(strings.Repeat("d", 43)),
+					CodeChallengeMethod: "S256",
+				})
+				consentURL, err := url.Parse(location)
+				r.NoError(err)
+				requestID := consentURL.Query().Get("request_id")
+				r.NotEmpty(requestID)
+
+				consent := tests.AssertRequest(cl.OAuthAuthoriseConsentWithResponse(root, &openapi.OAuthAuthoriseConsentParams{
+					RequestId: (*openapi.OAuthAuthorizationRequestIDQuery)(&requestID),
+				}, adminSession))(t, http.StatusOK)
+				r.NotNil(consent.JSON200)
+				a.NotContains(consent.JSON200.GrantedScopes, rbac.PermissionAdministrator.String())
+			})
+
+			t.Run("cached_metadata_is_reused", func(t *testing.T) {
+				r := require.New(t)
+				a := assert.New(t)
+
+				cm := newCIMDMetadataServer(t)
+
+				for i := 0; i < 3; i++ {
+					location := authorizeRedirect(t, root, ts, memberSession, authorizeRequest{
+						ClientID:            cm.clientID(),
+						RedirectURI:         "https://client.example/callback",
+						Scope:               "openid",
+						State:               "state-" + uuid.NewString(),
+						CodeChallenge:       codeChallenge(strings.Repeat("e", 43)),
+						CodeChallengeMethod: "S256",
+					})
+					consentURL, err := url.Parse(location)
+					r.NoError(err)
+					r.NotEmpty(consentURL.Query().Get("request_id"))
+				}
+
+				a.Equal(int64(1), cm.fetchCount(), "metadata document should be fetched once and cached")
+			})
+
+			t.Run("cimd_client_id_with_query_string_and_none_auth_hint_full_flow_to_token", func(t *testing.T) {
+				a := assert.New(t)
+				r := require.New(t)
+
+				cm := newCIMDMetadataServer(t)
+				// Simulate production usage (ChatGPT-style) where the client_id URL
+				// itself carries a query hint for the auth method the client will use.
+				queriedID := cm.server.URL + "/metadata.json?token_endpoint_auth_method=none"
+				cm.document["client_id"] = queriedID // doc must declare the exact (full) client_id for match
+				cm.document["scope"] = "openid offline_access " + rbac.PermissionReadPublishedThreads.String()
+
+				// Use a code_challenge that we can compute verifier for.
+				verifier := strings.Repeat("q", 43)
+				challenge := codeChallenge(verifier)
+
+				location := authorizeRedirect(t, root, ts, memberSession, authorizeRequest{
+					ClientID:            queriedID,
+					RedirectURI:         "https://client.example/callback",
+					Scope:               "openid offline_access " + rbac.PermissionReadPublishedThreads.String(),
+					State:               "state-q-" + uuid.NewString(),
+					CodeChallenge:       challenge,
+					CodeChallengeMethod: "S256",
+				})
+
+				consentURL, err := url.Parse(location)
+				r.NoError(err)
+				requestID := consentURL.Query().Get("request_id")
+				r.NotEmpty(requestID)
+
+				// Get consent form.
+				consent := tests.AssertRequest(cl.OAuthAuthoriseConsentWithResponse(root, &openapi.OAuthAuthoriseConsentParams{
+					RequestId: (*openapi.OAuthAuthorizationRequestIDQuery)(&requestID),
+				}, memberSession))(t, http.StatusOK)
+				r.NotNil(consent.JSON200)
+
+				// Approve.
+				submit := tests.AssertRequest(cl.OAuthAuthoriseConsentSubmitWithResponse(root, openapi.OAuthAuthoriseConsentSubmitJSONRequestBody{
+					RequestId: requestID,
+					Decision:  openapi.OAuthAuthoriseDecisionApprove,
+				}, memberSession))(t, http.StatusOK)
+				r.NotNil(submit.JSON200)
+				a.Equal(openapi.OAuthAuthoriseConsentResultStatusApproved, submit.JSON200.Status)
+
+				codeRedirect, err := url.Parse(submit.JSON200.Location)
+				r.NoError(err)
+				code := codeRedirect.Query().Get("code")
+				r.NotEmpty(code)
+
+				// Full token exchange for this public CIMD client (PKCE only, no secret).
+				tok, err := oauthToken(t, root, cl, oauthTokenRequest{
+					GrantType:    "authorization_code",
+					ClientId:     queriedID,
+					Code:         &code,
+					RedirectUri:  ptr("https://client.example/callback"),
+					CodeVerifier: &verifier,
+				})
+				r.NoError(err)
+				r.NotNil(tok)
+				a.Equal(http.StatusOK, tok.StatusCode())
+				r.NotNil(tok.JSON200)
+				r.NotEmpty(tok.JSON200.AccessToken)
+				r.NotEmpty(tok.JSON200.RefreshToken) // because doc requests offline_access + refresh grant
+			})
+
+			t.Run("cimd_metadata_updates_are_observed_after_cache_expiry", func(t *testing.T) {
+				a := assert.New(t)
+
+				cm := newCIMDMetadataServer(t)
+				// Force re-fetch on next resolve by making the document response indicate no caching.
+				// (Our cimdCacheTTL treats no-cache / max-age=0 as ttl=0 which invalidates.)
+				origHandler := cm.server.Config.Handler
+				cm.server.Config.Handler = http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+					atomic.AddInt64(&cm.fetches, 1)
+					w.Header().Set("Content-Type", "application/json")
+					w.Header().Set("Cache-Control", "no-cache, no-store")
+					_ = json.NewEncoder(w).Encode(cm.document)
+				})
+				t.Cleanup(func() { cm.server.Config.Handler = origHandler })
+
+				id := cm.clientID()
+
+				// First use: initial fetch + create snapshot.
+				_ = authorizeHTTPResponse(t, root, ts, memberSession, authorizeRequest{
+					ClientID:            id,
+					RedirectURI:         "https://client.example/callback",
+					Scope:               "openid",
+					State:               "state-f1-" + uuid.NewString(),
+					CodeChallenge:       codeChallenge(strings.Repeat("1", 43)),
+					CodeChallengeMethod: "S256",
+				}).Body.Close()
+
+				initialFetches := cm.fetchCount()
+				a.GreaterOrEqual(initialFetches, int64(1))
+
+				// Mutate the published metadata: add an extra redirect_uri.
+				// (Also keep the original so existing tests don't break.)
+				cm.document["redirect_uris"] = []string{
+					"https://client.example/callback",
+					"https://client.example/extra-cb",
+				}
+
+				// Second authorize using the *new* redirect should succeed and trigger a re-fetch
+				// because previous response forced ttl=0 / no-cache.
+				resp2 := authorizeHTTPResponse(t, root, ts, memberSession, authorizeRequest{
+					ClientID:            id,
+					RedirectURI:         "https://client.example/extra-cb",
+					Scope:               "openid",
+					State:               "state-f2-" + uuid.NewString(),
+					CodeChallenge:       codeChallenge(strings.Repeat("2", 43)),
+					CodeChallengeMethod: "S256",
+				})
+				defer resp2.Body.Close()
+				// It should have reached consent (200 would be after? but for redirect case we get 302 with location to consent or error).
+				// A 302 to the consent page (or success) means the client was accepted with the *updated* redirect.
+				a.True(resp2.StatusCode == http.StatusFound || resp2.StatusCode == http.StatusOK,
+					"updated redirect from mutated CIMD doc should be accepted after re-fetch")
+
+				a.Greater(cm.fetchCount(), initialFetches, "a re-fetch should have occurred due to cache expiry / no-cache header")
+			})
+		}))
+	}))
+}
+
+func TestOAuthCIMDRejectsPrivateMetadataHostByDefault(t *testing.T) {
+	t.Parallel()
+
+	// Default config: OAuthCIMDAllowInsecureFetch is false, so a loopback
+	// httptest server must be rejected by the SSRF protections.
+	integration.Test(t, oauthConfig(t), e2e.Setup(), fx.Invoke(func(
+		lc fx.Lifecycle,
+		root context.Context,
+		sh *e2e.SessionHelper,
+		aw *account_writer.Writer,
+		assignments *role_assign.Assignment,
+		roles *role_repo.Repository,
+		ts *httptest.Server,
+	) {
+		lc.Append(fx.StartHook(func() {
+			a := assert.New(t)
+
+			memberCtx, member := e2e.WithAccount(root, aw, seed.Account_004_Loki)
+			grantOAuthClientUse(t, root, roles, assignments, member.ID, rbac.PermissionReadPublishedThreads)
+			memberSession := sh.WithSession(memberCtx)
+
+			cm := newCIMDMetadataServer(t)
+
+			resp := authorizeHTTPResponse(t, root, ts, memberSession, authorizeRequest{
+				ClientID:            cm.clientID(), // http loopback URL
+				RedirectURI:         "https://client.example/callback",
+				Scope:               "openid",
+				State:               "state-" + uuid.NewString(),
+				CodeChallenge:       codeChallenge(strings.Repeat("f", 43)),
+				CodeChallengeMethod: "S256",
+			})
+			defer resp.Body.Close()
+
+			a.Equal(http.StatusBadRequest, resp.StatusCode)
+			a.Empty(resp.Header.Get("Location"))
+			a.Equal(int64(0), cm.fetchCount(), "metadata host must be rejected before any fetch")
+		}))
+	}))
+}
+
+func TestOAuthCIMDRejectsSection3ClientID(t *testing.T) {
+	t.Parallel()
+
+	integration.Test(t, cimdConfig(t), e2e.Setup(), fx.Invoke(func(
+		lc fx.Lifecycle,
+		root context.Context,
+		sh *e2e.SessionHelper,
+		aw *account_writer.Writer,
+		assignments *role_assign.Assignment,
+		roles *role_repo.Repository,
+		ts *httptest.Server,
+	) {
+		lc.Append(fx.StartHook(func() {
+			a := assert.New(t)
+
+			memberCtx, member := e2e.WithAccount(root, aw, seed.Account_004_Loki)
+			grantOAuthClientUse(t, root, roles, assignments, member.ID, rbac.PermissionReadPublishedThreads)
+			memberSession := sh.WithSession(memberCtx)
+
+			badIDs := []string{
+				"https://client.example",
+				"https://client.example/",
+				"https://client.example/../x.json",
+				"https://client.example/x?evil=1",
+			}
+			for _, bid := range badIDs {
+				resp := authorizeHTTPResponse(t, root, ts, memberSession, authorizeRequest{
+					ClientID:            bid,
+					RedirectURI:         "https://client.example/callback",
+					Scope:               "openid",
+					State:               "state-" + uuid.NewString(),
+					CodeChallenge:       codeChallenge(strings.Repeat("1", 43)),
+					CodeChallengeMethod: "S256",
+				})
+				defer resp.Body.Close()
+				a.Equal(http.StatusBadRequest, resp.StatusCode, bid)
+			}
+		}))
+	}))
+}
+
+func TestOAuthCIMDRejectsBadMetadataDoc(t *testing.T) {
+	t.Parallel()
+
+	integration.Test(t, cimdConfig(t), e2e.Setup(), fx.Invoke(func(
+		lc fx.Lifecycle,
+		root context.Context,
+		sh *e2e.SessionHelper,
+		aw *account_writer.Writer,
+		assignments *role_assign.Assignment,
+		roles *role_repo.Repository,
+		ts *httptest.Server,
+	) {
+		lc.Append(fx.StartHook(func() {
+			a := assert.New(t)
+
+			memberCtx, member := e2e.WithAccount(root, aw, seed.Account_004_Loki)
+			grantOAuthClientUse(t, root, roles, assignments, member.ID, rbac.PermissionReadPublishedThreads)
+			memberSession := sh.WithSession(memberCtx)
+
+			// doc with forbidden auth method
+			cm := newCIMDMetadataServer(t)
+			cm.document["token_endpoint_auth_method"] = "client_secret_basic"
+
+			resp := authorizeHTTPResponse(t, root, ts, memberSession, authorizeRequest{
+				ClientID:            cm.clientID(),
+				RedirectURI:         "https://client.example/callback",
+				Scope:               "openid",
+				State:               "state-" + uuid.NewString(),
+				CodeChallenge:       codeChallenge(strings.Repeat("2", 43)),
+				CodeChallengeMethod: "S256",
+			})
+			defer resp.Body.Close()
+			a.Equal(http.StatusBadRequest, resp.StatusCode)
+
+			// doc with fragment in redirect
+			cm2 := newCIMDMetadataServer(t)
+			cm2.document["redirect_uris"] = []string{"https://client.example/cb#f"}
+
+			resp2 := authorizeHTTPResponse(t, root, ts, memberSession, authorizeRequest{
+				ClientID:            cm2.clientID(),
+				RedirectURI:         "https://client.example/cb#f",
+				Scope:               "openid",
+				State:               "state-" + uuid.NewString(),
+				CodeChallenge:       codeChallenge(strings.Repeat("3", 43)),
+				CodeChallengeMethod: "S256",
+			})
+			defer resp2.Body.Close()
+			a.Equal(http.StatusBadRequest, resp2.StatusCode)
+		}))
+	}))
+}


### PR DESCRIPTION
Advertise and accept OAuth Client ID Metadata Documents so MCP clients
such as ChatGPT's connector can identify themselves with an https URL
client_id instead of pre-registering.

- Advertise `client_id_metadata_document_supported: true` in both
  `.well-known/oauth-authorization-server` and `.well-known/openid-configuration`.
- Resolve a URL client_id during authorization: fetch the metadata
  document, validate it (client_id must equal its URL, redirect_uris
  present), and drive the existing auth-code + PKCE flow.
- Treat CIMD clients as public; require authorization code + PKCE (S256);
  issue refresh tokens only when the document and policy allow it.
- Enforce strict exact redirect URI matching and a conservative,
  configurable scope allowlist; reject unknown scopes and privileged/
  admin scopes unless explicitly enabled by server policy.
- Cache resolved metadata with TTLs (honouring Cache-Control max-age,
  capped at 1h) and invalidate on failure; persist only a stable URL
  reference plus cached metadata, never a generated secret.
- SSRF hardening for metadata fetches: HTTPS only, block private/loopback/
  link-local IPs (literal and resolved, DNS-rebinding safe), no redirects,
  JSON content type, timeout and max response size.
- New config: OAUTH_CIMD_ENABLED, OAUTH_CIMD_ALLOWED_SCOPES,
  OAUTH_CIMD_ALLOW_PRIVILEGED_SCOPES, OAUTH_CIMD_ALLOW_INSECURE_FETCH.
- Unit + e2e tests and docs covering user-defined clients, DCR and CIMD.

https://claude.ai/code/session_01QX4f3J2Y3gBk99aijzpdRA