### PR TITLE
revoke refresh-token family on reuse

### DIFF
--- a/app/services/authentication/oauth/token.go
+++ b/app/services/authentication/oauth/token.go
@@ -182,7 +182,20 @@ func (s *Service) exchangeRefreshToken(ctx context.Context, input TokenRequest) 
 	}
 
 	rec, err := s.clients.GetRefreshTokenByTokenHash(ctx, hashString(refreshToken))
-	if err != nil || rec.ClientID != cl.ID || rec.ExpiresAt.Before(time.Now()) || rec.RevokedAt.Ok() {
+	if err != nil || rec.ClientID != cl.ID || rec.ExpiresAt.Before(time.Now()) {
+		return nil, oauthError("invalid_grant", "Refresh token is invalid, expired, or revoked"), nil
+	}
+	if rec.RevokedAt.Ok() {
+		// RFC 9700 §4.14.2: presenting a refresh token that was already rotated
+		// (was invalidated by rotation) signals theft of a token from rotation
+		// family. Revoke every descendant so the currently-active token is
+		// invalidated too. A token revoked without a replacement (e.g. an admin
+		// or self revocation) has no family to cascade and is simply rejected.
+		if rec.ReplacedByTokenID.Ok() {
+			if err := s.revokeRefreshTokenFamily(ctx, rec); err != nil {
+				return nil, nil, err
+			}
+		}
 		return nil, oauthError("invalid_grant", "Refresh token is invalid, expired, or revoked"), nil
 	}
 
@@ -216,6 +229,36 @@ func (s *Service) exchangeRefreshToken(ctx context.Context, input TokenRequest) 
 	}
 
 	return token, nil, nil
+}
+
+// revokeRefreshTokenFamily walks the rotation chain forward from a reused token,
+// revoking every descendant so the currently-active token is neutralised. The
+// visited set guards against cycles in malformed data.
+// NOTE: A bit heavy on reads here, could be done with a CTE.
+func (s *Service) revokeRefreshTokenFamily(ctx context.Context, reused *oauthresource.RefreshToken) error {
+	now := time.Now()
+	visited := map[oauthresource.RefreshTokenID]struct{}{reused.ID: {}}
+
+	nextID, ok := reused.ReplacedByTokenID.Get()
+	for ok {
+		if _, seen := visited[nextID]; seen {
+			break
+		}
+		visited[nextID] = struct{}{}
+
+		if _, err := s.tokens.RevokeRefreshToken(ctx, nextID, now, opt.NewEmpty[oauthresource.RefreshTokenID]()); err != nil {
+			return fault.Wrap(err, fctx.With(ctx))
+		}
+
+		next, err := s.clients.GetRefreshToken(ctx, nextID)
+		if err != nil {
+			return fault.Wrap(err, fctx.With(ctx))
+		}
+
+		nextID, ok = next.ReplacedByTokenID.Get()
+	}
+
+	return nil
 }
 
 func (s *Service) accountPermissions(ctx context.Context, accountID account.AccountID) (rbac.Permissions, error) {

--- a/tests/oauth/refresh_token_reuse_test.go
+++ b/tests/oauth/refresh_token_reuse_test.go
@@ -1,0 +1,106 @@
+package oauth_test
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"github.com/Southclaws/opt"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/fx"
+
+	"github.com/Southclaws/storyden/app/resources/account/account_writer"
+	oauthresource "github.com/Southclaws/storyden/app/resources/oauth"
+	"github.com/Southclaws/storyden/app/resources/oauth/oauth_writer"
+	"github.com/Southclaws/storyden/app/resources/seed"
+	"github.com/Southclaws/storyden/app/transports/http/openapi"
+	"github.com/Southclaws/storyden/internal/integration"
+	"github.com/Southclaws/storyden/internal/integration/e2e"
+	"github.com/Southclaws/storyden/tests"
+)
+
+func TestOAuthRefreshTokenReuseRevokesFamily(t *testing.T) {
+	t.Parallel()
+
+	integration.Test(t, oauthConfig(t), e2e.Setup(), fx.Invoke(func(
+		lc fx.Lifecycle,
+		root context.Context,
+		cl *openapi.ClientWithResponses,
+		sh *e2e.SessionHelper,
+		aw *account_writer.Writer,
+		ow *oauth_writer.Writer,
+	) {
+		lc.Append(fx.StartHook(func() {
+			r := require.New(t)
+			a := assert.New(t)
+
+			adminCtx, admin := e2e.WithAccount(root, aw, seed.Account_001_Odin)
+			adminSession := sh.WithSession(adminCtx)
+
+			clientID := "refresh-reuse-" + uuid.NewString()
+			createClient(t, root, ow, admin.ID, clientID, oauthresource.ClientTypePublic, oauthresource.ScopePolicyInheritUserPermissions, opt.NewEmpty[string](), standardScopes(), []string{oauthGrantDeviceCode, oauthGrantRefreshToken})
+
+			r1 := mintRefreshTokenViaDeviceFlow(t, root, cl, adminSession, clientID)
+
+			// Rotate r1 -> r2. r1 is now consumed and has r2 as its replacement.
+			rotate := tests.AssertRequest(oauthToken(t, root, cl, oauthTokenRequest{
+				GrantType:    oauthGrantRefreshToken,
+				ClientId:     clientID,
+				RefreshToken: &r1,
+			}))(t, http.StatusOK)
+			r.NotNil(rotate.JSON200)
+			r.NotNil(rotate.JSON200.RefreshToken)
+			r2 := *rotate.JSON200.RefreshToken
+
+			// Reuse the already-rotated r1: this is the theft signal.
+			reuse := tests.AssertRequest(oauthToken(t, root, cl, oauthTokenRequest{
+				GrantType:    oauthGrantRefreshToken,
+				ClientId:     clientID,
+				RefreshToken: &r1,
+			}))(t, http.StatusBadRequest)
+			r.NotNil(reuse.JSON400)
+			a.Equal("invalid_grant", reuse.JSON400.Error)
+
+			// The active descendant r2 must now be revoked as part of the family.
+			cascaded := tests.AssertRequest(oauthToken(t, root, cl, oauthTokenRequest{
+				GrantType:    oauthGrantRefreshToken,
+				ClientId:     clientID,
+				RefreshToken: &r2,
+			}))(t, http.StatusBadRequest)
+			r.NotNil(cascaded.JSON400)
+			a.Equal("invalid_grant", cascaded.JSON400.Error)
+		}))
+	}))
+}
+
+func mintRefreshTokenViaDeviceFlow(t *testing.T, ctx context.Context, cl *openapi.ClientWithResponses, session openapi.RequestEditorFn, clientID string) string {
+	t.Helper()
+	r := require.New(t)
+
+	start := tests.AssertRequest(cl.OAuthDeviceAuthorisationWithFormdataBodyWithResponse(ctx, openapi.OAuthDeviceAuthorisationFormdataRequestBody{
+		ClientId: clientID,
+		Scope:    ptr("openid profile offline_access"),
+	}))(t, http.StatusOK)
+	r.NotNil(start.JSON200)
+
+	tests.AssertRequest(cl.OAuthDeviceConsentWithResponse(ctx, &openapi.OAuthDeviceConsentParams{
+		UserCode: start.JSON200.UserCode,
+	}, session))(t, http.StatusOK)
+
+	tests.AssertRequest(cl.OAuthDeviceConsentSubmitWithResponse(ctx, openapi.OAuthDeviceConsentSubmitJSONRequestBody{
+		UserCode: *start.JSON200.UserCode,
+		Decision: openapi.OAuthDeviceDecisionApprove,
+	}, session))(t, http.StatusOK)
+
+	token := tests.AssertRequest(oauthToken(t, ctx, cl, oauthTokenRequest{
+		GrantType:  oauthGrantDeviceCode,
+		ClientId:   clientID,
+		DeviceCode: start.JSON200.DeviceCode,
+	}))(t, http.StatusOK)
+	r.NotNil(token.JSON200)
+	r.NotNil(token.JSON200.RefreshToken)
+
+	return *token.JSON200.RefreshToken
+}


### PR DESCRIPTION
RFC 9700 §4.14.2

When a revoked refresh token that still carries a ReplacedByTokenID is presented (a reuse/theft signal), walk the replacement chain and revoke every descendant including the active tail. Tokens revoked without a replacement (admin/self revocation) are rejected as before.