### PR TITLE
Serve integrations.sh discovery documents

### DIFF
--- a/app/transports/http/bindings/bindings.go
+++ b/app/transports/http/bindings/bindings.go
@@ -281,6 +281,12 @@ func mount(
 		return c.JSON(http.StatusOK, doc)
 	})
 
+	router.GET("/.well-known/integrations.json", func(c echo.Context) error {
+		c.Response().Header().Set("Cache-Control", "public, max-age=3600")
+
+		return c.JSON(http.StatusOK, buildIntegrationsDocument(cfg, oauthBinding))
+	})
+
 	// RFC 6750 §3 / RFC 9728 §5.1: bearer-protected OAuth resources must answer
 	// 401s with a WWW-Authenticate challenge pointing clients at the protected
 	// resource metadata document for discovery.

--- a/app/transports/http/bindings/integrations.go
+++ b/app/transports/http/bindings/integrations.go
@@ -1,0 +1,173 @@
+package bindings
+
+import (
+	"strings"
+
+	"github.com/Southclaws/storyden/internal/config"
+)
+
+// This file implements the integrations.sh discovery document, a static
+// description of this instance's remote-accessible surfaces (REST API, MCP
+// server, etc.) and how an agent authenticates against them.
+//
+// See: https://integrations.sh
+
+type integrationsDocument struct {
+	Version     int                               `json:"version"`
+	Summary     string                            `json:"summary,omitempty"`
+	Credentials map[string]integrationsCredential `json:"credentials,omitempty"`
+	Surfaces    []integrationsSurface             `json:"surfaces,omitempty"`
+}
+
+type integrationsCredential struct {
+	Type        string `json:"type"`
+	Label       string `json:"label"`
+	GenerateURL string `json:"generateUrl,omitempty"`
+	Setup       string `json:"setup"`
+}
+
+type integrationsBasis struct {
+	Via    string `json:"via"`
+	Source string `json:"source"`
+}
+
+type integrationsMechanics struct {
+	Source     string `json:"source"`
+	In         string `json:"in,omitempty"`
+	HeaderName string `json:"headerName,omitempty"`
+	Scheme     string `json:"scheme,omitempty"`
+	ParamName  string `json:"paramName,omitempty"`
+}
+
+type integrationsAuthUse struct {
+	ID        string                `json:"id"`
+	Mechanics integrationsMechanics `json:"mechanics"`
+}
+
+type integrationsAuthEntry struct {
+	Use   []integrationsAuthUse `json:"use"`
+	Basis integrationsBasis     `json:"basis"`
+}
+
+type integrationsAuthStatus struct {
+	Status  string                  `json:"status"`
+	Basis   *integrationsBasis      `json:"basis,omitempty"`
+	Entries []integrationsAuthEntry `json:"entries,omitempty"`
+}
+
+type integrationsSurface struct {
+	Slug       string                 `json:"slug"`
+	Name       string                 `json:"name"`
+	Type       string                 `json:"type"`
+	Docs       string                 `json:"docs,omitempty"`
+	Basis      integrationsBasis      `json:"basis"`
+	Auth       integrationsAuthStatus `json:"auth"`
+	Spec       string                 `json:"spec,omitempty"`
+	URL        string                 `json:"url,omitempty"`
+	Transports []string               `json:"transports,omitempty"`
+}
+
+const (
+	accessKeyCredentialID = "storyden_access_key"
+	oauthCredentialID     = "storyden_oauth"
+)
+
+func buildIntegrationsDocument(cfg config.Config, oauthBinding OAuth) integrationsDocument {
+	selfURL := trimSlash(cfg.PublicWebAddress.String()) + "/.well-known/integrations.json"
+	basis := integrationsBasis{Via: "declared", Source: selfURL}
+	apiBase := trimSlash(cfg.PublicAPIAddress.String())
+	webBase := trimSlash(cfg.PublicWebAddress.String())
+
+	credentials := map[string]integrationsCredential{
+		accessKeyCredentialID: {
+			Type:        "bearer",
+			Label:       "Storyden access key",
+			GenerateURL: webBase + "/settings",
+			Setup: "Sign in to your Storyden account, open Settings -> Access Keys and create a " +
+				"new key (requires the `USE_PERSONAL_ACCESS_KEYS` permission, granted automatically " +
+				"to administrators). Copy the secret immediately, it is only ever shown once.",
+		},
+	}
+
+	accessKeyEntry := integrationsAuthEntry{
+		Use: []integrationsAuthUse{{
+			ID: accessKeyCredentialID,
+			Mechanics: integrationsMechanics{
+				Source:     "http",
+				In:         "header",
+				HeaderName: "Authorization",
+				Scheme:     "Bearer",
+			},
+		}},
+		Basis: basis,
+	}
+
+	apiAuthEntries := []integrationsAuthEntry{accessKeyEntry}
+
+	if oauthBinding.oauth.Enabled() {
+		credentials[oauthCredentialID] = integrationsCredential{
+			Type:        "oauth2",
+			Label:       "Storyden OAuth 2.0",
+			GenerateURL: trimSlash(oauthBinding.Issuer()) + "/.well-known/oauth-authorization-server",
+			Setup: "Storyden runs a standard OAuth 2.0 / OpenID Connect authorisation server. " +
+				"Register a client (or use Dynamic Client Registration / a Client ID Metadata " +
+				"Document) and run the authorization_code or device_code grant to obtain a " +
+				"member-scoped bearer token. See /docs/introduction/oauth for details.",
+		}
+
+		apiAuthEntries = append(apiAuthEntries, integrationsAuthEntry{
+			Use: []integrationsAuthUse{{
+				ID: oauthCredentialID,
+				Mechanics: integrationsMechanics{
+					Source: "spec",
+					Scheme: "oauth_token",
+				},
+			}},
+			Basis: basis,
+		})
+	}
+
+	surfaces := []integrationsSurface{
+		{
+			Slug:  "storyden-api",
+			Name:  "Storyden REST API",
+			Type:  "http",
+			Docs:  apiBase + "/api/docs",
+			Basis: basis,
+			Auth: integrationsAuthStatus{
+				Status:  "required",
+				Entries: apiAuthEntries,
+			},
+			Spec: apiBase + "/api/openapi.json",
+			URL:  apiBase + "/api",
+		},
+	}
+
+	if cfg.MCPEnabled {
+		surfaces = append(surfaces, integrationsSurface{
+			Slug:  "storyden-mcp",
+			Name:  "Storyden MCP Server",
+			Type:  "mcp",
+			Docs:  "https://storyden.org/docs/introduction/mcp",
+			Basis: basis,
+			Auth: integrationsAuthStatus{
+				Status:  "required",
+				Entries: []integrationsAuthEntry{accessKeyEntry},
+			},
+			URL:        webBase + "/mcp",
+			Transports: []string{"streamable-http"},
+		})
+	}
+
+	return integrationsDocument{
+		Version: 3,
+		Summary: "Storyden is a self-hosted forum, wiki and community hub. This instance exposes " +
+			"a REST API and, when enabled, an MCP server for agent-driven content creation and search.",
+		Credentials: credentials,
+		Surfaces:    surfaces,
+	}
+}
+
+func trimSlash(s string) string {
+	return strings.TrimSuffix(s, "/")
+}

--- a/app/transports/http/bindings/integrations.go
+++ b/app/transports/http/bindings/integrations.go
@@ -154,7 +154,7 @@ func buildIntegrationsDocument(cfg config.Config, oauthBinding OAuth) integratio
 				Status:  "required",
 				Entries: []integrationsAuthEntry{accessKeyEntry},
 			},
-			URL:        webBase + "/mcp",
+			URL:        apiBase + "/mcp",
 			Transports: []string{"streamable-http"},
 		})
 	}

--- a/app/transports/http/bindings/integrations_test.go
+++ b/app/transports/http/bindings/integrations_test.go
@@ -1,0 +1,83 @@
+package bindings
+
+import (
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	oauthservice "github.com/Southclaws/storyden/app/services/authentication/oauth"
+	"github.com/Southclaws/storyden/internal/config"
+)
+
+func mustParseURL(t *testing.T, raw string) url.URL {
+	t.Helper()
+
+	u, err := url.Parse(raw)
+	require.NoError(t, err)
+
+	return *u
+}
+
+func TestBuildIntegrationsDocumentMCPDisabled(t *testing.T) {
+	t.Parallel()
+
+	cfg := config.Config{
+		PublicAPIAddress: mustParseURL(t, "https://example.com"),
+		PublicWebAddress: mustParseURL(t, "https://example.com"),
+		MCPEnabled:       false,
+	}
+	oauthBinding := OAuth{oauth: &oauthservice.Service{}}
+
+	doc := buildIntegrationsDocument(cfg, oauthBinding)
+
+	assert.Equal(t, 3, doc.Version)
+	require.Len(t, doc.Surfaces, 1)
+
+	api := doc.Surfaces[0]
+	assert.Equal(t, "storyden-api", api.Slug)
+	assert.Equal(t, "http", api.Type)
+	assert.Equal(t, "https://example.com/api", api.URL)
+	assert.Equal(t, "https://example.com/api/openapi.json", api.Spec)
+	assert.Equal(t, "https://example.com/api/docs", api.Docs)
+	assert.Equal(t, "https://example.com/.well-known/integrations.json", api.Basis.Source)
+
+	require.Equal(t, "required", api.Auth.Status)
+	require.Len(t, api.Auth.Entries, 1)
+	use := api.Auth.Entries[0].Use[0]
+	assert.Equal(t, accessKeyCredentialID, use.ID)
+	assert.Equal(t, "http", use.Mechanics.Source)
+	assert.Equal(t, "header", use.Mechanics.In)
+	assert.Equal(t, "Authorization", use.Mechanics.HeaderName)
+	assert.Equal(t, "Bearer", use.Mechanics.Scheme)
+
+	require.Contains(t, doc.Credentials, accessKeyCredentialID)
+	assert.NotContains(t, doc.Credentials, oauthCredentialID)
+}
+
+func TestBuildIntegrationsDocumentMCPEnabled(t *testing.T) {
+	t.Parallel()
+
+	cfg := config.Config{
+		PublicAPIAddress: mustParseURL(t, "https://example.com"),
+		PublicWebAddress: mustParseURL(t, "https://example.com"),
+		MCPEnabled:       true,
+	}
+	oauthBinding := OAuth{oauth: &oauthservice.Service{}}
+
+	doc := buildIntegrationsDocument(cfg, oauthBinding)
+
+	require.Len(t, doc.Surfaces, 2)
+
+	mcp := doc.Surfaces[1]
+	assert.Equal(t, "storyden-mcp", mcp.Slug)
+	assert.Equal(t, "mcp", mcp.Type)
+	assert.Equal(t, "https://example.com/mcp", mcp.URL)
+	assert.Equal(t, []string{"streamable-http"}, mcp.Transports)
+	assert.Equal(t, "https://example.com/.well-known/integrations.json", mcp.Basis.Source)
+
+	require.Equal(t, "required", mcp.Auth.Status)
+	require.Len(t, mcp.Auth.Entries, 1)
+	assert.Equal(t, accessKeyCredentialID, mcp.Auth.Entries[0].Use[0].ID)
+}

--- a/app/transports/http/bindings/integrations_test.go
+++ b/app/transports/http/bindings/integrations_test.go
@@ -60,7 +60,7 @@ func TestBuildIntegrationsDocumentMCPEnabled(t *testing.T) {
 	t.Parallel()
 
 	cfg := config.Config{
-		PublicAPIAddress: mustParseURL(t, "https://example.com"),
+		PublicAPIAddress: mustParseURL(t, "https://api.example.com"),
 		PublicWebAddress: mustParseURL(t, "https://example.com"),
 		MCPEnabled:       true,
 	}
@@ -73,7 +73,9 @@ func TestBuildIntegrationsDocumentMCPEnabled(t *testing.T) {
 	mcp := doc.Surfaces[1]
 	assert.Equal(t, "storyden-mcp", mcp.Slug)
 	assert.Equal(t, "mcp", mcp.Type)
-	assert.Equal(t, "https://example.com/mcp", mcp.URL)
+	// /mcp is mounted on the backend's own mux (same as /api), so it must be
+	// reachable via PublicAPIAddress, not the frontend's PublicWebAddress.
+	assert.Equal(t, "https://api.example.com/mcp", mcp.URL)
 	assert.Equal(t, []string{"streamable-http"}, mcp.Transports)
 	assert.Equal(t, "https://example.com/.well-known/integrations.json", mcp.Basis.Source)
 

--- a/app/transports/mcp/server.go
+++ b/app/transports/mcp/server.go
@@ -46,6 +46,14 @@ func MountMCP(
 		return
 	}
 
+	mux.HandleFunc("/.well-known/mcp/server-card.json", func(w http.ResponseWriter, r *http.Request) {
+		mcpURL := strings.TrimSuffix(cfg.PublicWebAddress.String(), "/") + "/mcp"
+
+		w.Header().Set("Content-Type", "application/json")
+		w.Header().Set("Cache-Control", "public, max-age=3600")
+		json.NewEncoder(w).Encode(map[string]string{"url": mcpURL})
+	})
+
 	lc.Append(fx.StartHook(func() error {
 		set, err := settings.Get(ctx)
 		if err != nil {

--- a/app/transports/mcp/server.go
+++ b/app/transports/mcp/server.go
@@ -47,7 +47,7 @@ func MountMCP(
 	}
 
 	mux.HandleFunc("/.well-known/mcp/server-card.json", func(w http.ResponseWriter, r *http.Request) {
-		mcpURL := strings.TrimSuffix(cfg.PublicWebAddress.String(), "/") + "/mcp"
+		mcpURL := strings.TrimSuffix(cfg.PublicAPIAddress.String(), "/") + "/mcp"
 
 		w.Header().Set("Content-Type", "application/json")
 		w.Header().Set("Cache-Control", "public, max-age=3600")

--- a/tests/discovery/integrations_test.go
+++ b/tests/discovery/integrations_test.go
@@ -1,0 +1,125 @@
+package discovery_test
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/fx"
+
+	transportmcp "github.com/Southclaws/storyden/app/transports/mcp"
+	"github.com/Southclaws/storyden/internal/config"
+	"github.com/Southclaws/storyden/internal/integration"
+	"github.com/Southclaws/storyden/internal/integration/e2e"
+)
+
+type integrationsSurface struct {
+	Slug string `json:"slug"`
+	Type string `json:"type"`
+	URL  string `json:"url"`
+	Spec string `json:"spec"`
+}
+
+type integrationsDocument struct {
+	Version  int                   `json:"version"`
+	Surfaces []integrationsSurface `json:"surfaces"`
+}
+
+func TestIntegrationsDiscoveryMCPDisabled(t *testing.T) {
+	t.Parallel()
+
+	integration.Test(t, nil, e2e.Setup(), fx.Invoke(func(
+		lc fx.Lifecycle,
+		root context.Context,
+		ts *httptest.Server,
+	) {
+		lc.Append(fx.StartHook(func() {
+			a := assert.New(t)
+			r := require.New(t)
+
+			resp := getJSON(t, root, ts.URL+"/.well-known/integrations.json")
+			defer resp.Body.Close()
+			r.Equal(http.StatusOK, resp.StatusCode)
+			a.Equal("application/json", resp.Header.Get("Content-Type"))
+			a.Contains(resp.Header.Get("Cache-Control"), "public")
+
+			var doc integrationsDocument
+			r.NoError(json.NewDecoder(resp.Body).Decode(&doc))
+			a.Equal(3, doc.Version)
+			r.Len(doc.Surfaces, 1)
+			a.Equal("storyden-api", doc.Surfaces[0].Slug)
+			a.Equal("http", doc.Surfaces[0].Type)
+
+			cardResp := getJSON(t, root, ts.URL+"/.well-known/mcp/server-card.json")
+			defer cardResp.Body.Close()
+			a.Equal(http.StatusNotFound, cardResp.StatusCode)
+		}))
+	}))
+}
+
+func TestIntegrationsDiscoveryMCPEnabled(t *testing.T) {
+	t.Parallel()
+
+	integration.Test(t, mcpConfig(t), e2e.Setup(), transportmcp.Build(), fx.Invoke(func(
+		lc fx.Lifecycle,
+		root context.Context,
+		ts *httptest.Server,
+	) {
+		lc.Append(fx.StartHook(func() {
+			a := assert.New(t)
+			r := require.New(t)
+
+			resp := getJSON(t, root, ts.URL+"/.well-known/integrations.json")
+			defer resp.Body.Close()
+			r.Equal(http.StatusOK, resp.StatusCode)
+
+			var doc integrationsDocument
+			r.NoError(json.NewDecoder(resp.Body).Decode(&doc))
+			r.Len(doc.Surfaces, 2)
+			a.Equal("storyden-mcp", doc.Surfaces[1].Slug)
+			a.Equal("mcp", doc.Surfaces[1].Type)
+
+			cardResp := getJSON(t, root, ts.URL+"/.well-known/mcp/server-card.json")
+			defer cardResp.Body.Close()
+			r.Equal(http.StatusOK, cardResp.StatusCode)
+			a.Equal("application/json", cardResp.Header.Get("Content-Type"))
+
+			var card map[string]string
+			r.NoError(json.NewDecoder(cardResp.Body).Decode(&card))
+			r.Contains(card, "url")
+			a.Contains(card["url"], "/mcp")
+		}))
+	}))
+}
+
+func getJSON(t *testing.T, ctx context.Context, target string) *http.Response {
+	t.Helper()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, target, nil)
+	require.NoError(t, err)
+
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+
+	return resp
+}
+
+func mcpConfig(t *testing.T) *config.Config {
+	t.Helper()
+
+	publicWebAddress, err := url.Parse("http://localhost:3000")
+	require.NoError(t, err)
+	publicAPIAddress, err := url.Parse("http://localhost:8000")
+	require.NoError(t, err)
+
+	return &config.Config{
+		PublicWebAddress: *publicWebAddress,
+		PublicAPIAddress: *publicAPIAddress,
+		MCPEnabled:       true,
+	}
+}

--- a/tests/discovery/integrations_test.go
+++ b/tests/discovery/integrations_test.go
@@ -25,6 +25,8 @@ type integrationsSurface struct {
 	Spec string `json:"spec"`
 }
 
+const testAPIAddress = "http://localhost:8000"
+
 type integrationsDocument struct {
 	Version  int                   `json:"version"`
 	Surfaces []integrationsSurface `json:"surfaces"`
@@ -83,6 +85,9 @@ func TestIntegrationsDiscoveryMCPEnabled(t *testing.T) {
 			r.Len(doc.Surfaces, 2)
 			a.Equal("storyden-mcp", doc.Surfaces[1].Slug)
 			a.Equal("mcp", doc.Surfaces[1].Type)
+			// PublicWebAddress (:3000) and PublicAPIAddress (:8000) differ in this
+			// config; /mcp is mounted on the backend so it must use the API address.
+			a.Equal(testAPIAddress+"/mcp", doc.Surfaces[1].URL)
 
 			cardResp := getJSON(t, root, ts.URL+"/.well-known/mcp/server-card.json")
 			defer cardResp.Body.Close()
@@ -92,7 +97,7 @@ func TestIntegrationsDiscoveryMCPEnabled(t *testing.T) {
 			var card map[string]string
 			r.NoError(json.NewDecoder(cardResp.Body).Decode(&card))
 			r.Contains(card, "url")
-			a.Contains(card["url"], "/mcp")
+			a.Equal(testAPIAddress+"/mcp", card["url"])
 		}))
 	}))
 }
@@ -114,7 +119,7 @@ func mcpConfig(t *testing.T) *config.Config {
 
 	publicWebAddress, err := url.Parse("http://localhost:3000")
 	require.NoError(t, err)
-	publicAPIAddress, err := url.Parse("http://localhost:8000")
+	publicAPIAddress, err := url.Parse(testAPIAddress)
 	require.NoError(t, err)
 
 	return &config.Config{


### PR DESCRIPTION
Adds a dynamically-built /.well-known/integrations.json describing this instance's REST API (and OAuth 2.0, when enabled) using an access-key bearer credential, plus the MCP server surface when MCP_ENABLED. Also serves a minimal /.well-known/mcp/server-card.json alongside the MCP mount so agent tooling can discover the connect URL.


Claude-Session: https://claude.ai/code/session_01Tus6Qt7yALcD6qgqg7TKDw