### PR TITLE
fix: stop issuing client-side cached reads with a zero TTL in RedisCache

### DIFF
--- a/internal/infrastructure/cache/redis/redis_cache.go
+++ b/internal/infrastructure/cache/redis/redis_cache.go
@@ -11,13 +11,7 @@ import (
 var errNotFound = fmt.Errorf("not found")
 
 type RedisCache struct {
-	client  rueidis.Client
-	options Options
-}
-
-type Options struct {
-	Expiration                time.Duration
-	ClientSideCacheExpiration time.Duration
+	client rueidis.Client
 }
 
 func New(client rueidis.Client) *RedisCache {
@@ -25,8 +19,8 @@ func New(client rueidis.Client) *RedisCache {
 }
 
 func (c *RedisCache) Get(ctx context.Context, key string) (string, error) {
-	cmd := c.client.B().Get().Key(key).Cache()
-	res := c.client.DoCache(ctx, cmd, c.options.ClientSideCacheExpiration)
+	cmd := c.client.B().Get().Key(key).Build()
+	res := c.client.Do(ctx, cmd)
 
 	str, err := res.ToString()
 	if rueidis.IsRedisNil(err) {


### PR DESCRIPTION
`RedisCache.Get` reads through rueidis client-side caching:

```go
cmd := c.client.B().Get().Key(key).Cache()
res := c.client.DoCache(ctx, cmd, c.options.ClientSideCacheExpiration)
```

`c.options` is never assigned, `New` only sets `client`, and nothing else in the tree constructs a `RedisCache` or touches `Options`, so `ClientSideCacheExpiration` is always the zero value

rueidis treats that as an entry that expires immediately, so the client-side cache never serves a hit, but every `Get` still pays for the opt-in path, which wraps the read in `MULTI`, `PTTL`, `GET`, `EXEC`, so each cache read is five commands instead of one and returns the same result it would have anyway, session validation goes through this path on every authenticated request

this switches `Get` to a plain `Do` with a normal `Build()` command and drops the unused `Options` struct, behaviour is identical to what actually happens today, minus the extra round trip

worth saying that the other direction is also reasonable, keep `DoCache` and give it a real TTL, i went with removal because it preserves current behaviour exactly, and turning on client-side caching for session lookups is a deliberate call about revocation latency rather than a bug fix, happy to redo it that way if you'd prefer

no test here, there's no redis harness or mock in the repo and adding one for this felt disproportionate, `go build ./internal/infrastructure/cache/...` and `go vet` are clean