### PR TITLE
fix: enforce account suspension on permission-free operations

### DIFF
--- a/app/transports/http/bindings/authorisation_validator.go
+++ b/app/transports/http/bindings/authorisation_validator.go
@@ -56,7 +56,17 @@ func (i *Authorisation) validator(oapictx context.Context, ai *openapi3filter.Au
 
 	sessionRequired, perm := GetPermissionForOperation(op)
 	if perm == nil {
-		// No specific permission required, just need a session.
+		// No specific permission required, just need a session. Suspension must
+		// still be enforced here otherwise suspended accounts could perform any
+		// operation that maps to no specific permission (creating content,
+		// updating their account, authorising OAuth clients, etc.)
+		if sessionRequired {
+			if acc, ok := session.GetOptAccount(ctx).Get(); ok {
+				if err := acc.RejectSuspended(); err != nil {
+					return fault.Wrap(err, fctx.With(ctx))
+				}
+			}
+		}
 		return nil
 	}
 


### PR DESCRIPTION
## Problem

The authorisation validator returns early when an operation maps to no specific permission, before the RejectSuspended check. Since suspending an account only sets DeletedAt and does not revoke sessions or tokens, suspended accounts can still perform session-required operations that carry no specific permission, such as creating or editing content, updating their account, and authorising OAuth clients.

## Fix

Enforce RejectSuspended in the perm == nil branch for session-required operations. Public operations and unauthenticated guests are unaffected.

## Verification

End-to-end tested: a suspended member calling AccountUpdate gets 200 before the fix and 403 after, with the admin, account, library, thread and collection suites still passing.