### PR TITLE
fix: hide non-published collection items from non-owners

### DIFF
--- a/app/services/collection/collection_read/reader.go
+++ b/app/services/collection/collection_read/reader.go
@@ -69,9 +69,11 @@ func (r *Hydrator) GetCollection(ctx context.Context, qk collection.QueryKey) (*
 		// TODO: Apply to posts as well, but this needs some more work on post
 		// data structure sharing and exposing visibility of the thread properly
 
-		if vis == visibility.VisibilityDraft || i.MembershipType == collection.MembershipTypeSubmissionReview {
-			// Don't reveal draft collection items unless the requesting account
-			// is either the owner of the collection or the owner of the item.
+		if vis != visibility.VisibilityPublished || i.MembershipType == collection.MembershipTypeSubmissionReview {
+			// Don't reveal non-published collection items (drafts, unlisted or
+			// in-review nodes) unless the requesting account is either the owner
+			// of the collection or the owner of the item. This mirrors the
+			// canonical library visibility rule applied in node_querier.
 			return accountOwnsItem
 		}
 


### PR DESCRIPTION
## Problem

Collection item visibility filtering in `collection_read/reader.go` only hid `Draft` nodes from non-owners. Nodes with visibility `Unlisted` (link-only) or `Review` (pending moderation) were leaked to **any** viewer who could read the collection, including unauthenticated guests.

This contradicts the canonical library visibility rule enforced in `node_querier` (`applyVisibilityRulesPredicate`): published nodes are visible to everyone, non-published nodes only to their owner (and privileged roles). A user could surface their own unlisted/in-review content publicly by adding it to a readable collection, bypassing moderation gating an information disclosure issue.

## Fix

Hide any collection item whose visibility is not `Published` from non-owners.

- Collection owners and administrators are unaffected they bypass the filter via `canReadUnlisted`.
- Posts are unaffected — they have no visibility field yet and are hardcoded to `Published`.

## Verification

Reproduced with an end-to-end test (a guest and an unrelated logged-in account could see an owner's unlisted and review nodes added to a collection) and confirmed the fix hides them while keeping published items and owner access intact. `./tests/collection/` passes; `go build`/`go vet` clean.