### PR TITLE
fix: evict the session cache after revoking, not only before

### DIFF
--- a/app/resources/account/token/repo.go
+++ b/app/resources/account/token/repo.go
@@ -51,6 +51,10 @@ func (r *cachedRepo) Revoke(ctx context.Context, token Token) error {
 		return err
 	}
 
+	if err := r.delete(ctx, token); err != nil {
+		return err
+	}
+
 	return nil
 }
 

--- a/app/resources/account/token/revoke_test.go
+++ b/app/resources/account/token/revoke_test.go
@@ -1,0 +1,73 @@
+package token
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/rs/xid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/Southclaws/storyden/app/resources/account"
+	"github.com/Southclaws/storyden/internal/infrastructure/cache/cachetest"
+)
+
+type revokeRacingRepo struct {
+	session      Session
+	revoked      bool
+	duringRevoke func()
+}
+
+func (f *revokeRacingRepo) Issue(context.Context, account.AccountID) (*Session, error) {
+	return &f.session, nil
+}
+
+func (f *revokeRacingRepo) Revoke(context.Context, Token) error {
+	if f.duringRevoke != nil {
+		f.duringRevoke()
+	}
+	f.revoked = true
+	return nil
+}
+
+func (f *revokeRacingRepo) Validate(context.Context, Token) (*Validated, error) {
+	if f.revoked {
+		return nil, ErrTokenRevoked
+	}
+	s := f.session
+	return (*Validated)(&s), nil
+}
+
+func TestCachedRevokeEvictsSessionCachedDuringTheWrite(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	store := cachetest.New()
+
+	tok := Generate()
+	inner := &revokeRacingRepo{
+		session: Session{
+			Token:     tok,
+			AccountID: account.AccountID(xid.New()),
+			ExpiresAt: time.Now().Add(90 * 24 * time.Hour),
+		},
+	}
+
+	repo := NewCachedRepository(inner, store)
+
+	inner.duringRevoke = func() {
+		_, err := repo.Validate(ctx, tok)
+		require.NoError(t, err)
+	}
+
+	require.NoError(t, repo.Revoke(ctx, tok))
+	require.True(t, inner.revoked)
+
+	_, err := store.Get(ctx, tok.String())
+	assert.Error(t, err, "the pre-revocation session must not survive in the cache")
+
+	v, err := repo.Validate(ctx, tok)
+	require.Error(t, err, "a revoked session must not validate after logout")
+	assert.Nil(t, v)
+}


### PR DESCRIPTION
`cachedRepo.Revoke` clears the cache first, then writes the revocation:

```go
if err := r.delete(ctx, token); err != nil { ... }
if err := r.repo.Revoke(ctx, token); err != nil { ... }
```

anything validating the same token in between misses the cache, reads a row that isn't revoked yet, and puts it straight back, nothing clears it a second time

`Validate` checks the cache before the database, so the resurrected entry keeps winning, and `cache` takes its TTL from `time.Until(s.ExpiresAt)` against a 90 day `Expiry`, so logging out can leave the session usable for months

fix is the before and after invalidation that `node_mutate` got in #796

the test forces the interleaving rather than hoping for it, the fake repo calls back into `Validate` from inside `Revoke`, which is where a real concurrent request would land, main fails it on both assertions