### PR TITLE
Feat/keycloak configurable display name

### DIFF
--- a/app/services/authentication/provider.go
+++ b/app/services/authentication/provider.go
@@ -21,6 +21,12 @@ type Provider interface {
 	Token() authentication.TokenType
 }
 
+// DisplayNamer is implemented by providers that expose a configurable,
+// human-readable name, overriding the default name derived from Service().
+type DisplayNamer interface {
+	DisplayName() string
+}
+
 type OAuthProvider interface {
 	// Link will, for providers that support it, provide a URL to a third-party
 	// authenticator. OAuth providers use this to start the authentication flow.

--- a/app/services/authentication/provider/oauth/keycloak/keycloak.go
+++ b/app/services/authentication/provider/oauth/keycloak/keycloak.go
@@ -49,6 +49,7 @@ func New(
 				Enabled:      cfg.KeycloakEnabled,
 				ClientID:     cfg.KeycloakClientID,
 				ClientSecret: cfg.KeycloakClientSecret,
+				DisplayName:  cfg.KeycloakDisplayName,
 			},
 		}, nil
 	}
@@ -69,6 +70,7 @@ func New(
 			Enabled:      cfg.KeycloakEnabled,
 			ClientID:     cfg.KeycloakClientID,
 			ClientSecret: cfg.KeycloakClientSecret,
+			DisplayName:  cfg.KeycloakDisplayName,
 		},
 		register: register,
 		ed:       ed,
@@ -82,6 +84,15 @@ func (p *Provider) Service() authentication.Service { return service }
 
 // Token returns the token type used by this provider (always OAuth).
 func (p *Provider) Token() authentication.TokenType { return tokenType }
+
+// DisplayName returns the human-readable name to show for this provider,
+// falling back to "Keycloak" when no custom display name is configured.
+func (p *Provider) DisplayName() string {
+	if p.config.DisplayName == "" {
+		return "Keycloak"
+	}
+	return p.config.DisplayName
+}
 
 // Enabled reports whether the provider is enabled via config.
 func (p *Provider) Enabled(ctx context.Context) (bool, error) {

--- a/app/services/authentication/provider/oauth/keycloak/keycloak_test.go
+++ b/app/services/authentication/provider/oauth/keycloak/keycloak_test.go
@@ -1,0 +1,31 @@
+package keycloak
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/Southclaws/storyden/internal/config"
+)
+
+func TestProviderDisplayNameDefault(t *testing.T) {
+	t.Parallel()
+
+	p, err := New(config.Config{KeycloakEnabled: false}, nil, nil)
+	require.NoError(t, err)
+
+	assert.Equal(t, "Keycloak", p.DisplayName())
+}
+
+func TestProviderDisplayNameCustom(t *testing.T) {
+	t.Parallel()
+
+	p, err := New(config.Config{
+		KeycloakEnabled:     false,
+		KeycloakDisplayName: "Corporate SSO",
+	}, nil, nil)
+	require.NoError(t, err)
+
+	assert.Equal(t, "Corporate SSO", p.DisplayName())
+}

--- a/app/services/authentication/provider/oauth/oauth.go
+++ b/app/services/authentication/provider/oauth/oauth.go
@@ -11,6 +11,7 @@ type Configuration struct {
 	Enabled      bool
 	ClientID     string
 	ClientSecret string
+	DisplayName  string
 }
 
 func Redirect(publicWebURL url.URL, svc authentication.Service) url.URL {

--- a/app/transports/http/bindings/auth.go
+++ b/app/transports/http/bindings/auth.go
@@ -220,16 +220,29 @@ func serialiseAuthProvider(redirectFn func(authentication.Service) url.URL) func
 			}
 			return openapi.AuthProvider{
 				Provider: p.Service().String(),
-				Name:     fmt.Sprintf("%v", p.Service()),
+				Name:     providerName(p),
 				Link:     &link,
 			}, nil
 		}
 
 		return openapi.AuthProvider{
 			Provider: p.Service().String(),
-			Name:     fmt.Sprintf("%v", p.Service()),
+			Name:     providerName(p),
 		}, nil
 	}
+}
+
+// providerName returns the provider's configured display name if it
+// implements DisplayNamer, otherwise falling back to the name derived from
+// its Service() identifier.
+func providerName(p auth_svc.Provider) string {
+	if dn, ok := p.(auth_svc.DisplayNamer); ok {
+		if name := dn.DisplayName(); name != "" {
+			return name
+		}
+	}
+
+	return fmt.Sprintf("%v", p.Service())
 }
 
 func deserialiseAuthMode(in openapi.AuthMode) (authentication.Mode, error) {

--- a/app/transports/http/bindings/auth_test.go
+++ b/app/transports/http/bindings/auth_test.go
@@ -1,0 +1,55 @@
+package bindings
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/Southclaws/storyden/app/resources/account/authentication"
+)
+
+type fakeProvider struct {
+	service authentication.Service
+}
+
+func (f fakeProvider) Enabled(ctx context.Context) (bool, error) { return true, nil }
+func (f fakeProvider) Service() authentication.Service           { return f.service }
+func (f fakeProvider) Token() authentication.TokenType           { return authentication.TokenTypeOAuth }
+
+type fakeDisplayNameProvider struct {
+	fakeProvider
+	name string
+}
+
+func (f fakeDisplayNameProvider) DisplayName() string { return f.name }
+
+func TestProviderNameFallsBackToServiceFormat(t *testing.T) {
+	t.Parallel()
+
+	p := fakeProvider{service: authentication.ServiceOAuthGitHub}
+
+	assert.Equal(t, "GitHub", providerName(p))
+}
+
+func TestProviderNameUsesDisplayNamerOverride(t *testing.T) {
+	t.Parallel()
+
+	p := fakeDisplayNameProvider{
+		fakeProvider: fakeProvider{service: authentication.ServiceOAuthKeycloak},
+		name:         "Corporate SSO",
+	}
+
+	assert.Equal(t, "Corporate SSO", providerName(p))
+}
+
+func TestProviderNameFallsBackWhenDisplayNameEmpty(t *testing.T) {
+	t.Parallel()
+
+	p := fakeDisplayNameProvider{
+		fakeProvider: fakeProvider{service: authentication.ServiceOAuthKeycloak},
+		name:         "",
+	}
+
+	assert.Equal(t, "Keycloak", providerName(p))
+}

--- a/home/content/docs/reference/configuration.mdx
+++ b/home/content/docs/reference/configuration.mdx
@@ -556,6 +556,15 @@ The client secret for the Keycloak OAuth2 application.
 
 The issuer/discovery URL for the Keycloak realm (e.g. https://auth.example.com/realms/YourRealm).
 
+### `OAUTH_KEYCLOAK_DISPLAY_NAME`
+
+<table>
+<tr><td>type</td><td>`string`</td></tr>
+<tr><td>default</td><td>`Keycloak`</td></tr>
+</table>
+
+The display name shown for the Keycloak login button.
+
 ### `OAUTH_ENABLED`
 
 <table>

--- a/home/content/docs/reference/oauth/keycloak.mdx
+++ b/home/content/docs/reference/oauth/keycloak.mdx
@@ -15,6 +15,7 @@ OAUTH_KEYCLOAK_ENABLED=true
 OAUTH_KEYCLOAK_CLIENT_ID=your-client-id
 OAUTH_KEYCLOAK_CLIENT_SECRET=your-client-secret
 OAUTH_KEYCLOAK_ISSUER_URL=https://auth.example.com/realms/YourRealm
+OAUTH_KEYCLOAK_DISPLAY_NAME=Keycloak # optional, defaults to "Keycloak"
 ```
 
 ## Setting Up Keycloak
@@ -32,7 +33,7 @@ Storyden uses OIDC discovery to automatically configure endpoints from `{issuer}
 
 ## Using with Other OIDC Providers
 
-Since Storyden uses standard OIDC discovery, you can use this integration with other identity providers that support OIDC:
+Since Storyden uses standard OIDC discovery, you can use this integration with other identity providers that support OIDC. Set `OAUTH_KEYCLOAK_DISPLAY_NAME` to match the actual provider you're using (e.g. `Authentik`, `Auth0`, `Okta`, `Microsoft Entra ID`) so the login button doesn't say "Keycloak":
 
 ### Authentik
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -297,6 +297,8 @@ type Config struct {
 	KeycloakClientSecret string `envconfig:"OAUTH_KEYCLOAK_CLIENT_SECRET"`
 	// The issuer/discovery URL for the Keycloak realm (e.g. https://auth.example.com/realms/YourRealm).
 	KeycloakIssuerURL url.URL `envconfig:"OAUTH_KEYCLOAK_ISSUER_URL"`
+	// The display name shown for the Keycloak login button.
+	KeycloakDisplayName string `default:"Keycloak" envconfig:"OAUTH_KEYCLOAK_DISPLAY_NAME"`
 	// Enable Storyden's built-in OAuth2/OIDC authorization server endpoints.
 	OAuthEnabled bool `envconfig:"OAUTH_ENABLED"`
 	// Access token lifetime for Storyden OAuth tokens.

--- a/internal/config/config.yaml
+++ b/internal/config/config.yaml
@@ -429,6 +429,13 @@
       description: |-
         The issuer/discovery URL for the Keycloak realm (e.g. https://auth.example.com/realms/YourRealm).
 
+    - env: OAUTH_KEYCLOAK_DISPLAY_NAME
+      name: KeycloakDisplayName
+      type: string
+      default: Keycloak
+      description: |-
+        The display name shown for the Keycloak login button.
+
     - env: OAUTH_ENABLED
       name: OAuthEnabled
       type: bool


### PR DESCRIPTION
Make the Keycloak login button's display name configurable

Storyden's Keycloak provider works with any OIDC-compatible IdP (Authentik, Auth0, Okta, Entra ID, etc.), but the login button always says "Keycloak" no matter which provider is actually configured.

This adds an optional OAUTH_KEYCLOAK_DISPLAY_NAME env var to customize that label. Defaults to "Keycloak", so nothing changes for existing setups.