### PR TITLE
fix: route mcp server card and transport fetches through httpsafe

### DIFF
--- a/app/services/semdex/robot/mcpclient/manager.go
+++ b/app/services/semdex/robot/mcpclient/manager.go
@@ -20,6 +20,7 @@ import (
 	"github.com/Southclaws/storyden/app/services/authentication/oauthremotetoken"
 	"github.com/Southclaws/storyden/app/services/semdex/robot/tools"
 	"github.com/Southclaws/storyden/internal/config"
+	"github.com/Southclaws/storyden/internal/infrastructure/httpsafe"
 	storydenmcp "github.com/Southclaws/storyden/lib/mcp"
 	"github.com/google/jsonschema-go/jsonschema"
 	sdkauth "github.com/modelcontextprotocol/go-sdk/auth"
@@ -46,6 +47,7 @@ type Manager struct {
 	settings *settings.SettingsRepository
 	tokens   *oauthremotetoken.Service
 	config   config.Config
+	client   *http.Client
 }
 
 func New(
@@ -65,6 +67,7 @@ func New(
 		settings: settings,
 		tokens:   tokens,
 		config:   cfg,
+		client:   httpsafe.NewClient(httpsafe.Config{DialTimeout: probeTimeout}),
 	}
 
 	lc.Append(fx.StartHook(func() error {
@@ -294,7 +297,7 @@ func (m *Manager) Probe(ctx context.Context, rawURL string, bearerToken string) 
 		EndpointURL: input.String(),
 	}
 
-	if card, cardURL, err := fetchServerCard(probeCtx, input); err == nil {
+	if card, cardURL, err := fetchServerCard(probeCtx, m.client, input); err == nil {
 		result.ServerCard = &card
 		result.ServerCardURL = cardURL
 		if input.Path == "" || input.Path == "/" {
@@ -484,6 +487,7 @@ func (m *Manager) connect(ctx context.Context, server mcp.Server) (*sdkmcp.Clien
 		Endpoint:             server.EndpointURL,
 		DisableStandaloneSSE: true,
 		OAuthHandler:         staticBearer(bearerToken),
+		HTTPClient:           m.client,
 	}
 	s, err1 := client.Connect(ctx, transport, nil)
 	if err1 == nil {
@@ -492,7 +496,8 @@ func (m *Manager) connect(ctx context.Context, server mcp.Server) (*sdkmcp.Clien
 
 	// fall back to sse transport for older servers
 	transport = &sdkmcp.SSEClientTransport{
-		Endpoint: server.EndpointURL,
+		Endpoint:   server.EndpointURL,
+		HTTPClient: m.client,
 	}
 	s, err2 := client.Connect(ctx, transport, nil)
 	if err2 == nil {
@@ -703,7 +708,7 @@ func serverCardURL(input *url.URL) string {
 	return u.String()
 }
 
-func fetchServerCard(ctx context.Context, input *url.URL) (ServerCard, string, error) {
+func fetchServerCard(ctx context.Context, client *http.Client, input *url.URL) (ServerCard, string, error) {
 	cardURL := serverCardURL(input)
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, cardURL, nil)
 	if err != nil {
@@ -711,7 +716,7 @@ func fetchServerCard(ctx context.Context, input *url.URL) (ServerCard, string, e
 	}
 	req.Header.Set("Accept", "application/json")
 
-	res, err := http.DefaultClient.Do(req)
+	res, err := client.Do(req)
 	if err != nil {
 		return ServerCard{}, cardURL, err
 	}

--- a/app/services/semdex/robot/mcpclient/manager_test.go
+++ b/app/services/semdex/robot/mcpclient/manager_test.go
@@ -1,10 +1,34 @@
 package mcpclient
 
 import (
+	"context"
+	"net/url"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/Southclaws/storyden/internal/infrastructure/httpsafe"
 )
+
+func TestFetchServerCardRefusesInternalHosts(t *testing.T) {
+	t.Parallel()
+
+	client := httpsafe.NewClient(httpsafe.Config{DialTimeout: time.Second})
+
+	for _, raw := range []string{
+		"http://127.0.0.1/",
+		"http://localhost/",
+		"http://169.254.169.254/",
+	} {
+		u, err := url.Parse(raw)
+		require.NoError(t, err)
+
+		_, _, err = fetchServerCard(context.Background(), client, u)
+		assert.Error(t, err, raw)
+	}
+}
 
 func TestCallableNameUsesReadableProviderPrefix(t *testing.T) {
 	t.Parallel()

--- a/internal/infrastructure/httpsafe/httpsafe.go
+++ b/internal/infrastructure/httpsafe/httpsafe.go
@@ -123,6 +123,7 @@ func Guard(resolve ResolveFunc, dial DialFunc) DialFunc {
 // Config tunes a guarded client
 type Config struct {
 	Timeout      time.Duration
+	DialTimeout  time.Duration
 	MaxRedirects int
 	UseEnvProxy  bool
 	Resolver     ResolveFunc
@@ -137,7 +138,12 @@ func NewClient(cfg Config) *http.Client {
 		resolve = net.DefaultResolver.LookupNetIP
 	}
 
-	dialer := &net.Dialer{Timeout: cfg.Timeout}
+	// dial timeout falls back to the overall timeout so streaming callers can set only DialTimeout
+	dialTimeout := cfg.DialTimeout
+	if dialTimeout == 0 {
+		dialTimeout = cfg.Timeout
+	}
+	dialer := &net.Dialer{Timeout: dialTimeout}
 
 	var proxy func(*http.Request) (*url.URL, error)
 	if cfg.UseEnvProxy {


### PR DESCRIPTION
this follows on from #784, which added `internal/infrastructure/httpsafe` and routed the link scraper, plugin download and oauth cimd fetches through it. the mcp integration was missed.

the mcp server card fetch in `fetchServerCard` used `http.DefaultClient`, and `connect` built the streamable and sse transports without setting `HTTPClient`, so the sdk also fell back to `http.DefaultClient`. neither checked for internal addresses, so a user with `PermissionManageRobots` could point an mcp endpoint at `127.0.0.1` or cloud metadata at `169.254.169.254`. it is worse than a plain endpoint because `Probe` can take the next connection target from the fetched server card (`result.EndpointURL = remote.URL`), so the probed server controls the second hop.

the fix gives the manager a guarded `httpsafe` client and uses it for the card fetch and for both transports. mcp connections can be long-lived over sse, so a new `DialTimeout` option on `httpsafe.Config` bounds the dial without setting an overall client timeout that would cut the stream. the dial timeout falls back to the overall timeout, so the existing callers are unchanged.

a new hermetic test checks that `fetchServerCard` refuses `127.0.0.1`, `localhost` and `169.254.169.254` without a server.