### PR TITLE
fix: scope single notification update to the requesting account

### DIFF
--- a/app/resources/account/notification/notify_writer/writer.go
+++ b/app/resources/account/notification/notify_writer/writer.go
@@ -73,8 +73,9 @@ func (n *Writer) Notification(ctx context.Context,
 	return nr, nil
 }
 
-func (n *Writer) SetRead(ctx context.Context, id xid.ID, read bool) (*notification.NotificationRef, error) {
+func (n *Writer) SetRead(ctx context.Context, accountID account.AccountID, id xid.ID, read bool) (*notification.NotificationRef, error) {
 	r, err := n.db.Notification.UpdateOneID(id).
+		Where(entnotification.HasOwnerWith(entaccount.ID(xid.ID(accountID)))).
 		SetRead(read).
 		Save(ctx)
 	if err != nil {

--- a/app/transports/http/bindings/notifications.go
+++ b/app/transports/http/bindings/notifications.go
@@ -56,7 +56,7 @@ func (h *Notifications) NotificationList(ctx context.Context, request openapi.No
 }
 
 func (h *Notifications) NotificationUpdate(ctx context.Context, request openapi.NotificationUpdateRequestObject) (openapi.NotificationUpdateResponseObject, error) {
-	_, err := session.GetAccountID(ctx)
+	accountID, err := session.GetAccountID(ctx)
 	if err != nil {
 		return nil, fault.Wrap(err, fctx.With(ctx))
 	}
@@ -69,7 +69,7 @@ func (h *Notifications) NotificationUpdate(ctx context.Context, request openapi.
 
 	status := opt.Map(opt.NewPtr(request.Body.Status), deserialiseNotificationStatus)
 
-	n, err := h.notifyWriter.SetRead(ctx, id, status.OrZero())
+	n, err := h.notifyWriter.SetRead(ctx, accountID, id, status.OrZero())
 	if err != nil {
 		return nil, fault.Wrap(err, fctx.With(ctx))
 	}


### PR DESCRIPTION
## Problem

`NotificationUpdate` resolves the session account only to confirm the caller is authenticated, then calls `SetRead` by notification ID with no owner scoping. Any authenticated account could mark another account's notification as read or unread, and the response returned that notification's details — a cross-account tamper and read (IDOR).

## Fix

Scope `SetRead` to the requesting account with `HasOwnerWith`, matching the existing `UpdateStatusMany` path. Updating a notification owned by another account now returns not-found.

## Verification

End-to-end tested: one account creating a notification for itself, then a second account calling `NotificationUpdate` with that notification's ID, is now rejected and the notification stays unread. The existing notification suite still passes.