### PR TITLE
fix: namespace session cache keys instead of using the bare token

### DIFF
--- a/app/resources/account/token/cache_key_test.go
+++ b/app/resources/account/token/cache_key_test.go
@@ -1,0 +1,74 @@
+package token
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/rs/xid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/Southclaws/storyden/app/resources/account"
+	"github.com/Southclaws/storyden/internal/infrastructure/cache/cachetest"
+)
+
+type keyStubRepo struct{ session Session }
+
+func (f *keyStubRepo) Issue(context.Context, account.AccountID) (*Session, error) {
+	return &f.session, nil
+}
+func (f *keyStubRepo) Revoke(context.Context, Token) error { return nil }
+func (f *keyStubRepo) Validate(context.Context, Token) (*Validated, error) {
+	s := f.session
+	return (*Validated)(&s), nil
+}
+
+func TestSessionCacheKeysAreNamespaced(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	store := cachetest.New()
+
+	tok := Generate()
+	inner := &keyStubRepo{session: Session{
+		Token:     tok,
+		AccountID: account.AccountID(xid.New()),
+		ExpiresAt: time.Now().Add(time.Hour),
+	}}
+
+	repo := NewCachedRepository(inner, store)
+
+	_, err := repo.Validate(ctx, tok)
+	require.NoError(t, err)
+
+	_, err = store.Get(ctx, tok.String())
+	assert.Error(t, err, "the bare token must not be usable as a cache key")
+
+	_, err = store.Get(ctx, cachePrefix+tok.String())
+	assert.NoError(t, err)
+}
+
+func TestSessionCacheReadWriteAndDeleteAgree(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	store := cachetest.New()
+
+	tok := Generate()
+	inner := &keyStubRepo{session: Session{
+		Token:     tok,
+		AccountID: account.AccountID(xid.New()),
+		ExpiresAt: time.Now().Add(time.Hour),
+	}}
+
+	repo := NewCachedRepository(inner, store)
+
+	_, err := repo.Validate(ctx, tok)
+	require.NoError(t, err)
+
+	require.NoError(t, repo.Revoke(ctx, tok))
+
+	_, err = store.Get(ctx, cachePrefix+tok.String())
+	assert.Error(t, err, "revoke must delete the key that cache and get use")
+}

--- a/app/resources/account/token/repo.go
+++ b/app/resources/account/token/repo.go
@@ -11,6 +11,8 @@ import (
 	"github.com/Southclaws/storyden/internal/infrastructure/cache"
 )
 
+const cachePrefix = "account:session:"
+
 type Repository interface {
 	Issue(context.Context, account.AccountID) (*Session, error)
 	Revoke(context.Context, Token) error
@@ -89,7 +91,7 @@ func (r *cachedRepo) Validate(ctx context.Context, t Token) (*Validated, error) 
 }
 
 func (r *cachedRepo) get(ctx context.Context, t Token) (*Session, bool, error) {
-	raw, err := r.store.Get(ctx, t.ID.String())
+	raw, err := r.store.Get(ctx, cacheKey(t))
 	if err != nil {
 		// Cache miss, found=false
 		// TODO: Expose a "cache miss" error/return value and distinguish
@@ -116,7 +118,7 @@ func (r *cachedRepo) cache(ctx context.Context, s Session) error {
 		return nil
 	}
 
-	err = r.store.Set(ctx, s.Token.String(), string(payload), ttl)
+	err = r.store.Set(ctx, cacheKey(s.Token), string(payload), ttl)
 	if err != nil {
 		return err
 	}
@@ -125,10 +127,14 @@ func (r *cachedRepo) cache(ctx context.Context, s Session) error {
 }
 
 func (r *cachedRepo) delete(ctx context.Context, token Token) error {
-	err := r.store.Delete(ctx, token.ID.String())
+	err := r.store.Delete(ctx, cacheKey(token))
 	if err != nil {
 		return err
 	}
 
 	return nil
+}
+
+func cacheKey(t Token) string {
+	return cachePrefix + t.String()
 }

--- a/app/resources/account/token/repo_test.go
+++ b/app/resources/account/token/repo_test.go
@@ -22,7 +22,7 @@ type fakeRepo struct {
 }
 
 func (f *fakeRepo) Issue(context.Context, account.AccountID) (*Session, error) { return f.session, nil }
-func (f *fakeRepo) Revoke(context.Context, Token) error                       { return nil }
+func (f *fakeRepo) Revoke(context.Context, Token) error                        { return nil }
 
 func (f *fakeRepo) Validate(context.Context, Token) (*Validated, error) {
 	f.calls++
@@ -45,7 +45,7 @@ func seed(t *testing.T, store *cachetest.Store, s Session) {
 
 	payload, err := s.Serialise()
 	require.NoError(t, err)
-	require.NoError(t, store.Set(context.Background(), s.Token.String(), string(payload), time.Hour))
+	require.NoError(t, store.Set(context.Background(), cacheKey(s.Token), string(payload), time.Hour))
 }
 
 func TestCachedValidateRejectsRevokedCachedSession(t *testing.T) {
@@ -97,7 +97,7 @@ func TestCachedValidateFallsBackWhenEntryIsUnreadable(t *testing.T) {
 	inner := &fakeRepo{session: &stored}
 	repo := NewCachedRepository(inner, store)
 
-	require.NoError(t, store.Set(context.Background(), tok.String(), "not json", time.Hour))
+	require.NoError(t, store.Set(context.Background(), cacheKey(tok), "not json", time.Hour))
 
 	v, err := repo.Validate(context.Background(), tok)
 


### PR DESCRIPTION
every other cache consumer in the tree namespaces its keys, `account:data:`, `account:role_ids:`, `role:list`, `node:last-modified:`, `thread:last-modified:` and so on

the session repository is the odd one out, it writes the token itself as the key:

```go
raw, err := r.store.Get(ctx, t.ID.String())
err = r.store.Set(ctx, s.Token.String(), string(payload), ttl)
err := r.store.Delete(ctx, token.ID.String())
```

so a session lives at a key like `d1p9f2a1s4gc73b8mnf0` with nothing marking it as ours, that is fine today because nothing else happens to write a bare xid, but it is one unlucky key away from a session being served from the wrong payload, or being clobbered by an unrelated write, and `REDIS_URL` frequently points at an instance shared with other things

the serialised session is also the most sensitive value in the cache, and right now you cannot pick it out with `SCAN account:session:*` for debugging, or delete it as a group, without also matching whatever else lives in the keyspace

this adds an `account:session:` prefix and routes read, write and delete through a single `cacheKey` helper, matching how the neighbouring caches do it, no behaviour change beyond the key name

one operational note worth flagging, existing cached sessions sit at the old keys and will simply be missed after deploy, `Validate` falls back to the database and re-caches under the new key, so nobody gets logged out, the stale entries expire on their own TTL

tests cover both the naming and the thing that actually bites if you get this wrong, that read, write and delete all agree on the same key