### PR TITLE
feat: scoped canonical resolve redirect for datagraph items

### DIFF
--- a/app/resources/datagraph/canonical.go
+++ b/app/resources/datagraph/canonical.go
@@ -1,0 +1,47 @@
+package datagraph
+
+import (
+	"net/url"
+	"strings"
+
+	"github.com/Southclaws/storyden/app/resources/mark"
+)
+
+// CanonicalResolvePathPrefix is the frontend route prefix that vendors are
+// expected to implement in order to resolve a datagraph item to its canonical
+// UI location. The API never knows the concrete frontend route for a given
+// resource kind, so instead of emitting frontend paths directly it emits URLs
+// under this prefix which the frontend redirects to the correct page.
+const CanonicalResolvePathPrefix = "/_/resolve"
+
+// CanonicalResolvePath builds the frontend-relative path that resolves to the
+// given datagraph item. The frontend redirects this to the appropriate UI route
+// for the resource kind, for example "/_/resolve/thread/foo" -> "/t/foo".
+func CanonicalResolvePath(kind Kind, mark string) string {
+	return CanonicalResolvePathPrefix + "/" + kind.String() + "/" + mark
+}
+
+// CanonicalResolveURL builds an absolute URL to the frontend resolve route for
+// the given datagraph item, using the provided public web address as the base.
+// This is the URL safe to share in emails, MCP responses, CLI output, etc.
+func CanonicalResolveURL(webAddress url.URL, kind Kind, mark string) *url.URL {
+	u := webAddress
+	u.Path = strings.TrimRight(u.Path, "/") + CanonicalResolvePath(kind, mark)
+	return &u
+}
+
+// CanonicalResolvePath builds the frontend-relative path that resolves to the
+// given datagraph item. The frontend redirects this to the appropriate UI route
+// for the resource kind, for example "/_/resolve/thread/foo" -> "/t/foo".
+func CanonicalResolveMarkPath(kind Kind, mark mark.Mark) string {
+	return CanonicalResolvePathPrefix + "/" + kind.String() + "/" + mark.String()
+}
+
+// CanonicalResolveURL builds an absolute URL to the frontend resolve route for
+// the given datagraph item, using the provided public web address as the base.
+// This is the URL safe to share in emails, MCP responses, CLI output, etc.
+func CanonicalResolveMarkURL(webAddress url.URL, kind Kind, mark mark.Mark) *url.URL {
+	u := webAddress
+	u.Path = strings.TrimRight(u.Path, "/") + CanonicalResolveMarkPath(kind, mark)
+	return &u
+}

--- a/app/resources/datagraph/canonical_test.go
+++ b/app/resources/datagraph/canonical_test.go
@@ -1,0 +1,44 @@
+package datagraph
+
+import (
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCanonicalResolvePath(t *testing.T) {
+	assert.Equal(t, "/_/resolve/thread/my-thread-abc123", CanonicalResolvePath(KindThread, "my-thread-abc123"))
+	assert.Equal(t, "/_/resolve/profile/southclaws", CanonicalResolvePath(KindProfile, "southclaws"))
+	assert.Equal(t, "/_/resolve/reply/cabcdef0123456789", CanonicalResolvePath(KindReply, "cabcdef0123456789"))
+}
+
+func TestCanonicalResolveURL(t *testing.T) {
+	t.Run("root path", func(t *testing.T) {
+		web, err := url.Parse("https://example.com")
+		require.NoError(t, err)
+		assert.Equal(t,
+			"https://example.com/_/resolve/thread/my-thread-abc123",
+			CanonicalResolveURL(*web, KindThread, "my-thread-abc123").String(),
+		)
+	})
+
+	t.Run("base path with trailing slash", func(t *testing.T) {
+		web, err := url.Parse("https://example.com/community/")
+		require.NoError(t, err)
+		assert.Equal(t,
+			"https://example.com/community/_/resolve/node/handbook",
+			CanonicalResolveURL(*web, KindNode, "handbook").String(),
+		)
+	})
+
+	t.Run("escapes the identifier", func(t *testing.T) {
+		web, err := url.Parse("https://example.com")
+		require.NoError(t, err)
+		assert.Equal(t,
+			"https://example.com/_/resolve/profile/with%20space",
+			CanonicalResolveURL(*web, KindProfile, "with space").String(),
+		)
+	})
+}

--- a/home/content/docs/introduction/frontend/index.mdx
+++ b/home/content/docs/introduction/frontend/index.mdx
@@ -1,0 +1,31 @@
+---
+title: Frontend
+description: Build your own frontend against the Storyden API. Its kinda like a CMS without a head.
+---
+
+Storyden is [API-driven](/docs/introduction/api), so you can build an entirely custom frontend for the web, mobile or embed it into existing software.
+
+You can get started by generating an API client from the [OpenAPI specification](https://github.com/Southclaws/storyden/blob/main/api/openapi.yaml) in your chosen language. For TypeScript, we recommend using [Orval](https://orval.dev/).
+
+There are some examples on the Storyden GitHub page for different languages and the setup shape for your project: https://github.com/storyden
+
+It's roughly:
+
+- Run Storyden locally in a container or on your computer
+  - Use the full-stack variant for development so you can still use Storyden's frontend to edit data.
+- Generate an API client from the OpenAPI spec
+- Build your frontend against `localhost:8000/api`
+- For production, either:
+  - deploy two separate containers: one running purely Storyden's headless image and the other running your frontend;
+  - or, build them into the same Docker image
+
+<Callout type="info">
+  Storyden *can* run a frontend itself (it acts as the process manager) however
+  this feature is not yet ready for non-Next.js or non-JavaScript based
+  frontends. This will change in future though!
+
+(it's also undocumented...)
+
+</Callout>
+
+<Callout type="warn">This documentation is incomplete.</Callout>

--- a/home/content/docs/introduction/frontend/resolve.mdx
+++ b/home/content/docs/introduction/frontend/resolve.mdx
@@ -1,0 +1,59 @@
+---
+title: Routing and Resources
+description: How the API and frontend work together to point users at the right pages.
+---
+
+The API is deliberately decoupled from any particular frontend's route structure: it can tell you the ID, slug and [kind](/docs/introduction/datagraph) of a resource, but it will never hand you a fully-formed URL to a page, because it cannot know how the frontend lays out its routes.
+
+This is especially important if you implement your own frontend!
+
+### The resolve route
+
+There are still cases where the API needs to point a human (or an agent) at the canonical UI representation of a resource: notification emails, MCP tool responses, CLI output and so on. To keep the API frontend-agnostic while still supporting this, Storyden defines a single scoped redirect convention that every frontend is expected to implement:
+
+```
+
+/_/resolve/<datagraph kind>/<id or slug>
+
+```
+
+When the API needs to emit a canonical link it builds a URL under this prefix
+using the [public web address](/docs/introduction/vps). The frontend implements
+`/_/resolve/...` as a route that inspects the datagraph kind and the
+[mark](/docs/introduction/marks) and redirects the visitor to the correct page.
+
+For example, a link to a thread is emitted as:
+
+```
+
+https://example.com/_/resolve/thread/crk0h7afunp7891n7cg0-very-demure
+
+```
+
+and the reference frontend redirects this to `/t/crk0h7afunp7891n7cg0-very-demure`.
+
+## Mapping
+
+The reference frontend maps each datagraph kind to a route as follows. A custom
+frontend is free to use different routes, but it must implement `/_/resolve` so
+that links emitted by the API continue to work.
+
+| Kind         | Redirect target      |
+| ------------ | -------------------- |
+| `post`       | `/t/locate/<slug>`\* |
+| `thread`     | `/t/<slug>`          |
+| `reply`      | `/t/locate/<id>`     |
+| `node`       | `/l/<slug>`          |
+| `collection` | `/c/<slug>`          |
+| `profile`    | `/m/<handle>`        |
+
+<Callout type="info">
+  \* The `post` kind is used for either threads or replies, in cases where the
+  API doesn't know which. In these cases, the frontend should call the
+  [`PostLocationGet`](/docs/api/posts/PostLocationGet) endpoint. This will tell
+  you if the post is a thread or a reply, and if it's a reply it'll give you the
+  parent thread's slug and even tell you which page it's on!
+</Callout>
+
+Any query parameters on the resolve URL are forwarded to the redirect target.
+Kinds the frontend does not have a page for should respond with a not-found.

--- a/home/content/docs/introduction/meta.json
+++ b/home/content/docs/introduction/meta.json
@@ -27,6 +27,6 @@
         "api",
         "oauth",
         "plugins",
-        "custom-frontend"
+        "frontend"
     ]
 }

--- a/web/src/app/%5F/resolve/[kind]/[mark]/page.tsx
+++ b/web/src/app/%5F/resolve/[kind]/[mark]/page.tsx
@@ -1,0 +1,56 @@
+import { notFound, redirect } from "next/navigation";
+
+import { DatagraphItemKind } from "@/api/openapi-schema";
+import { WEB_ADDRESS } from "@/config";
+
+export type Props = {
+  params: Promise<{
+    kind: string;
+    mark: string;
+  }>;
+  searchParams: Promise<{
+    [key: string]: string | string[] | undefined;
+  }>;
+};
+
+function resolvePath(kind: string, mark: string): string | undefined {
+  switch (kind) {
+    case DatagraphItemKind.post:
+      return `/t/locate/${mark}`;
+    case DatagraphItemKind.thread:
+      return `/t/${mark}`;
+    case DatagraphItemKind.reply:
+      return `/t/locate/${mark}`;
+    case DatagraphItemKind.node:
+      return `/l/${mark}`;
+    case DatagraphItemKind.collection:
+      return `/c/${mark}`;
+    case DatagraphItemKind.profile:
+      return `/m/${mark}`;
+    default:
+      return undefined;
+  }
+}
+
+export default async function Page(props: Props) {
+  const { kind, mark } = await props.params;
+  const searchParams = await props.searchParams;
+
+  const path = resolvePath(kind, mark);
+  if (!path) {
+    notFound();
+  }
+
+  const url = new URL(path, WEB_ADDRESS);
+
+  Object.entries(searchParams).forEach(([key, value]) => {
+    if (value === undefined) return;
+    if (typeof value === "string") {
+      url.searchParams.set(key, value);
+    } else if (Array.isArray(value)) {
+      value.forEach((v) => url.searchParams.append(key, v));
+    }
+  });
+
+  redirect(url.toString(), "replace");
+}


### PR DESCRIPTION
Adds a frontend-agnostic mechanism for the API to emit canonical links to
datagraph resources without depending on any particular frontend's route
structure.

- API: CanonicalResolvePath/CanonicalResolveURL helpers that build URLs
  under the /_/resolve/<kind>/<id-or-slug> convention from the public web
  address.
- Frontend: /_/resolve/[kind]/[idOrSlug] route that redirects to the
  correct page per datagraph kind, forwarding query parameters.
- Docs: custom-frontend page documenting the convention for vendors.

https://claude.ai/code/session_01SyEuXDnjr4JNQJobkqEYYD