### PR TITLE
fix: bound the size of assets copied from scraped links

### DIFF
--- a/app/services/link/fetcher/fetcher.go
+++ b/app/services/link/fetcher/fetcher.go
@@ -2,7 +2,9 @@
 package fetcher
 
 import (
+	"bytes"
 	"context"
+	"io"
 	"log/slog"
 	"net/http"
 	"net/url"
@@ -25,9 +27,15 @@ import (
 	"github.com/Southclaws/storyden/internal/infrastructure/pubsub"
 )
 
-var errEmptyLink = fault.New("empty link")
+var (
+	errEmptyLink     = fault.New("empty link")
+	errAssetTooLarge = fault.New("linked asset exceeds maximum size")
+)
 
-const assetFetchTimeout = 30 * time.Second
+const (
+	assetFetchTimeout  = 30 * time.Second
+	assetFetchMaxBytes = 8 * 1024 * 1024
+)
 
 type Fetcher struct {
 	logger   *slog.Logger
@@ -158,12 +166,29 @@ func (s *Fetcher) ScrapeAndStore(ctx context.Context, u url.URL) (*link_ref.Link
 }
 
 func (s *Fetcher) CopyAsset(ctx context.Context, url string) (*asset.Asset, error) {
+	body, err := fetchBounded(ctx, s.client, url, assetFetchMaxBytes)
+	if err != nil {
+		return nil, fault.Wrap(err, fctx.With(ctx))
+	}
+
+	// TODO: Better naming???
+	name := mark.Slugify(url)
+
+	a, err := s.uploader.Upload(ctx, bytes.NewReader(body), int64(len(body)), asset.NewFilename(name), asset_upload.Options{})
+	if err != nil {
+		return nil, fault.Wrap(err, fctx.With(ctx))
+	}
+
+	return a, nil
+}
+
+func fetchBounded(ctx context.Context, client *http.Client, url string, maxBytes int64) ([]byte, error) {
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 	if err != nil {
 		return nil, fault.Wrap(err, fctx.With(ctx))
 	}
 
-	resp, err := s.client.Do(req)
+	resp, err := client.Do(req)
 	if err != nil {
 		return nil, fault.Wrap(err, fctx.With(ctx))
 	}
@@ -174,13 +199,17 @@ func (s *Fetcher) CopyAsset(ctx context.Context, url string) (*asset.Asset, erro
 		return nil, fault.Wrap(fault.New("failed to get"), fctx.With(ctx))
 	}
 
-	// TODO: Better naming???
-	name := mark.Slugify(url)
+	if resp.ContentLength > maxBytes {
+		return nil, fault.Wrap(errAssetTooLarge, fctx.With(ctx))
+	}
 
-	a, err := s.uploader.Upload(ctx, resp.Body, resp.ContentLength, asset.NewFilename(name), asset_upload.Options{})
+	body, err := io.ReadAll(io.LimitReader(resp.Body, maxBytes+1))
 	if err != nil {
 		return nil, fault.Wrap(err, fctx.With(ctx))
 	}
+	if int64(len(body)) > maxBytes {
+		return nil, fault.Wrap(errAssetTooLarge, fctx.With(ctx))
+	}
 
-	return a, nil
+	return body, nil
 }

--- a/app/services/link/fetcher/fetcher_test.go
+++ b/app/services/link/fetcher/fetcher_test.go
@@ -1,0 +1,79 @@
+package fetcher
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFetchBoundedAcceptsSmallBody(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte("tiny"))
+	}))
+	defer srv.Close()
+
+	body, err := fetchBounded(context.Background(), srv.Client(), srv.URL, 16)
+
+	require.NoError(t, err)
+	assert.Equal(t, "tiny", string(body))
+}
+
+func TestFetchBoundedRejectsDeclaredOversizeBody(t *testing.T) {
+	t.Parallel()
+
+	served := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Length", "4096")
+		w.WriteHeader(http.StatusOK)
+		served, _ = w.Write(make([]byte, 4096))
+	}))
+	defer srv.Close()
+
+	_, err := fetchBounded(context.Background(), srv.Client(), srv.URL, 16)
+
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, errAssetTooLarge))
+	assert.NotZero(t, served)
+}
+
+func TestFetchBoundedRejectsUndeclaredOversizeBody(t *testing.T) {
+	t.Parallel()
+
+	// no Content-Length, the response streams until the reader gives up
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Transfer-Encoding", "chunked")
+		w.WriteHeader(http.StatusOK)
+		for range 64 {
+			if _, err := w.Write(make([]byte, 1024)); err != nil {
+				return
+			}
+			w.(http.Flusher).Flush()
+		}
+	}))
+	defer srv.Close()
+
+	_, err := fetchBounded(context.Background(), srv.Client(), srv.URL, 16)
+
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, errAssetTooLarge))
+}
+
+func TestFetchBoundedRejectsNonOK(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer srv.Close()
+
+	_, err := fetchBounded(context.Background(), srv.Client(), srv.URL, 16)
+
+	assert.Error(t, err)
+}


### PR DESCRIPTION
`CopyAsset` streams a scraped url straight into the uploader with no ceiling on it:

```go
a, err := s.uploader.Upload(ctx, resp.Body, resp.ContentLength, asset.NewFilename(name), asset_upload.Options{})
```

`Upload` hands the reader to the object storer, and `localStorer.Write` ignores the size argument entirely and just runs `io.Copy`, so whatever the remote sends is what lands on disk

the inbound side is covered, `WithRequestSizeLimiter` caps request bodies at 50 MiB, but that only applies to what a client uploads to us, this path is the server fetching on its own, driven by `ScrapeAndStore`, which calls `CopyAsset` for the favicon and og:image of any link a member posts, so the only thing standing between a posted url and an arbitrarily large write is the 30 second timeout, and 30 seconds of a fast connection is a lot of disk, repeat it a few times and the volume fills

`resp.ContentLength` is also unreliable here, a chunked response reports `-1`, so it cannot be trusted as the limit either

so this adds an 8 MiB cap, checked against the declared length first and then enforced with a `LimitReader` while reading, which is the same shape as `readAllBounded` in `plugin_manager`, the body is buffered and the real byte count is handed to `Upload` rather than the header value, 8 MiB is well clear of any sane favicon or preview image but small enough to be a real bound

pulling the fetch into `fetchBounded` makes it testable, the fetcher's own client goes through `httpsafe`, which refuses loopback, so the test passes in a plain client and covers the small body, the oversize declared length, the oversize chunked body with no declared length, and a non 200