### PR TITLE
fix: bound image dimensions before decoding branding uploads

### DIFF
--- a/app/services/branding/banner/opengraph.go
+++ b/app/services/branding/banner/opengraph.go
@@ -4,11 +4,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"image"
-	_ "image/gif"
-	_ "image/jpeg"
 	"image/png"
-	_ "image/png"
 	"io"
 	"strings"
 
@@ -23,6 +19,7 @@ import (
 	"github.com/Southclaws/storyden/app/services/asset/asset_download"
 	"github.com/Southclaws/storyden/app/services/asset/asset_upload"
 	"github.com/Southclaws/storyden/internal/config"
+	"github.com/Southclaws/storyden/internal/infrastructure/imagesafe"
 	"github.com/Southclaws/storyden/internal/mime"
 )
 
@@ -84,7 +81,7 @@ func (s *service) uploadSizes(ctx context.Context, or io.Reader, sizes []Size) e
 		return fault.Wrap(errBadFormat, fctx.With(ctx))
 	}
 
-	source, t, err := image.Decode(r)
+	source, t, err := imagesafe.Decode(r)
 	if err != nil {
 		return fault.Wrap(err, fctx.With(ctx))
 	}

--- a/app/services/branding/icon/service.go
+++ b/app/services/branding/icon/service.go
@@ -5,11 +5,7 @@ import (
 	"context"
 	_ "embed"
 	"fmt"
-	"image"
-	_ "image/gif"
-	_ "image/jpeg"
 	"image/png"
-	_ "image/png"
 	"io"
 	"net/url"
 	"strings"
@@ -25,6 +21,7 @@ import (
 	"github.com/Southclaws/storyden/app/services/asset/asset_download"
 	"github.com/Southclaws/storyden/app/services/asset/asset_upload"
 	"github.com/Southclaws/storyden/internal/config"
+	"github.com/Southclaws/storyden/internal/infrastructure/imagesafe"
 	"github.com/Southclaws/storyden/internal/infrastructure/object"
 	"github.com/Southclaws/storyden/internal/mime"
 )
@@ -106,7 +103,7 @@ func (s *service) uploadSizes(ctx context.Context, or io.Reader, sizes []Size) e
 		return fault.Wrap(errBadFormat, fctx.With(ctx))
 	}
 
-	source, t, err := image.Decode(r)
+	source, t, err := imagesafe.Decode(r)
 	if err != nil {
 		return fault.Wrap(err, fctx.With(ctx))
 	}

--- a/internal/infrastructure/imagesafe/imagesafe.go
+++ b/internal/infrastructure/imagesafe/imagesafe.go
@@ -4,7 +4,6 @@ package imagesafe
 import (
 	"bytes"
 	"errors"
-	"fmt"
 	"image"
 	_ "image/gif"
 	_ "image/jpeg"
@@ -18,7 +17,10 @@ const MaxPixels = 64 * 1000 * 1000
 // maxEncodedBytes bounds how much encoded data we buffer before decoding
 const maxEncodedBytes = 64 << 20
 
-var ErrImageTooLarge = errors.New("image dimensions exceed the allowed size")
+var (
+	ErrImageTooLarge   = errors.New("image dimensions exceed the allowed size")
+	ErrEncodedTooLarge = errors.New("encoded image exceeds the allowed size")
+)
 
 // Decode reads an image but rejects oversized dimensions before allocating pixels
 func Decode(r io.Reader) (image.Image, string, error) {
@@ -27,14 +29,15 @@ func Decode(r io.Reader) (image.Image, string, error) {
 		return nil, "", err
 	}
 	if int64(len(data)) > maxEncodedBytes {
-		return nil, "", fmt.Errorf("image exceeds %d bytes", int64(maxEncodedBytes))
+		return nil, "", ErrEncodedTooLarge
 	}
 
 	cfg, format, err := image.DecodeConfig(bytes.NewReader(data))
 	if err != nil {
 		return nil, "", err
 	}
-	if int64(cfg.Width)*int64(cfg.Height) > MaxPixels {
+	// non-positive dimensions can appear from integer wrap on 32-bit and must not slip past the pixel budget
+	if cfg.Width <= 0 || cfg.Height <= 0 || int64(cfg.Width)*int64(cfg.Height) > MaxPixels {
 		return nil, format, ErrImageTooLarge
 	}
 

--- a/internal/infrastructure/imagesafe/imagesafe.go
+++ b/internal/infrastructure/imagesafe/imagesafe.go
@@ -1,0 +1,46 @@
+// package imagesafe decodes images with a pixel budget to prevent decompression bombs
+package imagesafe
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"image"
+	_ "image/gif"
+	_ "image/jpeg"
+	_ "image/png"
+	"io"
+)
+
+// MaxPixels caps decoded dimensions so a tiny file cannot allocate huge memory
+const MaxPixels = 64 * 1000 * 1000
+
+// maxEncodedBytes bounds how much encoded data we buffer before decoding
+const maxEncodedBytes = 64 << 20
+
+var ErrImageTooLarge = errors.New("image dimensions exceed the allowed size")
+
+// Decode reads an image but rejects oversized dimensions before allocating pixels
+func Decode(r io.Reader) (image.Image, string, error) {
+	data, err := io.ReadAll(io.LimitReader(r, maxEncodedBytes+1))
+	if err != nil {
+		return nil, "", err
+	}
+	if int64(len(data)) > maxEncodedBytes {
+		return nil, "", fmt.Errorf("image exceeds %d bytes", int64(maxEncodedBytes))
+	}
+
+	cfg, format, err := image.DecodeConfig(bytes.NewReader(data))
+	if err != nil {
+		return nil, "", err
+	}
+	if int64(cfg.Width)*int64(cfg.Height) > MaxPixels {
+		return nil, format, ErrImageTooLarge
+	}
+
+	img, format, err := image.Decode(bytes.NewReader(data))
+	if err != nil {
+		return nil, format, err
+	}
+	return img, format, nil
+}

--- a/internal/infrastructure/imagesafe/imagesafe.go
+++ b/internal/infrastructure/imagesafe/imagesafe.go
@@ -24,15 +24,11 @@ var (
 
 // Decode reads an image but rejects oversized dimensions before allocating pixels
 func Decode(r io.Reader) (image.Image, string, error) {
-	data, err := io.ReadAll(io.LimitReader(r, maxEncodedBytes+1))
-	if err != nil {
-		return nil, "", err
-	}
-	if int64(len(data)) > maxEncodedBytes {
-		return nil, "", ErrEncodedTooLarge
-	}
+	limited := io.LimitReader(r, maxEncodedBytes+1)
 
-	cfg, format, err := image.DecodeConfig(bytes.NewReader(data))
+	// decodeconfig only reads the header, so tee those bytes and reject a dimension bomb before buffering the whole image
+	var header bytes.Buffer
+	cfg, format, err := image.DecodeConfig(io.TeeReader(limited, &header))
 	if err != nil {
 		return nil, "", err
 	}
@@ -41,7 +37,15 @@ func Decode(r io.Reader) (image.Image, string, error) {
 		return nil, format, ErrImageTooLarge
 	}
 
-	img, format, err := image.Decode(bytes.NewReader(data))
+	data, err := io.ReadAll(io.MultiReader(&header, limited))
+	if err != nil {
+		return nil, format, err
+	}
+	if int64(len(data)) > maxEncodedBytes {
+		return nil, format, ErrEncodedTooLarge
+	}
+
+	img, _, err := image.Decode(bytes.NewReader(data))
 	if err != nil {
 		return nil, format, err
 	}

--- a/internal/infrastructure/imagesafe/imagesafe_test.go
+++ b/internal/infrastructure/imagesafe/imagesafe_test.go
@@ -1,0 +1,57 @@
+package imagesafe
+
+import (
+	"bytes"
+	"encoding/binary"
+	"hash/crc32"
+	"image"
+	"image/png"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDecodeAllowsNormalImage(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+	require.NoError(t, png.Encode(&buf, image.NewRGBA(image.Rect(0, 0, 32, 32))))
+
+	img, format, err := Decode(bytes.NewReader(buf.Bytes()))
+	require.NoError(t, err)
+	assert.Equal(t, "png", format)
+	assert.Equal(t, 32, img.Bounds().Dx())
+}
+
+func TestDecodeRejectsOversizedDimensions(t *testing.T) {
+	t.Parallel()
+
+	// a valid png header claiming enormous dimensions must be rejected before the
+	// pixel buffer is allocated, which would otherwise consume gigabytes
+	side := 200000
+	assert.Greater(t, int64(side)*int64(side), int64(MaxPixels))
+
+	_, _, err := Decode(bytes.NewReader(pngHeader(side, side)))
+	require.ErrorIs(t, err, ErrImageTooLarge)
+}
+
+// pngHeader builds a valid png signature and IHDR chunk so DecodeConfig can read
+// the declared dimensions without any pixel data present
+func pngHeader(w, h int) []byte {
+	var b bytes.Buffer
+	b.Write([]byte{0x89, 'P', 'N', 'G', 0x0d, 0x0a, 0x1a, 0x0a})
+
+	ihdr := make([]byte, 13)
+	binary.BigEndian.PutUint32(ihdr[0:], uint32(w))
+	binary.BigEndian.PutUint32(ihdr[4:], uint32(h))
+	ihdr[8] = 8 // bit depth
+	ihdr[9] = 6 // colour type rgba
+
+	binary.Write(&b, binary.BigEndian, uint32(len(ihdr)))
+	chunk := append([]byte("IHDR"), ihdr...)
+	b.Write(chunk)
+	binary.Write(&b, binary.BigEndian, crc32.ChecksumIEEE(chunk))
+
+	return b.Bytes()
+}

--- a/internal/infrastructure/imagesafe/imagesafe_test.go
+++ b/internal/infrastructure/imagesafe/imagesafe_test.go
@@ -6,6 +6,7 @@ import (
 	"hash/crc32"
 	"image"
 	"image/png"
+	"io"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -35,6 +36,32 @@ func TestDecodeRejectsOversizedDimensions(t *testing.T) {
 	_, _, err := Decode(bytes.NewReader(pngHeader(side, side)))
 	require.ErrorIs(t, err, ErrImageTooLarge)
 }
+
+func TestDecodeAllowsExactMaxPixels(t *testing.T) {
+	t.Parallel()
+
+	// 8000x8000 == MaxPixels and the check is >, so this must not be rejected for size
+	side := 8000
+	require.Equal(t, int64(MaxPixels), int64(side)*int64(side))
+
+	// the header carries no pixel data so decode still fails, but not on the size guard
+	_, _, err := Decode(bytes.NewReader(pngHeader(side, side)))
+	require.Error(t, err)
+	assert.NotErrorIs(t, err, ErrImageTooLarge)
+}
+
+func TestDecodeRejectsOversizedEncodedInput(t *testing.T) {
+	t.Parallel()
+
+	r := io.MultiReader(bytes.NewReader(pngHeader(1, 1)), infiniteReader{})
+
+	_, _, err := Decode(r)
+	require.ErrorIs(t, err, ErrEncodedTooLarge)
+}
+
+type infiniteReader struct{}
+
+func (infiniteReader) Read(p []byte) (int, error) { return len(p), nil }
 
 // pngHeader builds a valid png signature and IHDR chunk so DecodeConfig can read
 // the declared dimensions without any pixel data present


### PR DESCRIPTION
the icon and banner uploaders in `branding` decode a user-supplied image with `image.Decode` right after checking the mime type. nothing checks the image dimensions first.

image formats store width and height in a small header, separate from the compressed pixel data, and a decoder allocates a full buffer of `width * height * bytes_per_pixel` no matter how small the file is. formats like png and gif compress uniform areas extremely well, so a `100000 x 100000` single-colour png is a few hundred kb on disk but decodes to about `40 gb` in memory. the request body cap of 50 mb does not help because it limits the encoded bytes, not the decoded ones. in go a failed allocation is fatal, so one upload can oom and take down the whole instance.

this is reachable by any user with `PermissionManageSettings`, which is often delegated to staff, so a single upload can crash the server for everyone.

the fix adds `internal/infrastructure/imagesafe`, which reads only the header with `image.DecodeConfig`, rejects anything over 64 megapixels, and only then decodes. both the icon and banner uploaders go through it. a test builds a valid png header that declares huge dimensions and confirms it is rejected before any pixel buffer is allocated.