### PR TITLE
fix: neutralise stored xss from user-uploaded assets

### DIFF
--- a/app/transports/http/middleware/headers/security.go
+++ b/app/transports/http/middleware/headers/security.go
@@ -1,0 +1,25 @@
+package headers
+
+import (
+	"net/http"
+	"strings"
+)
+
+const assetPathPrefix = "/api/assets/"
+
+// user-uploaded files are served inline from the same origin, so neutralise active content to prevent stored xss
+const assetContentSecurityPolicy = "default-src 'none'; sandbox"
+
+func (m *Middleware) WithAssetSecurityHeaders() func(next http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if strings.HasPrefix(r.URL.Path, assetPathPrefix) {
+				h := w.Header()
+				h.Set("X-Content-Type-Options", "nosniff")
+				h.Set("Content-Security-Policy", assetContentSecurityPolicy)
+			}
+
+			next.ServeHTTP(w, r)
+		})
+	}
+}

--- a/app/transports/http/middleware/headers/security_test.go
+++ b/app/transports/http/middleware/headers/security_test.go
@@ -1,0 +1,37 @@
+package headers
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestWithAssetSecurityHeaders(t *testing.T) {
+	t.Parallel()
+
+	handler := (&Middleware{}).WithAssetSecurityHeaders()(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	t.Run("neutralises active content on asset responses", func(t *testing.T) {
+		t.Parallel()
+
+		rec := httptest.NewRecorder()
+		handler.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/api/assets/evil-svg", nil))
+
+		assert.Equal(t, "nosniff", rec.Header().Get("X-Content-Type-Options"))
+		assert.Equal(t, "default-src 'none'; sandbox", rec.Header().Get("Content-Security-Policy"))
+	})
+
+	t.Run("leaves non-asset responses untouched", func(t *testing.T) {
+		t.Parallel()
+
+		rec := httptest.NewRecorder()
+		handler.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/api/threads", nil))
+
+		assert.Empty(t, rec.Header().Get("X-Content-Type-Options"))
+		assert.Empty(t, rec.Header().Get("Content-Security-Policy"))
+	})
+}

--- a/app/transports/http/router.go
+++ b/app/transports/http/router.go
@@ -38,6 +38,7 @@ func MountOpenAPI(
 	lc.Append(fx.StartHook(func() {
 		applied := httpserver.Apply(router,
 			ri.WithHeaderContext(),
+			ri.WithAssetSecurityHeaders(),
 			co.WithCORS(),
 			lo.WithLogger(),
 			fe.WithFrontendProxy(),


### PR DESCRIPTION
any registered member can upload arbitrary files and turn them into stored xss.

the upload path in `asset_upload.Upload` only runs `mime.Detect` and stores the bytes, with no allowlist, so an `image/svg+xml` or `text/html` file is accepted. `PermissionUploadAsset` is in the default `Member` role, so this is available to every member. `AssetGet` then serves the file inline from `/api/assets/{filename}`, same origin as the app, with `Content-Type` set to the stored mime and no `Content-Disposition`, `X-Content-Type-Options` or `Content-Security-Policy`. next.js sets no mitigating csp either.

so an attacker uploads an svg (or html) containing a `<script>`, gets its `/api/assets/...` url, and lures a victim to open it. the browser renders it as a document and executes the script in the app origin, which means it can call the api as the victim, change their email and take over the account. an admin opening the link is fully compromised.

this adds a middleware that sets `X-Content-Type-Options: nosniff` and `Content-Security-Policy: default-src 'none'; sandbox` on responses under `/api/assets/`. the `sandbox` csp stops the browser executing scripts in svg/html served from the asset path, while normal images still render and can still be embedded with `<img>` (csp on the asset response does not affect embedding). a follow-up could also add a mime allowlist or force `Content-Disposition: attachment` for non-image types.

tests cover that asset responses get the headers and non-asset responses do not. `go vet` is clean.