### PR TITLE
fix delete role

### DIFF
--- a/web/src/components/role/RoleEdit/useRoleEdit.ts
+++ b/web/src/components/role/RoleEdit/useRoleEdit.ts
@@ -77,6 +77,7 @@ export function useRoleEditScreen({ role, onSave }: Props) {
     await handle(
       async () => {
         await roleDelete(role.id);
+        onSave?.();
       },
       {
         promiseToast: {
@@ -94,6 +95,7 @@ export function useRoleEditScreen({ role, onSave }: Props) {
     await handle(
       async () => {
         await roleDelete(role.id);
+        onSave?.();
       },
       {
         promiseToast: {


### PR DESCRIPTION
Fix an issue where, when an admin creates a role and then immediately deletes it, the role edit menu does not close automatically