### PR TITLE
fix: cap OAuth token permissions to the roles the account still holds

### DIFF
--- a/app/resources/rbac/permission.go
+++ b/app/resources/rbac/permission.go
@@ -88,6 +88,19 @@ func NewList(permissions ...Permission) Permissions {
 	return Permissions{permissions, m}
 }
 
+// Intersect returns only the permissions held by both sets, used where a
+// delegated credential must never outrank the account it acts for.
+func (p Permissions) Intersect(other Permissions) Permissions {
+	held := make([]Permission, 0, len(p.p))
+	for _, pp := range p.p {
+		if _, ok := other.m[pp]; ok {
+			held = append(held, pp)
+		}
+	}
+
+	return NewList(held...)
+}
+
 func (p Permissions) HasAll(perms ...Permission) bool {
 	for _, pp := range perms {
 		if _, ok := p.m[pp]; !ok {

--- a/app/resources/rbac/permission_test.go
+++ b/app/resources/rbac/permission_test.go
@@ -1,0 +1,41 @@
+package rbac
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPermissionsIntersect(t *testing.T) {
+	t.Parallel()
+
+	token := NewList(PermissionCreatePost, PermissionManageRoles, PermissionReadProfile)
+	account := NewList(PermissionCreatePost, PermissionReadProfile)
+
+	granted := token.Intersect(account)
+
+	assert.True(t, granted.HasAll(PermissionCreatePost, PermissionReadProfile))
+	assert.False(t, granted.HasAny(PermissionManageRoles), "a permission the account lost must not survive")
+	assert.Len(t, granted.List(), 2)
+}
+
+func TestPermissionsIntersectDropsAdministrator(t *testing.T) {
+	t.Parallel()
+
+	token := NewList(PermissionAdministrator, PermissionCreatePost)
+	account := NewList(PermissionCreatePost)
+
+	granted := token.Intersect(account)
+
+	assert.False(t, granted.HasAny(PermissionAdministrator), "Authorise short circuits on administrator, it cannot be inherited from a stale token")
+	assert.True(t, granted.HasAll(PermissionCreatePost))
+}
+
+func TestPermissionsIntersectWithEmpty(t *testing.T) {
+	t.Parallel()
+
+	token := NewList(PermissionCreatePost, PermissionUploadAsset)
+
+	assert.Empty(t, token.Intersect(NewList()).List())
+	assert.Empty(t, NewList().Intersect(token).List())
+}

--- a/app/services/authentication/session/validator.go
+++ b/app/services/authentication/session/validator.go
@@ -168,7 +168,14 @@ func (v *Validator) ValidateOAuthToken(ctx context.Context, raw string) (context
 		return nil, fault.Wrap(err, fctx.With(ctx))
 	}
 
-	return WithOAuthToken(ctx, *acc, result.Permissions, result.Scopes), nil
+	roles, err := v.resolveRolesForAccount(ctx, acc)
+	if err != nil {
+		return nil, fault.Wrap(err, fctx.With(ctx))
+	}
+
+	granted := result.Permissions.Intersect(roles.Permissions())
+
+	return WithOAuthToken(ctx, *acc, granted, result.Scopes), nil
 }
 
 // WithUnauthenticatedRoles returns a context with guest role permissions.

--- a/tests/oauth/revoked_role_test.go
+++ b/tests/oauth/revoked_role_test.go
@@ -1,0 +1,89 @@
+package oauth_test
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"github.com/Southclaws/opt"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/fx"
+
+	"github.com/Southclaws/storyden/app/resources/account/account_writer"
+	"github.com/Southclaws/storyden/app/resources/account/role/role_assign"
+	"github.com/Southclaws/storyden/app/resources/account/role/role_repo"
+	oauthresource "github.com/Southclaws/storyden/app/resources/oauth"
+	"github.com/Southclaws/storyden/app/resources/oauth/oauth_writer"
+	"github.com/Southclaws/storyden/app/resources/rbac"
+	"github.com/Southclaws/storyden/app/resources/seed"
+	"github.com/Southclaws/storyden/app/transports/http/openapi"
+	"github.com/Southclaws/storyden/internal/integration"
+	"github.com/Southclaws/storyden/internal/integration/e2e"
+	"github.com/Southclaws/storyden/tests"
+)
+
+func TestOAuthTokenLosesPermissionWhenRoleIsRevoked(t *testing.T) {
+	t.Parallel()
+
+	integration.Test(t, oauthConfig(t), e2e.Setup(), fx.Invoke(func(
+		lc fx.Lifecycle,
+		root context.Context,
+		cl *openapi.ClientWithResponses,
+		sh *e2e.SessionHelper,
+		aw *account_writer.Writer,
+		ow *oauth_writer.Writer,
+		roles *role_repo.Repository,
+		assignments *role_assign.Assignment,
+	) {
+		lc.Append(fx.StartHook(func() {
+			r := require.New(t)
+
+			memberCtx, member := e2e.WithAccount(root, aw, seed.Account_002_Frigg)
+			roleID := grantOAuthClientUse(t, root, roles, assignments, member.ID, rbac.PermissionManageCategories)
+			memberSession := sh.WithSession(memberCtx)
+
+			clientID := "revoked-role-cli-" + uuid.NewString()
+			allowed := append(standardScopes(), rbac.PermissionManageCategories.String())
+			createClient(t, root, ow, member.ID, clientID, oauthresource.ClientTypePublic, oauthresource.ScopePolicyExplicit, opt.NewEmpty[string](), allowed, []string{oauthGrantDeviceCode})
+
+			start := tests.AssertRequest(cl.OAuthDeviceAuthorisationWithFormdataBodyWithResponse(root, openapi.OAuthDeviceAuthorisationFormdataRequestBody{
+				ClientId: clientID,
+				Scope:    ptr("openid profile " + rbac.PermissionManageCategories.String()),
+			}))(t, http.StatusOK)
+			r.NotNil(start.JSON200)
+
+			tests.AssertRequest(cl.OAuthDeviceConsentWithResponse(root, &openapi.OAuthDeviceConsentParams{
+				UserCode: start.JSON200.UserCode,
+			}, memberSession))(t, http.StatusOK)
+
+			tests.AssertRequest(cl.OAuthDeviceConsentSubmitWithResponse(root, openapi.OAuthDeviceConsentSubmitJSONRequestBody{
+				UserCode: *start.JSON200.UserCode,
+				Decision: openapi.OAuthDeviceDecisionApprove,
+			}, memberSession))(t, http.StatusOK)
+
+			token := tests.AssertRequest(oauthToken(t, root, cl, oauthTokenRequest{
+				GrantType:  oauthGrantDeviceCode,
+				ClientId:   clientID,
+				DeviceCode: start.JSON200.DeviceCode,
+			}))(t, http.StatusOK)
+			r.NotNil(token.JSON200.AccessToken)
+
+			access := bearer(*token.JSON200.AccessToken)
+
+			t.Run("granted_while_the_role_is_held", func(t *testing.T) {
+				tests.AssertRequest(cl.CategoryCreateWithResponse(root, openapi.CategoryInitialProps{
+					Name: "before-revocation-" + uuid.NewString(),
+				}, access))(t, http.StatusOK)
+			})
+
+			revokeOAuthClientUse(t, root, assignments, member.ID, roleID)
+
+			t.Run("denied_once_the_role_is_gone", func(t *testing.T) {
+				tests.AssertRequest(cl.CategoryCreateWithResponse(root, openapi.CategoryInitialProps{
+					Name: "after-revocation-" + uuid.NewString(),
+				}, access))(t, http.StatusForbidden)
+			})
+		}))
+	}))
+}


### PR DESCRIPTION
the three session validators do not agree on where permissions come from

`ValidateSessionToken` and `ValidateAccessKeyToken` both run `resolveRolesForAccount`, which reads the account's live roles and drops it to guest when the installation requires email verification and the address is still unverified, `ValidateOAuthToken` skips that entirely and trusts the scope claim baked into the jwt:

```go
acc, err := v.accountQuerier.GetRefByID(ctx, result.AccountID)
return WithOAuthToken(ctx, *acc, result.Permissions, result.Scopes), nil
```

scopes are checked against the account's permissions when the token is issued, by `grantScope`, but never again, so the token keeps whatever it was granted for its whole lifetime, take a role away from someone and their outstanding access tokens carry on using the permissions from that role, `OAUTH_ACCESS_TOKEN_TTL` is the only thing that ends it, and a refresh token quietly re-issues from `rec.Scope` so the window can keep rolling

the email verification gap comes out of the same hole, an account that a browser session would have pushed down to guest keeps its full permissions if it holds an oauth token

so `ValidateOAuthToken` now resolves roles like the other two and intersects them with the scope-derived permissions, the token can still be narrower than the account, which is the point of scopes, it just can no longer be wider, `Intersect` lives on `rbac.Permissions` since that is where the set already is

`PermissionAdministrator` is the one worth calling out, `Authorise` returns early for it, so a stale admin scope was a full bypass, the intersection drops it as soon as the role is gone

the integration test issues a token with `MANAGE_CATEGORIES` through the device flow, creates a category with it, revokes the role, and creates another, on main the second call still returns 200, `CREATE_POST` was my first choice and it does not work as a test subject, the default Member role already grants it, worth knowing if anyone writes something similar later

the rest of `tests/oauth` passes unchanged