### PR TITLE
fix: never return a nil session with a nil error from the cached token repository

### DIFF
--- a/app/resources/account/token/repo.go
+++ b/app/resources/account/token/repo.go
@@ -57,11 +57,17 @@ func (r *cachedRepo) Revoke(ctx context.Context, token Token) error {
 func (r *cachedRepo) Validate(ctx context.Context, t Token) (*Validated, error) {
 	sess, found, err := r.get(ctx, t)
 	if err != nil {
-		return nil, r.delete(ctx, t)
-	}
+		// an unreadable entry is evicted so the database decides instead
+		if delErr := r.delete(ctx, t); delErr != nil {
+			return nil, fault.Wrap(delErr, fctx.With(ctx))
+		}
+	} else if found {
+		v, err := sess.Validate()
+		if err != nil {
+			return nil, fault.Wrap(err, fctx.With(ctx))
+		}
 
-	if found {
-		return sess, nil
+		return v, nil
 	}
 
 	// Fall back to database query.
@@ -78,7 +84,7 @@ func (r *cachedRepo) Validate(ctx context.Context, t Token) (*Validated, error) 
 	return v, nil
 }
 
-func (r *cachedRepo) get(ctx context.Context, t Token) (*Validated, bool, error) {
+func (r *cachedRepo) get(ctx context.Context, t Token) (*Session, bool, error) {
 	raw, err := r.store.Get(ctx, t.ID.String())
 	if err != nil {
 		// Cache miss, found=false
@@ -92,12 +98,7 @@ func (r *cachedRepo) get(ctx context.Context, t Token) (*Validated, bool, error)
 		return nil, false, fault.Wrap(err, fctx.With(ctx))
 	}
 
-	v, err := session.Validate()
-	if err != nil {
-		return nil, false, fault.Wrap(err, fctx.With(ctx))
-	}
-
-	return v, true, nil
+	return session, true, nil
 }
 
 func (r *cachedRepo) cache(ctx context.Context, s Session) error {

--- a/app/resources/account/token/repo_test.go
+++ b/app/resources/account/token/repo_test.go
@@ -1,0 +1,127 @@
+package token
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/Southclaws/opt"
+	"github.com/rs/xid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/Southclaws/storyden/app/resources/account"
+	"github.com/Southclaws/storyden/internal/infrastructure/cache/cachetest"
+)
+
+type fakeRepo struct {
+	session *Session
+	err     error
+	calls   int
+}
+
+func (f *fakeRepo) Issue(context.Context, account.AccountID) (*Session, error) { return f.session, nil }
+func (f *fakeRepo) Revoke(context.Context, Token) error                       { return nil }
+
+func (f *fakeRepo) Validate(context.Context, Token) (*Validated, error) {
+	f.calls++
+	if f.err != nil {
+		return nil, f.err
+	}
+	return (*Validated)(f.session), nil
+}
+
+func liveSession(t Token) Session {
+	return Session{
+		Token:     t,
+		AccountID: account.AccountID(xid.New()),
+		ExpiresAt: time.Now().Add(time.Hour),
+	}
+}
+
+func seed(t *testing.T, store *cachetest.Store, s Session) {
+	t.Helper()
+
+	payload, err := s.Serialise()
+	require.NoError(t, err)
+	require.NoError(t, store.Set(context.Background(), s.Token.String(), string(payload), time.Hour))
+}
+
+func TestCachedValidateRejectsRevokedCachedSession(t *testing.T) {
+	t.Parallel()
+
+	store := cachetest.New()
+	inner := &fakeRepo{}
+	repo := NewCachedRepository(inner, store)
+
+	tok := Generate()
+	revoked := liveSession(tok)
+	revoked.RevokedAt = opt.New(time.Now())
+	seed(t, store, revoked)
+
+	v, err := repo.Validate(context.Background(), tok)
+
+	require.Error(t, err, "a revoked cached session must not validate")
+	assert.True(t, errors.Is(err, ErrTokenRevoked))
+	assert.Nil(t, v)
+	assert.Zero(t, inner.calls, "a revoked cached session must not fall through to the database")
+}
+
+func TestCachedValidateRejectsExpiredCachedSession(t *testing.T) {
+	t.Parallel()
+
+	store := cachetest.New()
+	inner := &fakeRepo{}
+	repo := NewCachedRepository(inner, store)
+
+	tok := Generate()
+	expired := liveSession(tok)
+	expired.ExpiresAt = time.Now().Add(-time.Minute)
+	seed(t, store, expired)
+
+	v, err := repo.Validate(context.Background(), tok)
+
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, ErrTokenExpired))
+	assert.Nil(t, v)
+}
+
+func TestCachedValidateFallsBackWhenEntryIsUnreadable(t *testing.T) {
+	t.Parallel()
+
+	store := cachetest.New()
+
+	tok := Generate()
+	stored := liveSession(tok)
+	inner := &fakeRepo{session: &stored}
+	repo := NewCachedRepository(inner, store)
+
+	require.NoError(t, store.Set(context.Background(), tok.String(), "not json", time.Hour))
+
+	v, err := repo.Validate(context.Background(), tok)
+
+	require.NoError(t, err)
+	require.NotNil(t, v, "an unreadable entry must never yield a nil session with a nil error")
+	assert.Equal(t, stored.AccountID, v.AccountID)
+	assert.Equal(t, 1, inner.calls)
+}
+
+func TestCachedValidateServesValidCachedSession(t *testing.T) {
+	t.Parallel()
+
+	store := cachetest.New()
+	inner := &fakeRepo{}
+	repo := NewCachedRepository(inner, store)
+
+	tok := Generate()
+	stored := liveSession(tok)
+	seed(t, store, stored)
+
+	v, err := repo.Validate(context.Background(), tok)
+
+	require.NoError(t, err)
+	require.NotNil(t, v)
+	assert.Equal(t, stored.AccountID, v.AccountID)
+	assert.Zero(t, inner.calls, "a usable cached session must not hit the database")
+}


### PR DESCRIPTION
`cachedRepo.Validate` has an error path that returns a nil session and a nil error:

```go
sess, found, err := r.get(ctx, t)
if err != nil {
    return nil, r.delete(ctx, t)
}
```

when `r.get` fails, the return value is whatever `r.delete` gives back, and `delete` returns nil on success, so the caller gets `(nil, nil)`, the original error is dropped on the floor at the same time

`session.Validator.ValidateSessionToken` reads the result straight away:

```go
tv, err := v.tokenRepo.Validate(ctx, t)
if err != nil { ... }
acc, err := v.accountQuerier.GetRefByID(ctx, tv.AccountID)
```

so `tv.AccountID` panics on the nil pointer, and the request dies in the session middleware before any handler runs

`r.get` reaches that path for two different reasons, a cached entry that will not deserialise, and a cached entry whose session is revoked or expired, they want opposite handling, so this splits them, `get` now only fetches and deserialises, and validation moves up into `Validate`, a cached session that is revoked or expired returns `ErrTokenRevoked` or `ErrTokenExpired` to the caller instead of being silently swallowed, an entry that cannot be read is evicted and the lookup falls through to the database, a failure to evict is returned as a real error rather than masking the result

new tests in `repo_test.go` cover all four cases against a fake inner repository, revoked and expired cached sessions now error and never reach the database, an unreadable entry falls back and returns the stored session, and a healthy cached session is served without a database call, `go test ./app/resources/account/token/` and `go vet` are clean