### PR TITLE
Add background cleanup job for unused DCR clients

### DIFF
--- a/app/resources/oauth/oauth_writer/writer.go
+++ b/app/resources/oauth/oauth_writer/writer.go
@@ -411,6 +411,68 @@ func (w *Writer) ConsumeDeviceAuthorisation(ctx context.Context, id oauth.Device
 	return updated > 0, nil
 }
 
+func (w *Writer) DeleteUnusedDCRClients(ctx context.Context, before time.Time) (int, error) {
+	var deleted int
+
+	err := ent.WithTx(ctx, w.db, func(tx *ent.Tx) error {
+		ids, err := w.db.OAuthClient.Query().
+			Where(
+				oauthclient.AccountIDIsNil(),
+				oauthclient.ClientIDHasPrefix(oauth.OAuthAccessKeyPrefix),
+				oauthclient.CreatedAtLT(before),
+				oauthclient.Not(oauthclient.HasAuthorisationCodes()),
+				oauthclient.Not(oauthclient.HasRefreshTokens()),
+			).
+			IDs(ctx)
+		if err != nil {
+			return wrapWriteError(ctx, err)
+		}
+
+		if len(ids) == 0 {
+			return nil
+		}
+
+		if _, err := tx.OAuthAuthorisationCode.Delete().
+			Where(oauthauthorisationcode.ClientIDIn(ids...)).
+			Exec(ctx); err != nil {
+			return err
+		}
+
+		if _, err := tx.OAuthAuthorisationRequest.Delete().
+			Where(oauthauthorisationrequest.ClientIDIn(ids...)).
+			Exec(ctx); err != nil {
+			return err
+		}
+
+		if _, err := tx.OAuthDeviceAuthorisation.Delete().
+			Where(oauthdeviceauthorisation.ClientIDIn(ids...)).
+			Exec(ctx); err != nil {
+			return err
+		}
+
+		if _, err := tx.OAuthRefreshToken.Delete().
+			Where(oauthrefreshtoken.ClientIDIn(ids...)).
+			Exec(ctx); err != nil {
+			return err
+		}
+
+		n, err := tx.OAuthClient.Delete().
+			Where(oauthclient.IDIn(ids...)).
+			Exec(ctx)
+		if err != nil {
+			return err
+		}
+
+		deleted = n
+		return nil
+	})
+	if err != nil {
+		return 0, wrapWriteError(ctx, err)
+	}
+
+	return deleted, nil
+}
+
 func (w *Writer) DeleteExpiredDeviceAuthorisations(ctx context.Context, now time.Time) (int, error) {
 	deleted, err := w.db.OAuthDeviceAuthorisation.Delete().
 		Where(oauthdeviceauthorisation.ExpiresAtLT(now)).

--- a/app/services/authentication/oauth/oauth.go
+++ b/app/services/authentication/oauth/oauth.go
@@ -33,7 +33,8 @@ const (
 
 	StorydenCLIClientID = "storyden-cli"
 
-	cleanupInterval = time.Hour
+	cleanupInterval          = time.Hour
+	dcrClientRetentionPeriod = 7 * 24 * time.Hour
 )
 
 type Error struct {
@@ -167,7 +168,7 @@ func (s *Service) cleanupExpiredRecordsLoop(ctx context.Context, logger *slog.Lo
 func (s *Service) cleanupExpiredRecords(ctx context.Context, logger *slog.Logger) {
 	now := time.Now()
 
-	DeviceAuthorisations, err := s.tokens.DeleteExpiredDeviceAuthorisations(ctx, now)
+	deviceAuthorisations, err := s.tokens.DeleteExpiredDeviceAuthorisations(ctx, now)
 	if err != nil {
 		logger.Error("failed to clean expired oauth device authorizations", slog.Any("error", err))
 		return
@@ -179,11 +180,18 @@ func (s *Service) cleanupExpiredRecords(ctx context.Context, logger *slog.Logger
 		return
 	}
 
-	if DeviceAuthorisations > 0 || authorizationRequests > 0 {
+	unusedDCRClients, err := s.tokens.DeleteUnusedDCRClients(ctx, now.Add(-dcrClientRetentionPeriod))
+	if err != nil {
+		logger.Error("failed to clean unused dcr clients", slog.Any("error", err))
+		return
+	}
+
+	if deviceAuthorisations > 0 || authorizationRequests > 0 || unusedDCRClients > 0 {
 		logger.Debug(
 			"cleaned expired oauth records",
-			slog.Int("device_authorizations", DeviceAuthorisations),
+			slog.Int("device_authorizations", deviceAuthorisations),
 			slog.Int("authorization_requests", authorizationRequests),
+			slog.Int("unused_dcr_clients", unusedDCRClients),
 		)
 	}
 }


### PR DESCRIPTION
DCR clients registered but never finalised via the consent flow
(no authorisation codes and no refresh tokens) are now deleted by
the hourly cleanup job after a 7-day retention period.

https://claude.ai/code/session_012XWqUBbgHQHJsXUctaMYRq