### PR TITLE
fix: invalidate caches after writes, not before

### DIFF
--- a/app/services/account/account_email/account_email.go
+++ b/app/services/account/account_email/account_email.go
@@ -34,12 +34,12 @@ func (m *Manager) Add(ctx context.Context, accountID account.AccountID, address 
 		return nil, fault.Wrap(err, fctx.With(ctx))
 	}
 
-	err = m.profileCache.Invalidate(ctx, xid.ID(accountID))
+	ae, err := m.verifier.BeginEmailVerification(ctx, accountID, address, otp)
 	if err != nil {
 		return nil, fault.Wrap(err, fctx.With(ctx))
 	}
 
-	ae, err := m.verifier.BeginEmailVerification(ctx, accountID, address, otp)
+	err = m.profileCache.Invalidate(ctx, xid.ID(accountID))
 	if err != nil {
 		return nil, fault.Wrap(err, fctx.With(ctx))
 	}
@@ -57,12 +57,12 @@ func (m *Manager) AddUnverified(ctx context.Context, accountID account.AccountID
 		return nil, fault.Wrap(err, fctx.With(ctx))
 	}
 
-	err = m.profileCache.Invalidate(ctx, xid.ID(accountID))
+	ae, err := m.emailRepo.Add(ctx, accountID, address, code)
 	if err != nil {
 		return nil, fault.Wrap(err, fctx.With(ctx))
 	}
 
-	ae, err := m.emailRepo.Add(ctx, accountID, address, code)
+	err = m.profileCache.Invalidate(ctx, xid.ID(accountID))
 	if err != nil {
 		return nil, fault.Wrap(err, fctx.With(ctx))
 	}
@@ -84,12 +84,12 @@ func (m *Manager) LookupAccount(ctx context.Context, address mail.Address) (*acc
 }
 
 func (m *Manager) Remove(ctx context.Context, accountID account.AccountID, id xid.ID) error {
-	err := m.profileCache.Invalidate(ctx, xid.ID(accountID))
+	err := m.emailRepo.Remove(ctx, accountID, id)
 	if err != nil {
 		return fault.Wrap(err, fctx.With(ctx))
 	}
 
-	err = m.emailRepo.Remove(ctx, accountID, id)
+	err = m.profileCache.Invalidate(ctx, xid.ID(accountID))
 	if err != nil {
 		return fault.Wrap(err, fctx.With(ctx))
 	}
@@ -102,12 +102,12 @@ func (m *Manager) Remove(ctx context.Context, accountID account.AccountID, id xi
 }
 
 func (m *Manager) SetVerifiedStatus(ctx context.Context, accountID account.AccountID, id xid.ID, verified bool) (*account.EmailAddress, error) {
-	err := m.profileCache.Invalidate(ctx, xid.ID(accountID))
+	ae, err := m.emailRepo.SetVerifiedStatus(ctx, accountID, id, verified)
 	if err != nil {
 		return nil, fault.Wrap(err, fctx.With(ctx))
 	}
 
-	ae, err := m.emailRepo.SetVerifiedStatus(ctx, accountID, id, verified)
+	err = m.profileCache.Invalidate(ctx, xid.ID(accountID))
 	if err != nil {
 		return nil, fault.Wrap(err, fctx.With(ctx))
 	}

--- a/app/services/account/account_role_assign/service.go
+++ b/app/services/account/account_role_assign/service.go
@@ -30,11 +30,11 @@ func New(assign *role_assign.Assignment, profileCache *profile_cache.Cache, bus 
 }
 
 func (m *Manager) UpdateRoles(ctx context.Context, accountID account_ref.ID, roles ...role_assign.Mutation) error {
-	if err := m.profileCache.Invalidate(ctx, xid.ID(accountID)); err != nil {
+	if err := m.assign.UpdateRoles(ctx, accountID, roles...); err != nil {
 		return fault.Wrap(err, fctx.With(ctx))
 	}
 
-	if err := m.assign.UpdateRoles(ctx, accountID, roles...); err != nil {
+	if err := m.profileCache.Invalidate(ctx, xid.ID(accountID)); err != nil {
 		return fault.Wrap(err, fctx.With(ctx))
 	}
 
@@ -44,11 +44,11 @@ func (m *Manager) UpdateRoles(ctx context.Context, accountID account_ref.ID, rol
 }
 
 func (m *Manager) SetBadge(ctx context.Context, accountID account_ref.ID, roleID role.RoleID, badge bool) error {
-	if err := m.profileCache.Invalidate(ctx, xid.ID(accountID)); err != nil {
+	if err := m.assign.SetBadge(ctx, accountID, roleID, badge); err != nil {
 		return fault.Wrap(err, fctx.With(ctx))
 	}
 
-	if err := m.assign.SetBadge(ctx, accountID, roleID, badge); err != nil {
+	if err := m.profileCache.Invalidate(ctx, xid.ID(accountID)); err != nil {
 		return fault.Wrap(err, fctx.With(ctx))
 	}
 

--- a/app/services/account/account_update/account_update.go
+++ b/app/services/account/account_update/account_update.go
@@ -81,12 +81,12 @@ func (u *Updater) Update(ctx context.Context, id account.AccountID, params Parti
 		opts = append(opts, account_writer.SetMetadata(v))
 	}
 
-	err := u.profileCache.Invalidate(ctx, xid.ID(id))
+	acc, err := u.writer.Update(ctx, id, opts...)
 	if err != nil {
 		return nil, fault.Wrap(err, fctx.With(ctx))
 	}
 
-	acc, err := u.writer.Update(ctx, id, opts...)
+	err = u.profileCache.Invalidate(ctx, xid.ID(id))
 	if err != nil {
 		return nil, fault.Wrap(err, fctx.With(ctx))
 	}

--- a/app/services/category/service.go
+++ b/app/services/category/service.go
@@ -120,10 +120,6 @@ func (s *service) Create(ctx context.Context, partial Partial) (*category.Catego
 }
 
 func (s *service) Update(ctx context.Context, slug string, partial Partial) (*category.Category, error) {
-	if err := s.cache.Invalidate(ctx, slug); err != nil {
-		return nil, fault.Wrap(err, fctx.With(ctx))
-	}
-
 	opts := []category.Option{}
 
 	if v, ok := partial.Name.Get(); ok {
@@ -153,16 +149,16 @@ func (s *service) Update(ctx context.Context, slug string, partial Partial) (*ca
 		return nil, fault.Wrap(err, fctx.With(ctx))
 	}
 
+	if err := s.cache.Invalidate(ctx, slug); err != nil {
+		return nil, fault.Wrap(err, fctx.With(ctx))
+	}
+
 	s.bus.Publish(ctx, &rpc.EventCategoryUpdated{Slug: cat.Slug})
 
 	return cat, nil
 }
 
 func (s *service) Move(ctx context.Context, slug string, move Move) ([]*category.Category, error) {
-	if err := s.cache.Invalidate(ctx, slug); err != nil {
-		return nil, fault.Wrap(err, fctx.With(ctx))
-	}
-
 	parentOpt, deleteParent := move.Parent.Get()
 	parentProvided := deleteParent
 	var parentID *category.CategoryID
@@ -194,6 +190,10 @@ func (s *service) Move(ctx context.Context, slug string, move Move) ([]*category
 		After:          afterID,
 	})
 	if err != nil {
+		return nil, fault.Wrap(err, fctx.With(ctx))
+	}
+
+	if err := s.cache.Invalidate(ctx, slug); err != nil {
 		return nil, fault.Wrap(err, fctx.With(ctx))
 	}
 

--- a/app/services/library/node_mutate/update.go
+++ b/app/services/library/node_mutate/update.go
@@ -65,11 +65,8 @@ func (s *Manager) update(ctx context.Context, qk library.QueryKey, p Partial, ap
 		}
 	}
 
-	if err := s.cache.Invalidate(ctx, n.GetSlug()); err != nil {
-		return nil, fault.Wrap(err, fctx.With(ctx))
-	}
-
 	oldVisibility := n.Visibility
+	previousSlug := n.GetSlug()
 
 	pre, err := s.preMutation(ctx, p, opt.NewPtr(n))
 	if err != nil {
@@ -96,6 +93,10 @@ func (s *Manager) update(ctx context.Context, qk library.QueryKey, p Partial, ap
 		}
 
 		n.Properties = opt.New(*updatedProperties)
+	}
+
+	if err := s.cache.Invalidate(ctx, previousSlug); err != nil {
+		return nil, fault.Wrap(err, fctx.With(ctx))
 	}
 
 	// Emit update event

--- a/app/services/library/nodetree/nodetree.go
+++ b/app/services/library/nodetree/nodetree.go
@@ -103,10 +103,6 @@ func (s *service) Move(ctx context.Context, child library.QueryKey, parent libra
 		return nil, fault.Wrap(ErrVisibilityRules, fctx.With(ctx))
 	}
 
-	if err := s.cache.Invalidate(ctx, cnode.GetSlug()); err != nil {
-		return nil, fault.Wrap(err, fctx.With(ctx))
-	}
-
 	// If the target parent is actually a child of the target child, sever this
 	// connection before adding the target child to the target parent.
 	if parentParent, ok := pnode.Parent.Get(); ok {
@@ -120,6 +116,10 @@ func (s *service) Move(ctx context.Context, child library.QueryKey, parent libra
 
 	cnode, err = s.nodeWriter.Update(ctx, library.NewQueryKey(cnode.Mark), node_writer.WithParent(library.NodeID(pnode.Mark.ID())))
 	if err != nil {
+		return nil, fault.Wrap(err, fctx.With(ctx))
+	}
+
+	if err := s.cache.Invalidate(ctx, cnode.GetSlug()); err != nil {
 		return nil, fault.Wrap(err, fctx.With(ctx))
 	}
 
@@ -167,12 +167,12 @@ func (s *service) Sever(ctx context.Context, child library.QueryKey, parent libr
 		return nil, fault.Wrap(err, fctx.With(ctx))
 	}
 
-	if err := s.cache.Invalidate(ctx, cnode.GetSlug()); err != nil {
+	_, err = s.nodeWriter.Update(ctx, library.NewQueryKey(pnode.Mark), node_writer.WithChildNodeRemove(xid.ID(cnode.Mark.ID())))
+	if err != nil {
 		return nil, fault.Wrap(err, fctx.With(ctx))
 	}
 
-	_, err = s.nodeWriter.Update(ctx, library.NewQueryKey(pnode.Mark), node_writer.WithChildNodeRemove(xid.ID(cnode.Mark.ID())))
-	if err != nil {
+	if err := s.cache.Invalidate(ctx, cnode.GetSlug()); err != nil {
 		return nil, fault.Wrap(err, fctx.With(ctx))
 	}
 

--- a/app/services/library/nodetree/position.go
+++ b/app/services/library/nodetree/position.go
@@ -115,12 +115,12 @@ func (p *Position) Move(ctx context.Context, nm library.QueryKey, opts Options) 
 	// Now handle re-ordering of the node using the before/after/index params.
 
 	if beforeID, ok := opts.Before.Get(); ok {
-		if err := p.cache.Invalidate(ctx, thisnode.GetSlug()); err != nil {
+		n, err := p.nodeChildren.MoveBefore(ctx, thisnode, beforeID)
+		if err != nil {
 			return nil, fault.Wrap(err, fctx.With(ctx))
 		}
 
-		n, err := p.nodeChildren.MoveBefore(ctx, thisnode, beforeID)
-		if err != nil {
+		if err := p.cache.Invalidate(ctx, thisnode.GetSlug()); err != nil {
 			return nil, fault.Wrap(err, fctx.With(ctx))
 		}
 
@@ -133,12 +133,12 @@ func (p *Position) Move(ctx context.Context, nm library.QueryKey, opts Options) 
 	}
 
 	if afterID, ok := opts.After.Get(); ok {
-		if err := p.cache.Invalidate(ctx, thisnode.GetSlug()); err != nil {
+		n, err := p.nodeChildren.MoveAfter(ctx, thisnode, afterID)
+		if err != nil {
 			return nil, fault.Wrap(err, fctx.With(ctx))
 		}
 
-		n, err := p.nodeChildren.MoveAfter(ctx, thisnode, afterID)
-		if err != nil {
+		if err := p.cache.Invalidate(ctx, thisnode.GetSlug()); err != nil {
 			return nil, fault.Wrap(err, fctx.With(ctx))
 		}
 
@@ -151,12 +151,12 @@ func (p *Position) Move(ctx context.Context, nm library.QueryKey, opts Options) 
 	}
 
 	if index, ok := opts.Index.Get(); ok {
-		if err := p.cache.Invalidate(ctx, thisnode.GetSlug()); err != nil {
+		n, err := p.nodeChildren.MoveIndex(ctx, thisnode, index)
+		if err != nil {
 			return nil, fault.Wrap(err, fctx.With(ctx))
 		}
 
-		n, err := p.nodeChildren.MoveIndex(ctx, thisnode, index)
-		if err != nil {
+		if err := p.cache.Invalidate(ctx, thisnode.GetSlug()); err != nil {
 			return nil, fault.Wrap(err, fctx.With(ctx))
 		}
 

--- a/app/services/like/post_liker/liker.go
+++ b/app/services/like/post_liker/liker.go
@@ -41,12 +41,12 @@ func (l *PostLiker) AddPostLike(ctx context.Context, accountID account.AccountID
 		return err
 	}
 
-	if err := l.cache.Invalidate(ctx, xid.ID(postRef.Root)); err != nil {
+	err = l.likeWriter.AddPostLike(ctx, accountID, postID)
+	if err != nil {
 		return err
 	}
 
-	err = l.likeWriter.AddPostLike(ctx, accountID, postID)
-	if err != nil {
+	if err := l.cache.Invalidate(ctx, xid.ID(postRef.Root)); err != nil {
 		return err
 	}
 
@@ -64,12 +64,12 @@ func (l *PostLiker) RemovePostLike(ctx context.Context, accountID account.Accoun
 		return err
 	}
 
-	if err := l.cache.Invalidate(ctx, xid.ID(postRef.Root)); err != nil {
+	err = l.likeWriter.RemovePostLike(ctx, accountID, postID)
+	if err != nil {
 		return err
 	}
 
-	err = l.likeWriter.RemovePostLike(ctx, accountID, postID)
-	if err != nil {
+	if err := l.cache.Invalidate(ctx, xid.ID(postRef.Root)); err != nil {
 		return err
 	}
 

--- a/app/services/react_manager/reactions.go
+++ b/app/services/react_manager/reactions.go
@@ -57,12 +57,12 @@ func (s *Reactor) Add(ctx context.Context, postID post.ID, emoji string) (*react
 		return nil, fault.Wrap(err, fctx.With(ctx))
 	}
 
-	if err := s.cache.Invalidate(ctx, xid.ID(pref.Root)); err != nil {
+	r, err := s.reactWriter.Add(ctx, accountID, xid.ID(postID), emoji)
+	if err != nil {
 		return nil, fault.Wrap(err, fctx.With(ctx))
 	}
 
-	r, err := s.reactWriter.Add(ctx, accountID, xid.ID(postID), emoji)
-	if err != nil {
+	if err := s.cache.Invalidate(ctx, xid.ID(pref.Root)); err != nil {
 		return nil, fault.Wrap(err, fctx.With(ctx))
 	}
 
@@ -109,12 +109,12 @@ func (s *Reactor) Remove(ctx context.Context, reactID reaction.ReactID) error {
 		return fault.Wrap(err, fctx.With(ctx))
 	}
 
-	if err := s.cache.Invalidate(ctx, xid.ID(pref.Root)); err != nil {
+	err = s.reactWriter.Remove(ctx, accountID, reactID)
+	if err != nil {
 		return fault.Wrap(err, fctx.With(ctx))
 	}
 
-	err = s.reactWriter.Remove(ctx, accountID, reactID)
-	if err != nil {
+	if err := s.cache.Invalidate(ctx, xid.ID(pref.Root)); err != nil {
 		return fault.Wrap(err, fctx.With(ctx))
 	}
 

--- a/app/services/reply/create.go
+++ b/app/services/reply/create.go
@@ -36,10 +36,6 @@ func (s *Mutator) Create(
 	opts := partial.Opts()
 	opts = append(opts, reply_writer.WithVisibility(visibility.VisibilityPublished))
 
-	if err := s.cache.Invalidate(ctx, xid.ID(parentID)); err != nil {
-		return nil, fault.Wrap(err, fctx.With(ctx), fmsg.With("failed to invalidate thread cache"))
-	}
-
 	p, err := s.replyWriter.Create(ctx, authorID, parentID, opts...)
 	if err != nil {
 		return nil, fault.Wrap(err, fctx.With(ctx), fmsg.With("failed to create reply post in thread"))
@@ -60,6 +56,10 @@ func (s *Mutator) Create(
 			p = updatedReply
 			wasMovedToReview = true
 		}
+	}
+
+	if err := s.cache.Invalidate(ctx, xid.ID(parentID)); err != nil {
+		return nil, fault.Wrap(err, fctx.With(ctx), fmsg.With("failed to invalidate thread cache"))
 	}
 
 	replyToAuthorID := opt.Map(p.ReplyTo, func(r reply.Reply) account.AccountID {

--- a/app/services/reply/create.go
+++ b/app/services/reply/create.go
@@ -41,6 +41,10 @@ func (s *Mutator) Create(
 		return nil, fault.Wrap(err, fctx.With(ctx), fmsg.With("failed to create reply post in thread"))
 	}
 
+	if err := s.cache.Invalidate(ctx, xid.ID(parentID)); err != nil {
+		return nil, fault.Wrap(err, fctx.With(ctx), fmsg.With("failed to invalidate thread cache"))
+	}
+
 	wasMovedToReview := false
 	if content, ok := partial.Content.Get(); ok {
 		result, err := s.cpm.CheckContent(ctx, xid.ID(p.ID), datagraph.KindReply, "", content)
@@ -55,11 +59,11 @@ func (s *Mutator) Create(
 			}
 			p = updatedReply
 			wasMovedToReview = true
-		}
-	}
 
-	if err := s.cache.Invalidate(ctx, xid.ID(parentID)); err != nil {
-		return nil, fault.Wrap(err, fctx.With(ctx), fmsg.With("failed to invalidate thread cache"))
+			if err := s.cache.Invalidate(ctx, xid.ID(parentID)); err != nil {
+				return nil, fault.Wrap(err, fctx.With(ctx), fmsg.With("failed to invalidate thread cache"))
+			}
+		}
 	}
 
 	replyToAuthorID := opt.Map(p.ReplyTo, func(r reply.Reply) account.AccountID {

--- a/app/services/reply/delete.go
+++ b/app/services/reply/delete.go
@@ -41,12 +41,12 @@ func (s *Mutator) Delete(ctx context.Context, postID post.ID) error {
 		return fault.Wrap(err, fctx.With(ctx))
 	}
 
-	if err := s.cache.Invalidate(ctx, xid.ID(pref.RootPostID)); err != nil {
+	err = s.replyWriter.Delete(ctx, postID)
+	if err != nil {
 		return fault.Wrap(err, fctx.With(ctx))
 	}
 
-	err = s.replyWriter.Delete(ctx, postID)
-	if err != nil {
+	if err := s.cache.Invalidate(ctx, xid.ID(pref.RootPostID)); err != nil {
 		return fault.Wrap(err, fctx.With(ctx))
 	}
 

--- a/app/services/reply/update.go
+++ b/app/services/reply/update.go
@@ -83,12 +83,12 @@ func (s *Mutator) Update(ctx context.Context, replyID post.ID, partial Partial) 
 		return nil, fault.Wrap(err, fctx.With(ctx))
 	}
 
-	if err := s.cache.Invalidate(ctx, xid.ID(pref.RootPostID)); err != nil {
+	p, err = s.replyWriter.Update(ctx, replyID, opts...)
+	if err != nil {
 		return nil, fault.Wrap(err, fctx.With(ctx))
 	}
 
-	p, err = s.replyWriter.Update(ctx, replyID, opts...)
-	if err != nil {
+	if err := s.cache.Invalidate(ctx, xid.ID(pref.RootPostID)); err != nil {
 		return nil, fault.Wrap(err, fctx.With(ctx))
 	}
 

--- a/app/services/thread/delete.go
+++ b/app/services/thread/delete.go
@@ -38,13 +38,13 @@ func (s *service) Delete(ctx context.Context, id post.ID) error {
 		return fault.Wrap(err, fctx.With(ctx))
 	}
 
-	if err := s.cache.Invalidate(ctx, xid.ID(id)); err != nil {
-		return fault.Wrap(err, fctx.With(ctx))
-	}
-
 	err = s.threadWriter.Delete(ctx, id)
 	if err != nil {
 		return fault.Wrap(err, fctx.With(ctx), fmsg.With("failed to delete thread"))
+	}
+
+	if err := s.cache.Invalidate(ctx, xid.ID(id)); err != nil {
+		return fault.Wrap(err, fctx.With(ctx))
 	}
 
 	s.bus.Publish(ctx, &rpc.EventThreadDeleted{

--- a/app/services/thread/update.go
+++ b/app/services/thread/update.go
@@ -106,12 +106,12 @@ func (s *service) Update(ctx context.Context, threadID post.ID, partial Partial)
 		}
 	}
 
-	if err := s.cache.Invalidate(ctx, xid.ID(threadID)); err != nil {
+	thr, err = s.threadWriter.Update(ctx, threadID, opts...)
+	if err != nil {
 		return nil, fault.Wrap(err, fctx.With(ctx))
 	}
 
-	thr, err = s.threadWriter.Update(ctx, threadID, opts...)
-	if err != nil {
+	if err := s.cache.Invalidate(ctx, xid.ID(threadID)); err != nil {
 		return nil, fault.Wrap(err, fctx.With(ctx))
 	}
 


### PR DESCRIPTION
the last-modified cache (`thread_cache`, `profile_cache`, etc) stores a timestamp per resource that drives conditional requests: a client sends `If-Modified-Since` and gets a `304` if the stored timestamp has not moved. reactions, likes, replies and other mutations call `Invalidate`, which bumps that timestamp to now, so clients refetch.

the problem is ordering: many services called `Invalidate` before the write. that leaves a window where a concurrent reader of the same resource, between the invalidate and the write commit, reads the old state from the db and serves it tagged with the new timestamp. the write then commits, but the timestamp is never bumped again, so the next request from that client sends `If-Modified-Since` equal to the stored value, gets a `304`, and keeps the stale copy until some unrelated change happens to bump the timestamp again. for reactions and likes this is especially easy to hit because adding a reaction does not change the post's own `updated_at`, so the `Invalidate` call is the only signal that anything changed.

this moves every `Invalidate` to run after the write succeeds, so the stored timestamp always reflects a time at or after the change. it also means a failed write no longer bumps the timestamp for a change that did not happen.

sites covered: reactions add/remove, post likes add/remove, reply create/update/delete, thread update/delete, category update/move, library node update, node tree attach/sever and before/after/index moves, and account email add/remove/verify, role assign/badge and profile update. thread create already invalidated after the write and is left as-is.

`go vet` and the existing unit tests in the touched packages pass.