### PR TITLE
Upgrade Go version to 1.26.4

### DIFF
--- a/.github/workflows/test-application.yml
+++ b/.github/workflows/test-application.yml
@@ -23,7 +23,7 @@ jobs:
 
       - uses: actions/setup-go@v6
         with:
-          go-version: "1.25"
+          go-version: "1.26.4"
           cache: true
           cache-dependency-path: "**/go.sum"
 

--- a/.github/workflows/test-backend.yml
+++ b/.github/workflows/test-backend.yml
@@ -44,7 +44,7 @@ jobs:
       - uses: actions/checkout@v5
       - uses: actions/setup-go@v6
         with:
-          go-version: "1.25"
+          go-version: "1.26.4"
           cache: true
           cache-dependency-path: "**/go.sum"
 
@@ -57,7 +57,7 @@ jobs:
       - uses: actions/checkout@v5
       - uses: actions/setup-go@v6
         with:
-          go-version: "1.25"
+          go-version: "1.26.4"
           cache: true
           cache-dependency-path: "**/go.sum"
       - run: go run ./cmd/migrate
@@ -71,7 +71,7 @@ jobs:
       - uses: actions/checkout@v5
       - uses: actions/setup-go@v6
         with:
-          go-version: "1.25"
+          go-version: "1.26.4"
           cache: true
           cache-dependency-path: "**/go.sum"
       - run: go run ./cmd/migrate

--- a/docker/all/Dockerfile
+++ b/docker/all/Dockerfile
@@ -2,7 +2,7 @@
 # BACKEND API LAYER
 #
 
-FROM docker.io/golang:1.25-alpine AS api-builder
+FROM docker.io/golang:1.26.4-alpine AS api-builder
 
 WORKDIR /server
 

--- a/docker/api/Dockerfile
+++ b/docker/api/Dockerfile
@@ -2,7 +2,7 @@
 # BACKEND API LAYER
 #
 
-FROM golang:1.25-alpine AS api-builder
+FROM golang:1.26.4-alpine AS api-builder
 
 WORKDIR /build
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/Southclaws/storyden
 
-go 1.25.8
+go 1.26.4
 
 tool (
 	entgo.io/ent/cmd/ent


### PR DESCRIPTION
## Summary

Updates the Go version across the project from 1.25 to 1.26.4 to leverage the latest language features, performance improvements, and security patches.

## Changes

- Updated `go.mod` to specify Go 1.26.4
- Updated GitHub Actions workflows (`test-backend.yml` and `test-application.yml`) to use Go 1.26.4
- Updated Docker build images (`docker/all/Dockerfile` and `docker/api/Dockerfile`) to use the `golang:1.26.4-alpine` base image

## Notes

This is a minor version upgrade that ensures consistency across local development, CI/CD pipelines, and containerized deployments. All build and test infrastructure now targets the same Go version.

https://claude.ai/code/session_01NDfvuGe3zPZwnFqnMyc4KQ