### PR TITLE
Remove sd download timeout and add progress

### DIFF
--- a/cmd/sd/internal/api/auth.go
+++ b/cmd/sd/internal/api/auth.go
@@ -18,27 +18,17 @@ import (
 	"github.com/Southclaws/storyden/cmd/sd/internal/config"
 )
 
-const (
-	refreshLeeway  = time.Minute
-	requestTimeout = 30 * time.Second
-)
+const refreshLeeway = time.Minute
 
 type AuthenticatedClientOption func(*authenticatedClientOptions)
 
 type authenticatedClientOptions struct {
 	rateLimitWarnings io.Writer
-	requestTimeout    time.Duration
 }
 
 func WithRateLimitWarnings(w io.Writer) AuthenticatedClientOption {
 	return func(opts *authenticatedClientOptions) {
 		opts.rateLimitWarnings = w
-	}
-}
-
-func WithRequestTimeout(timeout time.Duration) AuthenticatedClientOption {
-	return func(opts *authenticatedClientOptions) {
-		opts.requestTimeout = timeout
 	}
 }
 
@@ -54,7 +44,6 @@ type AuthSession struct {
 func NewAuthenticatedClient(ctx context.Context, store *config.Store, options ...AuthenticatedClientOption) (*Client, error) {
 	opts := authenticatedClientOptions{
 		rateLimitWarnings: os.Stderr,
-		requestTimeout:    requestTimeout,
 	}
 	for _, option := range options {
 		option(&opts)
@@ -85,7 +74,7 @@ func NewAuthenticatedClient(ctx context.Context, store *config.Store, options ..
 	authenticated, err := openapi.NewClientWithResponses(
 		client.BaseURL,
 		openapi.WithHTTPClient(authenticatedDoer{
-			base:              &http.Client{Timeout: opts.requestTimeout},
+			base:              &http.Client{},
 			session:           session,
 			rateLimitWarnings: opts.rateLimitWarnings,
 		}),

--- a/cmd/sd/internal/api/auth_test.go
+++ b/cmd/sd/internal/api/auth_test.go
@@ -15,10 +15,43 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/Southclaws/storyden/app/transports/http/openapi"
 	"github.com/Southclaws/storyden/cmd/sd/internal/config"
 )
 
 func TestNewAuthenticatedClient(t *testing.T) {
+	t.Run("does not impose a whole request timeout", func(t *testing.T) {
+		r := require.New(t)
+
+		server := httptest.NewServer(http.NotFoundHandler())
+		defer server.Close()
+
+		store := config.NewFileStoreAt(filepath.Join(t.TempDir(), "storyden", "config.yaml"))
+		cfg := config.New()
+		cfg.UpsertContext("local", config.Context{
+			APIURL:   server.URL,
+			AuthType: config.AuthStorageFile,
+			Auth: &config.Auth{
+				Method:      config.AuthMethodAccessKey,
+				AccessToken: "sdak_test_access_key",
+				TokenType:   "Bearer",
+			},
+		})
+		cfg.SetCurrentContext("local")
+		r.NoError(store.Save(cfg))
+
+		client, err := NewAuthenticatedClient(context.Background(), store)
+		r.NoError(err)
+
+		generated, ok := client.OpenAPI.ClientInterface.(*openapi.Client)
+		r.True(ok)
+		authenticated, ok := generated.Client.(authenticatedDoer)
+		r.True(ok)
+		httpClient, ok := authenticated.base.(*http.Client)
+		r.True(ok)
+		r.Zero(httpClient.Timeout)
+	})
+
 	t.Run("returns human readable rate limit errors", func(t *testing.T) {
 		r := require.New(t)
 

--- a/cmd/sd/internal/commands/plugin/dev/download/download.go
+++ b/cmd/sd/internal/commands/plugin/dev/download/download.go
@@ -50,10 +50,13 @@ sd plugin dev download d8cg... --no-unzip
 				return err
 			}
 
-			data, err := plugindev.DownloadPackage(cmd.Context(), client.OpenAPI, args[0])
+			progress := newDownloadProgress(cmd.ErrOrStderr())
+			data, err := plugindev.DownloadPackage(cmd.Context(), client.OpenAPI, args[0], progress.Update)
 			if err != nil {
+				progress.Clear()
 				return err
 			}
+			progress.Finish(int64(len(data)))
 
 			if noUnzip {
 				filename := plugindev.PackageFilename(cmd.Context(), data, args[0])

--- a/cmd/sd/internal/commands/plugin/dev/download/progress.go
+++ b/cmd/sd/internal/commands/plugin/dev/download/progress.go
@@ -1,0 +1,71 @@
+package download
+
+import (
+	"fmt"
+	"io"
+	"time"
+
+	"charm.land/bubbles/v2/progress"
+	"github.com/dustin/go-humanize"
+
+	"github.com/Southclaws/storyden/cmd/sd/internal/output"
+)
+
+const progressRefreshInterval = 100 * time.Millisecond
+
+type downloadProgress struct {
+	out        io.Writer
+	bar        progress.Model
+	enabled    bool
+	lastRender time.Time
+}
+
+func newDownloadProgress(out io.Writer) *downloadProgress {
+	barWidth := max(10, output.TerminalWidth(out, 80)-42)
+
+	return &downloadProgress{
+		out:     out,
+		bar:     progress.New(progress.WithDefaultBlend(), progress.WithWidth(barWidth)),
+		enabled: output.IsTerminal(out),
+	}
+}
+
+func (p *downloadProgress) Update(downloaded, total int64) {
+	if !p.enabled {
+		return
+	}
+
+	now := time.Now()
+	if downloaded > 0 && downloaded < total && now.Sub(p.lastRender) < progressRefreshInterval {
+		return
+	}
+	p.lastRender = now
+
+	if total <= 0 {
+		fmt.Fprintf(p.out, "\r\x1b[2KDownloading plugin package: %s", humanize.Bytes(uint64(max(downloaded, 0))))
+		return
+	}
+
+	percent := min(float64(downloaded)/float64(total), 1)
+	fmt.Fprintf(
+		p.out,
+		"\r\x1b[2KDownloading %s / %s %s",
+		humanize.Bytes(uint64(max(downloaded, 0))),
+		humanize.Bytes(uint64(total)),
+		p.bar.ViewAs(percent),
+	)
+}
+
+func (p *downloadProgress) Finish(downloaded int64) {
+	if !p.enabled {
+		return
+	}
+	p.Update(downloaded, downloaded)
+	fmt.Fprintln(p.out)
+}
+
+func (p *downloadProgress) Clear() {
+	if p.enabled {
+		fmt.Fprint(p.out, "\r\x1b[2K")
+	}
+}

--- a/cmd/sd/internal/commands/plugin/logs/logs.go
+++ b/cmd/sd/internal/commands/plugin/logs/logs.go
@@ -24,7 +24,7 @@ func New(store *config.Store) LogsCommand {
 		Short: "Stream supervised plugin logs",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			client, err := api.NewAuthenticatedClient(cmd.Context(), store, api.WithRequestTimeout(0))
+			client, err := api.NewAuthenticatedClient(cmd.Context(), store)
 			if err != nil {
 				return err
 			}

--- a/go.mod
+++ b/go.mod
@@ -163,6 +163,7 @@ require (
 	github.com/cenkalti/backoff/v5 v5.0.3 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/charmbracelet/colorprofile v0.4.3 // indirect
+	github.com/charmbracelet/harmonica v0.2.0 // indirect
 	github.com/charmbracelet/ultraviolet v0.0.0-20260416155717-489999b90468 // indirect
 	github.com/charmbracelet/x/ansi v0.11.7 // indirect
 	github.com/charmbracelet/x/exp/charmtone v0.0.0-20250603201427-c31516f43444 // indirect

--- a/go.sum
+++ b/go.sum
@@ -164,6 +164,8 @@ github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UF
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/charmbracelet/colorprofile v0.4.3 h1:QPa1IWkYI+AOB+fE+mg/5/4HRMZcaXex9t5KX76i20Q=
 github.com/charmbracelet/colorprofile v0.4.3/go.mod h1:/zT4BhpD5aGFpqQQqw7a+VtHCzu+zrQtt1zhMt9mR4Q=
+github.com/charmbracelet/harmonica v0.2.0 h1:8NxJWRWg/bzKqqEaaeFNipOu77YR5t8aSwG4pgaUBiQ=
+github.com/charmbracelet/harmonica v0.2.0/go.mod h1:KSri/1RMQOZLbw7AHqgcBycp8pgJnQMYYT8QZRqZ1Ao=
 github.com/charmbracelet/ultraviolet v0.0.0-20260416155717-489999b90468 h1:Q9fO0y1Zo5KB/5Vu8JZoLGm1N3RzF9bNj3Ao3xoR+Ac=
 github.com/charmbracelet/ultraviolet v0.0.0-20260416155717-489999b90468/go.mod h1:bAAz7dh/FTYfC+oiHavL4mX1tOIBZ0ZwYjSi3qE6ivM=
 github.com/charmbracelet/x/ansi v0.11.7 h1:kzv1kJvjg2S3r9KHo8hDdHFQLEqn4RBCb39dAYC84jI=

--- a/lib/plugin/dev/plugin_api.go
+++ b/lib/plugin/dev/plugin_api.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"io"
 	"net/http"
 	"net/url"
 	"strings"
@@ -23,6 +24,32 @@ type statusResponse interface {
 	Status() string
 	StatusCode() int
 }
+
+type DownloadProgress func(downloaded, total int64)
+
+type downloadProgressReader struct {
+	reader     io.Reader
+	downloaded int64
+	total      int64
+	progress   DownloadProgress
+}
+
+func (r *downloadProgressReader) Read(buffer []byte) (int, error) {
+	read, err := r.reader.Read(buffer)
+	if read > 0 {
+		r.downloaded += int64(read)
+		r.progress(r.downloaded, r.total)
+	}
+	return read, err
+}
+
+type httpStatusResponse struct {
+	response *http.Response
+}
+
+func (r httpStatusResponse) Status() string { return r.response.Status }
+
+func (r httpStatusResponse) StatusCode() int { return r.response.StatusCode }
 
 func EnsureExternalPlugin(ctx context.Context, client *openapi.ClientWithResponses, manifest rpc.Manifest, requestedID string, noUpdate bool) (*ExternalPlugin, error) {
 	if requestedID != "" {
@@ -149,15 +176,36 @@ func GetPlugin(ctx context.Context, client *openapi.ClientWithResponses, id stri
 	return (*openapi.Plugin)(response.JSON200), nil
 }
 
-func DownloadPackage(ctx context.Context, client *openapi.ClientWithResponses, id string) ([]byte, error) {
-	response, err := client.PluginDownloadPackageWithResponse(ctx, openapi.PluginIDParam(id))
+func DownloadPackage(ctx context.Context, client *openapi.ClientWithResponses, id string, progress DownloadProgress) ([]byte, error) {
+	response, err := client.PluginDownloadPackage(ctx, openapi.PluginIDParam(id))
 	if err != nil {
 		return nil, err
 	}
-	if response.StatusCode() != http.StatusOK {
-		return nil, requestError("plugin package download request", response, response.Body)
+	defer response.Body.Close()
+
+	if response.StatusCode != http.StatusOK {
+		body, readErr := io.ReadAll(response.Body)
+		if readErr != nil {
+			return nil, fmt.Errorf("read plugin package download error: %w", readErr)
+		}
+		return nil, requestError("plugin package download request", httpStatusResponse{response}, body)
 	}
-	return response.Body, nil
+
+	var reader io.Reader = response.Body
+	if progress != nil {
+		progress(0, response.ContentLength)
+		reader = &downloadProgressReader{
+			reader:   response.Body,
+			total:    response.ContentLength,
+			progress: progress,
+		}
+	}
+
+	data, err := io.ReadAll(reader)
+	if err != nil {
+		return nil, fmt.Errorf("read plugin package download: %w", err)
+	}
+	return data, nil
 }
 
 func DeletePlugin(ctx context.Context, client *openapi.ClientWithResponses, id string) error {

--- a/lib/plugin/dev/plugin_api_test.go
+++ b/lib/plugin/dev/plugin_api_test.go
@@ -1,0 +1,51 @@
+package dev
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/Southclaws/storyden/app/transports/http/openapi"
+)
+
+func TestDownloadPackageReportsProgress(t *testing.T) {
+	packageData := []byte("a plugin package large enough to arrive in a few writes")
+	server := httptest.NewServer(http.HandlerFunc(func(response http.ResponseWriter, request *http.Request) {
+		assert.Equal(t, "/plugins/plugin-instance/package", request.URL.Path)
+		response.Header().Set("Content-Type", "application/zip")
+		response.Header().Set("Content-Length", fmt.Sprint(len(packageData)))
+		response.WriteHeader(http.StatusOK)
+		_, err := response.Write(packageData)
+		require.NoError(t, err)
+	}))
+	defer server.Close()
+
+	client, err := openapi.NewClientWithResponses(server.URL)
+	require.NoError(t, err)
+
+	type progressEvent struct {
+		downloaded int64
+		total      int64
+	}
+	events := []progressEvent{}
+
+	data, err := DownloadPackage(
+		context.Background(),
+		client,
+		"plugin-instance",
+		func(downloaded, total int64) {
+			events = append(events, progressEvent{downloaded: downloaded, total: total})
+		},
+	)
+
+	require.NoError(t, err)
+	assert.Equal(t, packageData, data)
+	require.NotEmpty(t, events)
+	assert.Equal(t, progressEvent{downloaded: 0, total: int64(len(packageData))}, events[0])
+	assert.Equal(t, progressEvent{downloaded: int64(len(packageData)), total: int64(len(packageData))}, events[len(events)-1])
+}


### PR DESCRIPTION
## Summary

- remove the authenticated `sd` HTTP client's 30-second whole-request timeout
- stream plugin package response reads through byte progress reporting
- render a terminal-only Charm progress bar while keeping redirected output clean
- retain the separate 15-second OAuth discovery timeout and command-context cancellation

## Root cause

The authenticated CLI client configured `http.Client.Timeout` to 30 seconds. Go applies that deadline to the entire exchange, including reading the response body, so large plugin packages could fail on slow networks even while the download was making progress.

## Impact

`sd plugin dev download` can now wait as long as needed for a package body, while users can still cancel the command normally. Interactive downloads show transferred and total bytes with a progress bar.

## Validation

- `go test ./cmd/sd/... ./lib/plugin/dev`
- `git diff --check`
- `go install ./cmd/sd` and `sd --help`