### PR TITLE
fix: harden outbound link fetching against ssrf and dns rebinding

### DIFF
--- a/app/services/authentication/oauth/cimd.go
+++ b/app/services/authentication/oauth/cimd.go
@@ -22,6 +22,7 @@ import (
 	"github.com/Southclaws/storyden/app/resources/oauth"
 	"github.com/Southclaws/storyden/app/resources/oauth/oauth_writer"
 	"github.com/Southclaws/storyden/app/resources/rbac"
+	"github.com/Southclaws/storyden/internal/infrastructure/httpsafe"
 )
 
 var (
@@ -31,18 +32,6 @@ var (
 	cimdMaxCacheTTL            = time.Hour
 	cimdMaxCacheEntries        = 4096
 )
-
-var cimdDisallowedPrefixes = []netip.Prefix{
-	netip.MustParsePrefix("10.0.0.0/8"),
-	netip.MustParsePrefix("100.64.0.0/10"),
-	netip.MustParsePrefix("127.0.0.0/8"),
-	netip.MustParsePrefix("169.254.0.0/16"),
-	netip.MustParsePrefix("172.16.0.0/12"),
-	netip.MustParsePrefix("192.168.0.0/16"),
-	netip.MustParsePrefix("::1/128"),
-	netip.MustParsePrefix("fc00::/7"),
-	netip.MustParsePrefix("fe80::/10"),
-}
 
 var cimdLookupNetIP = net.DefaultResolver.LookupNetIP
 
@@ -277,19 +266,8 @@ func (s *Service) fetchClientMetadata(ctx context.Context, u *url.URL) (*clientM
 	client := &http.Client{
 		Timeout: cimdFetchTimeout,
 		Transport: &http.Transport{
-			Proxy: nil,
-			DialContext: func(dialCtx context.Context, network, address string) (net.Conn, error) {
-				host, _, err := net.SplitHostPort(address)
-				if err != nil {
-					host = address
-				}
-				if !allowInsecure {
-					if err := cimdValidateResolvedHost(dialCtx, host); err != nil {
-						return nil, err
-					}
-				}
-				return (&net.Dialer{Timeout: cimdFetchTimeout}).DialContext(dialCtx, network, address)
-			},
+			Proxy:           nil,
+			DialContext:     cimdDialContext(allowInsecure),
 			TLSClientConfig: &tls.Config{InsecureSkipVerify: allowInsecure},
 		},
 		CheckRedirect: func(*http.Request, []*http.Request) error {
@@ -504,62 +482,21 @@ func cimdCacheTTL(h http.Header) time.Duration {
 	return cimdDefaultCacheTTL
 }
 
-func cimdIsDisallowedHost(host string) bool {
-	host = strings.TrimSpace(strings.ToLower(host))
-	if host == "" {
-		return true
+// cimdDialContext guards outbound dials unless insecure fetching is enabled
+func cimdDialContext(allowInsecure bool) httpsafe.DialFunc {
+	dialer := &net.Dialer{Timeout: cimdFetchTimeout}
+	if allowInsecure {
+		return dialer.DialContext
 	}
-	if host == "localhost" || strings.HasSuffix(host, ".localhost") {
-		return true
-	}
+	return httpsafe.Guard(cimdLookupNetIP, dialer.DialContext)
+}
 
-	addr, err := netip.ParseAddr(host)
-	if err != nil {
-		return false
-	}
-	return cimdIsDisallowedAddr(addr)
+func cimdIsDisallowedHost(host string) bool {
+	return httpsafe.IsDisallowedHost(host)
 }
 
 func cimdIsDisallowedAddr(addr netip.Addr) bool {
-	addr = addr.Unmap()
-	if addr.IsLoopback() || addr.IsLinkLocalMulticast() || addr.IsLinkLocalUnicast() || addr.IsMulticast() || addr.IsUnspecified() {
-		return true
-	}
-	for _, prefix := range cimdDisallowedPrefixes {
-		if prefix.Contains(addr) {
-			return true
-		}
-	}
-	return false
-}
-
-func cimdValidateResolvedHost(ctx context.Context, host string) error {
-	host = strings.TrimSpace(host)
-	if host == "" {
-		return fault.New("cimd metadata host is required")
-	}
-	if cimdIsDisallowedHost(host) {
-		return fault.New("cimd metadata host is not allowed")
-	}
-
-	if _, err := netip.ParseAddr(host); err == nil {
-		return nil
-	}
-
-	addrs, err := cimdLookupNetIP(ctx, "ip", host)
-	if err != nil {
-		return fault.Wrap(err)
-	}
-	if len(addrs) == 0 {
-		return fault.New("cimd metadata host did not resolve to any addresses")
-	}
-	for _, addr := range addrs {
-		if cimdIsDisallowedAddr(addr) {
-			return fault.New("cimd metadata host resolves to a disallowed address")
-		}
-	}
-
-	return nil
+	return httpsafe.IsDisallowedAddr(addr)
 }
 
 func cimdPrevalidateHost(ctx context.Context, host string) error {

--- a/app/services/link/fetcher/fetcher.go
+++ b/app/services/link/fetcher/fetcher.go
@@ -6,6 +6,7 @@ import (
 	"log/slog"
 	"net/http"
 	"net/url"
+	"time"
 
 	"github.com/Southclaws/fault"
 	"github.com/Southclaws/fault/fctx"
@@ -20,10 +21,13 @@ import (
 	"github.com/Southclaws/storyden/app/resources/message"
 	"github.com/Southclaws/storyden/app/services/asset/asset_upload"
 	"github.com/Southclaws/storyden/app/services/link/scrape"
+	"github.com/Southclaws/storyden/internal/infrastructure/httpsafe"
 	"github.com/Southclaws/storyden/internal/infrastructure/pubsub"
 )
 
 var errEmptyLink = fault.New("empty link")
+
+const assetFetchTimeout = 30 * time.Second
 
 type Fetcher struct {
 	logger   *slog.Logger
@@ -32,6 +36,7 @@ type Fetcher struct {
 	lr       *link_writer.LinkWriter
 	sc       scrape.Scraper
 	bus      *pubsub.Bus
+	client   *http.Client
 }
 
 func New(
@@ -49,6 +54,7 @@ func New(
 		lr:       lr,
 		sc:       sc,
 		bus:      bus,
+		client:   httpsafe.NewClient(httpsafe.Config{Timeout: assetFetchTimeout}),
 	}
 }
 
@@ -152,7 +158,12 @@ func (s *Fetcher) ScrapeAndStore(ctx context.Context, u url.URL) (*link_ref.Link
 }
 
 func (s *Fetcher) CopyAsset(ctx context.Context, url string) (*asset.Asset, error) {
-	resp, err := http.Get(url)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, fault.Wrap(err, fctx.With(ctx))
+	}
+
+	resp, err := s.client.Do(req)
 	if err != nil {
 		return nil, fault.Wrap(err, fctx.With(ctx))
 	}

--- a/app/services/link/fetcher/fetcher.go
+++ b/app/services/link/fetcher/fetcher.go
@@ -167,6 +167,7 @@ func (s *Fetcher) CopyAsset(ctx context.Context, url string) (*asset.Asset, erro
 	if err != nil {
 		return nil, fault.Wrap(err, fctx.With(ctx))
 	}
+	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
 		ctx = fctx.WithMeta(ctx, "status", resp.Status)

--- a/app/services/link/scrape/scraper.go
+++ b/app/services/link/scrape/scraper.go
@@ -4,13 +4,17 @@ import (
 	"context"
 	"net/http"
 	"net/url"
+	"time"
 
 	"github.com/Southclaws/fault"
 	"github.com/Southclaws/fault/fctx"
 	"github.com/Southclaws/fault/fmsg"
 	"github.com/Southclaws/fault/ftag"
 	"github.com/Southclaws/storyden/app/resources/datagraph"
+	"github.com/Southclaws/storyden/internal/infrastructure/httpsafe"
 )
+
+const scrapeFetchTimeout = 30 * time.Second
 
 var errFailedToScrape = fault.New("failed to scrape")
 
@@ -27,10 +31,14 @@ type WebContent struct {
 	Content     datagraph.Content
 }
 
-type webScraper struct{}
+type webScraper struct {
+	client *http.Client
+}
 
 func New() Scraper {
-	return &webScraper{}
+	return &webScraper{
+		client: httpsafe.NewClient(httpsafe.Config{Timeout: scrapeFetchTimeout}),
+	}
 }
 
 func (s *webScraper) Scrape(ctx context.Context, addr url.URL) (*WebContent, error) {
@@ -61,7 +69,7 @@ func (s *webScraper) Scrape(ctx context.Context, addr url.URL) (*WebContent, err
 	req.Header.Add("Upgrade-Insecure-Requests", "1")
 	req.Header.Add("User-Agent", `Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/119.0.0.0 Safari/537.36`)
 
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := s.client.Do(req)
 	if err != nil {
 		return nil, fault.Wrap(err, fctx.With(ctx))
 	}

--- a/app/services/link/scrape/scraper.go
+++ b/app/services/link/scrape/scraper.go
@@ -73,6 +73,7 @@ func (s *webScraper) Scrape(ctx context.Context, addr url.URL) (*WebContent, err
 	if err != nil {
 		return nil, fault.Wrap(err, fctx.With(ctx))
 	}
+	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
 		return nil, fault.Wrap(errFailedToScrape, fctx.With(ctx))

--- a/app/services/link/scrape/scraper_test.go
+++ b/app/services/link/scrape/scraper_test.go
@@ -23,3 +23,23 @@ func Test_scraper_Scrape(t *testing.T) {
 	assert.Equal(t, "https://ogp.me/logo.png", wc.Image)
 	assert.Equal(t, "https://ogp.me/favicon.ico", wc.Favicon)
 }
+
+func Test_scraper_Scrape_RefusesInternalHosts(t *testing.T) {
+	t.Parallel()
+	sc := New()
+
+	
+	for _, raw := range []string{
+		"http://127.0.0.1/",
+		"http://localhost/",
+		"http://192.168.0.1/",
+		"http://169.254.169.254/latest/meta-data/",
+		"http://[::1]/",
+	} {
+		u, err := url.Parse(raw)
+		require.NoError(t, err)
+
+		_, err = sc.Scrape(context.Background(), *u)
+		assert.Error(t, err, raw)
+	}
+}

--- a/app/services/plugin/plugin_manager/download.go
+++ b/app/services/plugin/plugin_manager/download.go
@@ -14,24 +14,13 @@ import (
 	"github.com/Southclaws/fault"
 	"github.com/Southclaws/fault/fmsg"
 	"github.com/Southclaws/storyden/app/resources/plugin"
+	"github.com/Southclaws/storyden/internal/infrastructure/httpsafe"
 )
 
 const (
 	pluginFetchTimeout      = 30 * time.Second
 	pluginFetchMaxRedirects = 5
 )
-
-var disallowedHostPrefixes = []netip.Prefix{
-	netip.MustParsePrefix("10.0.0.0/8"),
-	netip.MustParsePrefix("100.64.0.0/10"),
-	netip.MustParsePrefix("127.0.0.0/8"),
-	netip.MustParsePrefix("169.254.0.0/16"),
-	netip.MustParsePrefix("172.16.0.0/12"),
-	netip.MustParsePrefix("192.168.0.0/16"),
-	netip.MustParsePrefix("::1/128"),
-	netip.MustParsePrefix("fc00::/7"),
-	netip.MustParsePrefix("fe80::/10"),
-}
 
 var lookupNetIP = net.DefaultResolver.LookupNetIP
 
@@ -81,32 +70,11 @@ func validatePluginSourceURL(u url.URL) error {
 }
 
 func isDisallowedHost(host string) bool {
-	host = strings.TrimSpace(strings.ToLower(host))
-	if host == "" {
-		return true
-	}
-	if host == "localhost" || strings.HasSuffix(host, ".localhost") {
-		return true
-	}
-
-	addr, err := netip.ParseAddr(host)
-	if err != nil {
-		return false
-	}
-	return isDisallowedAddr(addr)
+	return httpsafe.IsDisallowedHost(host)
 }
 
 func isDisallowedAddr(addr netip.Addr) bool {
-	addr = addr.Unmap()
-	if addr.IsLoopback() || addr.IsLinkLocalMulticast() || addr.IsMulticast() || addr.IsUnspecified() {
-		return true
-	}
-	for _, prefix := range disallowedHostPrefixes {
-		if prefix.Contains(addr) {
-			return true
-		}
-	}
-	return false
+	return httpsafe.IsDisallowedAddr(addr)
 }
 
 func validateResolvedHost(ctx context.Context, host string) error {
@@ -145,37 +113,12 @@ func fetchPluginArchive(ctx context.Context, u url.URL) ([]byte, error) {
 		return nil, err
 	}
 
-	client := &http.Client{
-		Timeout: pluginFetchTimeout,
-		Transport: &http.Transport{
-			Proxy: http.ProxyFromEnvironment,
-			DialContext: func(dialCtx context.Context, network, address string) (net.Conn, error) {
-				host, _, err := net.SplitHostPort(address)
-				if err != nil {
-					host = address
-				}
-
-				if err := validateResolvedHost(dialCtx, host); err != nil {
-					return nil, err
-				}
-
-				dialer := net.Dialer{Timeout: pluginFetchTimeout}
-				return dialer.DialContext(dialCtx, network, address)
-			},
-		},
-		CheckRedirect: func(req *http.Request, via []*http.Request) error {
-			if len(via) >= pluginFetchMaxRedirects {
-				return fault.New("too many redirects while fetching plugin")
-			}
-			if err := validatePluginSourceURL(*req.URL); err != nil {
-				return err
-			}
-			if len(via) > 0 && strings.EqualFold(via[len(via)-1].URL.Scheme, "https") && !strings.EqualFold(req.URL.Scheme, "https") {
-				return fault.New("refusing insecure redirect from https to http")
-			}
-			return nil
-		},
-	}
+	client := httpsafe.NewClient(httpsafe.Config{
+		Timeout:      pluginFetchTimeout,
+		MaxRedirects: pluginFetchMaxRedirects,
+		UseEnvProxy:  true,
+		Resolver:     lookupNetIP,
+	})
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u.String(), nil)
 	if err != nil {

--- a/internal/infrastructure/httpsafe/httpsafe.go
+++ b/internal/infrastructure/httpsafe/httpsafe.go
@@ -1,0 +1,172 @@
+// package httpsafe provides http clients hardened against server-side request forgery
+package httpsafe
+
+import (
+	"context"
+	"errors"
+	"net"
+	"net/http"
+	"net/netip"
+	"net/url"
+	"strings"
+	"time"
+)
+
+var (
+	ErrDisallowedHost    = errors.New("host is not allowed")
+	ErrDisallowedAddress = errors.New("host resolves to a disallowed address")
+	ErrNoResolution      = errors.New("host did not resolve to any addresses")
+)
+
+var disallowedPrefixes = []netip.Prefix{
+	netip.MustParsePrefix("10.0.0.0/8"),
+	netip.MustParsePrefix("100.64.0.0/10"),
+	netip.MustParsePrefix("127.0.0.0/8"),
+	netip.MustParsePrefix("169.254.0.0/16"),
+	netip.MustParsePrefix("172.16.0.0/12"),
+	netip.MustParsePrefix("192.168.0.0/16"),
+	netip.MustParsePrefix("::1/128"),
+	netip.MustParsePrefix("fc00::/7"),
+	netip.MustParsePrefix("fe80::/10"),
+}
+
+// resolveFunc matches net.Resolver.LookupNetIP so a stub can be injected in tests
+type ResolveFunc func(ctx context.Context, network, host string) ([]netip.Addr, error)
+
+// dialFunc matches net.Dialer.DialContext
+type DialFunc func(ctx context.Context, network, address string) (net.Conn, error)
+
+// IsDisallowedAddr reports whether addr is unsafe to reach from the server
+func IsDisallowedAddr(addr netip.Addr) bool {
+	addr = addr.Unmap()
+	if addr.IsLoopback() ||
+		addr.IsLinkLocalUnicast() ||
+		addr.IsLinkLocalMulticast() ||
+		addr.IsMulticast() ||
+		addr.IsUnspecified() {
+		return true
+	}
+	for _, prefix := range disallowedPrefixes {
+		if prefix.Contains(addr) {
+			return true
+		}
+	}
+	return false
+}
+
+// IsDisallowedHost reports whether a host literal is unsafe, hostnames are validated after resolution
+func IsDisallowedHost(host string) bool {
+	host = strings.TrimSpace(strings.ToLower(host))
+	if host == "" {
+		return true
+	}
+	if host == "localhost" || strings.HasSuffix(host, ".localhost") {
+		return true
+	}
+
+	addr, err := netip.ParseAddr(host)
+	if err != nil {
+		return false
+	}
+	return IsDisallowedAddr(addr)
+}
+
+// Guard resolves once, refuses any disallowed address, then dials a validated literal to close the dns-rebinding window
+func Guard(resolve ResolveFunc, dial DialFunc) DialFunc {
+	return func(ctx context.Context, network, address string) (net.Conn, error) {
+		host, port, err := net.SplitHostPort(address)
+		if err != nil {
+			host, port = address, ""
+		}
+
+		if IsDisallowedHost(host) {
+			return nil, ErrDisallowedHost
+		}
+
+		if addr, err := netip.ParseAddr(host); err == nil {
+			if IsDisallowedAddr(addr) {
+				return nil, ErrDisallowedAddress
+			}
+			return dial(ctx, network, address)
+		}
+
+		addrs, err := resolve(ctx, "ip", host)
+		if err != nil {
+			return nil, err
+		}
+		if len(addrs) == 0 {
+			return nil, ErrNoResolution
+		}
+		for _, addr := range addrs {
+			if IsDisallowedAddr(addr) {
+				return nil, ErrDisallowedAddress
+			}
+		}
+
+		var lastErr error
+		for _, addr := range addrs {
+			target := addr.String()
+			if port != "" {
+				target = net.JoinHostPort(addr.String(), port)
+			}
+			conn, err := dial(ctx, network, target)
+			if err == nil {
+				return conn, nil
+			}
+			lastErr = err
+		}
+		return nil, lastErr
+	}
+}
+
+// Config tunes a guarded client
+type Config struct {
+	Timeout      time.Duration
+	MaxRedirects int
+	UseEnvProxy  bool
+	Resolver     ResolveFunc
+}
+
+const defaultMaxRedirects = 10
+
+// NewClient builds an http.Client whose connections are restricted to public addresses
+func NewClient(cfg Config) *http.Client {
+	resolve := cfg.Resolver
+	if resolve == nil {
+		resolve = net.DefaultResolver.LookupNetIP
+	}
+
+	dialer := &net.Dialer{Timeout: cfg.Timeout}
+
+	var proxy func(*http.Request) (*url.URL, error)
+	if cfg.UseEnvProxy {
+		proxy = http.ProxyFromEnvironment
+	}
+
+	maxRedirects := cfg.MaxRedirects
+	if maxRedirects == 0 {
+		maxRedirects = defaultMaxRedirects
+	}
+
+	return &http.Client{
+		Timeout: cfg.Timeout,
+		Transport: &http.Transport{
+			Proxy:       proxy,
+			DialContext: Guard(resolve, dialer.DialContext),
+		},
+		CheckRedirect: func(req *http.Request, via []*http.Request) error {
+			if maxRedirects < 0 {
+				return http.ErrUseLastResponse
+			}
+			if len(via) >= maxRedirects {
+				return errors.New("too many redirects")
+			}
+			if len(via) > 0 &&
+				strings.EqualFold(via[len(via)-1].URL.Scheme, "https") &&
+				!strings.EqualFold(req.URL.Scheme, "https") {
+				return errors.New("refusing insecure redirect from https to http")
+			}
+			return nil
+		},
+	}
+}

--- a/internal/infrastructure/httpsafe/httpsafe.go
+++ b/internal/infrastructure/httpsafe/httpsafe.go
@@ -26,6 +26,7 @@ var disallowedPrefixes = []netip.Prefix{
 	netip.MustParsePrefix("172.16.0.0/12"),
 	netip.MustParsePrefix("192.168.0.0/16"),
 	netip.MustParsePrefix("::1/128"),
+	netip.MustParsePrefix("64:ff9b::/96"),
 	netip.MustParsePrefix("fc00::/7"),
 	netip.MustParsePrefix("fe80::/10"),
 }

--- a/internal/infrastructure/httpsafe/httpsafe_test.go
+++ b/internal/infrastructure/httpsafe/httpsafe_test.go
@@ -19,8 +19,9 @@ func TestIsDisallowedAddr(t *testing.T) {
 	for _, ip := range []string{"8.8.8.8", "1.1.1.1", "2606:4700:4700::1111"} {
 		assert.False(t, IsDisallowedAddr(netip.MustParseAddr(ip)), ip)
 	}
-	// ipv4-mapped ipv6 form of the metadata address must also be caught
+	// ipv4-mapped and nat64 forms of the metadata address must also be caught
 	assert.True(t, IsDisallowedAddr(netip.MustParseAddr("::ffff:169.254.169.254")))
+	assert.True(t, IsDisallowedAddr(netip.MustParseAddr("64:ff9b::169.254.169.254")))
 }
 
 func TestGuardRejectsDisallowedResolution(t *testing.T) {

--- a/internal/infrastructure/httpsafe/httpsafe_test.go
+++ b/internal/infrastructure/httpsafe/httpsafe_test.go
@@ -1,0 +1,71 @@
+package httpsafe
+
+import (
+	"context"
+	"net"
+	"net/netip"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestIsDisallowedAddr(t *testing.T) {
+	t.Parallel()
+
+	for _, ip := range []string{"127.0.0.1", "10.0.0.1", "192.168.1.1", "172.16.0.1", "169.254.169.254", "::1", "fc00::1", "fe80::1", "0.0.0.0"} {
+		assert.True(t, IsDisallowedAddr(netip.MustParseAddr(ip)), ip)
+	}
+	for _, ip := range []string{"8.8.8.8", "1.1.1.1", "2606:4700:4700::1111"} {
+		assert.False(t, IsDisallowedAddr(netip.MustParseAddr(ip)), ip)
+	}
+	// ipv4-mapped ipv6 form of the metadata address must also be caught
+	assert.True(t, IsDisallowedAddr(netip.MustParseAddr("::ffff:169.254.169.254")))
+}
+
+func TestGuardRejectsDisallowedResolution(t *testing.T) {
+	t.Parallel()
+
+	resolve := func(context.Context, string, string) ([]netip.Addr, error) {
+		return []netip.Addr{netip.MustParseAddr("127.0.0.1")}, nil
+	}
+	dialed := false
+	dial := func(context.Context, string, string) (net.Conn, error) {
+		dialed = true
+		return nil, nil
+	}
+
+	_, err := Guard(resolve, dial)(context.Background(), "tcp", "evil.example.com:443")
+	require.ErrorIs(t, err, ErrDisallowedAddress)
+	assert.False(t, dialed, "must not dial when resolution is disallowed")
+}
+
+func TestGuardDialsValidatedLiteralNotHostname(t *testing.T) {
+	t.Parallel()
+
+	// resolve reports a public address, and the guard must dial THAT literal so a
+	// second lookup (dns rebinding to a private ip) can never happen
+	resolve := func(context.Context, string, string) ([]netip.Addr, error) {
+		return []netip.Addr{netip.MustParseAddr("93.184.216.34")}, nil
+	}
+	var dialedAddress string
+	dial := func(_ context.Context, _ string, address string) (net.Conn, error) {
+		dialedAddress = address
+		return nil, nil
+	}
+
+	_, err := Guard(resolve, dial)(context.Background(), "tcp", "example.com:443")
+	require.NoError(t, err)
+	assert.Equal(t, "93.184.216.34:443", dialedAddress)
+}
+
+func TestGuardRejectsDisallowedLiteralHost(t *testing.T) {
+	t.Parallel()
+
+	resolve := func(context.Context, string, string) ([]netip.Addr, error) {
+		t.Fatal("resolve must not be called for a literal ip host")
+		return nil, nil
+	}
+	_, err := Guard(resolve, nil)(context.Background(), "tcp", "169.254.169.254:80")
+	require.ErrorIs(t, err, ErrDisallowedHost)
+}


### PR DESCRIPTION
the app fetches user-supplied urls in a few places, and two of them are not safe.

the link scraper in `link/scrape` and `CopyAsset` in `link/fetcher` fetch urls from user content using `http.DefaultClient` and `http.Get`. they only check the url scheme. so any logged-in user can post a link and make the server fetch anything: internal services, `127.0.0.1`, or cloud metadata at `169.254.169.254`. the scraped title, description and image come back in the link preview, so the response can be read. redirects are followed too, so a public url can redirect into the internal network.

the plugin download in `plugin_manager/download.go` and the oauth cimd fetch in `oauth/cimd.go` do check the host, but they check the hostname and then let `net.Dialer` resolve it again. the two lookups can differ, so an attacker dns can return a public ip for the check and a private ip for the real connection.

the fix is a new package `internal/infrastructure/httpsafe`. it has one shared block list for private, loopback, link-local, the `169.254` metadata range, cgnat, ula, multicast and unspecified addresses. it has a guarded dialer, `Guard`, that resolves the host once, blocks if any address is on the list, then dials the checked ip directly instead of the hostname. dialing the ip is what removes the dns-rebinding gap, and tls still uses the real hostname. it also has `NewClient` with a redirect limit and no https to http downgrade. all four fetchers use this now, and the two duplicate block lists become one.

tests cover the block list including `::ffff:169.254.169.254`, the dialer using the checked ip, and rejecting bad resolutions. `link/scrape` has a new test that refuses `127.0.0.1`, `localhost`, `192.168.x`, `169.254.169.254` and `[::1]` without needing a server. the existing `plugin_manager` and `oauth` tests still pass, and `go vet` is clean on all changed packages.