### PR TITLE
fix: block reserved and tunnelled address ranges in httpsafe

### DIFF
--- a/internal/infrastructure/httpsafe/httpsafe.go
+++ b/internal/infrastructure/httpsafe/httpsafe.go
@@ -19,14 +19,23 @@ var (
 )
 
 var disallowedPrefixes = []netip.Prefix{
+	netip.MustParsePrefix("0.0.0.0/8"),
 	netip.MustParsePrefix("10.0.0.0/8"),
 	netip.MustParsePrefix("100.64.0.0/10"),
 	netip.MustParsePrefix("127.0.0.0/8"),
 	netip.MustParsePrefix("169.254.0.0/16"),
 	netip.MustParsePrefix("172.16.0.0/12"),
+	netip.MustParsePrefix("192.0.0.0/24"),
 	netip.MustParsePrefix("192.168.0.0/16"),
+	netip.MustParsePrefix("198.18.0.0/15"),
+	netip.MustParsePrefix("240.0.0.0/4"),
+	netip.MustParsePrefix("::/128"),
 	netip.MustParsePrefix("::1/128"),
 	netip.MustParsePrefix("64:ff9b::/96"),
+	// 6to4 and teredo embed an arbitrary ipv4 address that would otherwise
+	// bypass the ipv4 checks above
+	netip.MustParsePrefix("2001::/32"),
+	netip.MustParsePrefix("2002::/16"),
 	netip.MustParsePrefix("fc00::/7"),
 	netip.MustParsePrefix("fe80::/10"),
 }

--- a/internal/infrastructure/httpsafe/httpsafe_test.go
+++ b/internal/infrastructure/httpsafe/httpsafe_test.go
@@ -19,6 +19,16 @@ func TestIsDisallowedAddr(t *testing.T) {
 	for _, ip := range []string{"8.8.8.8", "1.1.1.1", "2606:4700:4700::1111"} {
 		assert.False(t, IsDisallowedAddr(netip.MustParseAddr(ip)), ip)
 	}
+
+	// reserved ranges that route to the local host or to unrouteable space
+	for _, ip := range []string{"0.1.2.3", "192.0.0.1", "198.18.0.1", "240.0.0.1", "255.255.255.255", "::"} {
+		assert.True(t, IsDisallowedAddr(netip.MustParseAddr(ip)), ip)
+	}
+
+	// 6to4 and teredo tunnel an arbitrary ipv4 destination inside an ipv6 literal
+	for _, ip := range []string{"2002:7f00:0001::", "2002:a9fe:a9fe::", "2001:0:4136:e378:8000:63bf:3fff:fdd2"} {
+		assert.True(t, IsDisallowedAddr(netip.MustParseAddr(ip)), ip)
+	}
 	// ipv4-mapped and nat64 forms of the metadata address must also be caught
 	assert.True(t, IsDisallowedAddr(netip.MustParseAddr("::ffff:169.254.169.254")))
 	assert.True(t, IsDisallowedAddr(netip.MustParseAddr("64:ff9b::169.254.169.254")))


### PR DESCRIPTION
`httpsafe` covers the obvious private ranges, but a few reserved ones are still reachable, and two of them are useful to an attacker

`0.0.0.0/8` is the interesting one, `IsDisallowedAddr` only catches the unspecified address exactly via `addr.IsUnspecified()`, so `0.0.0.0` is blocked but `0.1.2.3` is not, on linux the whole `0.0.0.0/8` block routes to the local host, so `http://0.1.2.3/` reaches a service on `127.0.1.2`

the other gap is ipv6 tunnel space, `2002::/16` (6to4) and `2001::/32` (teredo) embed an arbitrary ipv4 address inside an ipv6 literal, so `2002:7f00:0001::` is a valid way to write `127.0.0.1` that never touches any of the ipv4 prefixes in the list

this adds `0.0.0.0/8`, `192.0.0.0/24`, `198.18.0.0/15`, `240.0.0.0/4`, `::/128`, `2001::/32` and `2002::/16` to `disallowedPrefixes`, the `240.0.0.0/4` entry also picks up the broadcast address

`TestIsDisallowedAddr` gains cases for each new range, including the 6to4 forms of `127.0.0.1` and `169.254.169.254`, the existing public-address cases still pass and `go test ./internal/infrastructure/httpsafe/` is green