### PR TITLE
fix: record the bytes actually stored as the asset size

### DIFF
--- a/app/services/asset/asset_upload/uploader.go
+++ b/app/services/asset/asset_upload/uploader.go
@@ -55,22 +55,35 @@ func (s *Uploader) Upload(ctx context.Context, or io.Reader, size int64, name as
 		return nil, fault.Wrap(err, fctx.With(ctx))
 	}
 
+	counter := &countingReader{r: r}
+
+	if err := s.objects.Write(ctx, asset.BuildAssetPath(name), counter, size); err != nil {
+		return nil, fault.Wrap(err, fctx.With(ctx))
+	}
+
+	stored := int(counter.n)
+
 	a, err := func() (asset *asset.Asset, err error) {
 		if pid, ok := opts.ParentID.Get(); ok {
-			return s.assets.AddVersion(ctx, xid.ID(accountID), name, int(size), *mt, pid)
+			return s.assets.AddVersion(ctx, xid.ID(accountID), name, stored, *mt, pid)
 		} else {
-			return s.assets.Add(ctx, xid.ID(accountID), name, int(size), *mt)
+			return s.assets.Add(ctx, xid.ID(accountID), name, stored, *mt)
 		}
 	}()
 	if err != nil {
 		return nil, fault.Wrap(err, fctx.With(ctx))
 	}
 
-	path := asset.BuildAssetPath(a.Name)
-
-	if err := s.objects.Write(ctx, path, r, size); err != nil {
-		return nil, fault.Wrap(err, fctx.With(ctx))
-	}
-
 	return a, nil
+}
+
+type countingReader struct {
+	r io.Reader
+	n int64
+}
+
+func (c *countingReader) Read(p []byte) (int, error) {
+	n, err := c.r.Read(p)
+	c.n += int64(n)
+	return n, err
 }

--- a/tests/asset/upload_test.go
+++ b/tests/asset/upload_test.go
@@ -1,0 +1,87 @@
+package asset_test
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/fx"
+
+	"github.com/Southclaws/storyden/app/resources/account/account_writer"
+	"github.com/Southclaws/storyden/app/resources/asset"
+	"github.com/Southclaws/storyden/app/resources/rbac"
+	"github.com/Southclaws/storyden/app/resources/seed"
+	"github.com/Southclaws/storyden/app/services/asset/asset_upload"
+	authsession "github.com/Southclaws/storyden/app/services/authentication/session"
+	"github.com/Southclaws/storyden/internal/infrastructure/object"
+	"github.com/Southclaws/storyden/internal/integration"
+	"github.com/Southclaws/storyden/internal/integration/e2e"
+)
+
+func TestUploadRecordsBytesWrittenNotDeclaredSize(t *testing.T) {
+	t.Parallel()
+
+	integration.Test(t, nil, e2e.Setup(), fx.Invoke(func(
+		lc fx.Lifecycle,
+		root context.Context,
+		aw *account_writer.Writer,
+		uploader *asset_upload.Uploader,
+		objects object.Storer,
+	) {
+		lc.Append(fx.StartHook(func() {
+			_, acc := e2e.WithAccount(root, aw, seed.Account_001_Odin)
+			ctx := authsession.WithAccountPermissions(root, *acc, rbac.NewList(rbac.PermissionUploadAsset))
+
+			payload := bytes.Repeat([]byte("storyden"), 512)
+			require.Len(t, payload, 4096)
+
+			name := asset.NewFilename("declared-size-lies.txt")
+
+			a, err := uploader.Upload(ctx, bytes.NewReader(payload), 10, name, asset_upload.Options{})
+			require.NoError(t, err)
+
+			assert.Equal(t, len(payload), a.Size, "the recorded size must be the bytes actually stored")
+
+			r, size, err := objects.Read(ctx, asset.BuildAssetPath(a.Name))
+			require.NoError(t, err)
+
+			stored, err := io.ReadAll(r)
+			require.NoError(t, err)
+
+			assert.Equal(t, len(payload), len(stored))
+			assert.Equal(t, int64(a.Size), size, "AssetGet serves a.Size as Content-Length, it must match the object")
+		}))
+	}))
+}
+
+func TestUploadRecordsSizeForUnknownLength(t *testing.T) {
+	t.Parallel()
+
+	integration.Test(t, nil, e2e.Setup(), fx.Invoke(func(
+		lc fx.Lifecycle,
+		root context.Context,
+		aw *account_writer.Writer,
+		uploader *asset_upload.Uploader,
+		objects object.Storer,
+	) {
+		lc.Append(fx.StartHook(func() {
+			_, acc := e2e.WithAccount(root, aw, seed.Account_001_Odin)
+			ctx := authsession.WithAccountPermissions(root, *acc, rbac.NewList(rbac.PermissionUploadAsset))
+
+			payload := bytes.Repeat([]byte("chunked"), 128)
+			name := asset.NewFilename("unknown-length.txt")
+
+			a, err := uploader.Upload(ctx, bytes.NewReader(payload), -1, name, asset_upload.Options{})
+			require.NoError(t, err)
+
+			assert.Equal(t, len(payload), a.Size, "a chunked upload reports -1 and must still record a real size")
+
+			_, size, err := objects.Read(ctx, asset.BuildAssetPath(a.Name))
+			require.NoError(t, err)
+			assert.Equal(t, int64(a.Size), size)
+		}))
+	}))
+}


### PR DESCRIPTION
`Uploader.Upload` writes the size it was handed into the database before it has written a single byte:

```go
a, err := s.assets.Add(ctx, xid.ID(accountID), name, int(size), *mt)
path := asset.BuildAssetPath(a.Name)
if err := s.objects.Write(ctx, path, r, size); err != nil {
```

that `size` comes from `request.Params.ContentLength` in `AssetUpload`, so it is a client-supplied header rather than anything we measured, and `localStorer.Write` ignores the argument entirely and just runs `io.Copy`, so the row and the file can disagree from the moment they are created

`AssetGet` then serves the stored number back as a real transport header:

```go
ContentLength: int64(a.Size),
```

send `Content-Length: 10` with a 4 KiB body and every later read advertises 10 bytes for a 4 KiB object, which truncates the asset for anyone fetching it

the `CopyAsset` path is worse without meaning to be, it passes `resp.ContentLength`, and a chunked response reports `-1`, so the asset is recorded with a negative size and `AssetGet` hands out `Content-Length: -1`, the test on main reproduces exactly that

the fix flips the order, write the object first through a counting reader, then create the row with the number of bytes that actually went to storage, nothing is buffered so large uploads still stream, and `BuildAssetPath` works off the `asset.Filename` argument, which is the same value `asset.Map` reconstructs, so the path is unchanged

a nice side effect is that a failed write no longer leaves an orphaned row pointing at an object that was never created

tests go through the real service with the e2e harness, one uploads 4096 bytes while declaring 10, the other declares `-1` the way a chunked fetch does, both assert the row matches what the object storer reports back, on main they record 10 and -1