### PR TITLE
fix: bind endec tokens to a purpose so they cannot be replayed across features

### DIFF
--- a/app/services/authentication/provider/oauth/discord/discord.go
+++ b/app/services/authentication/provider/oauth/discord/discord.go
@@ -80,7 +80,7 @@ func (p *Provider) oauthConfig(redirect string) *oauth2.Config {
 }
 
 func (p *Provider) Link(redirectPath string) (string, error) {
-	state, err := p.ed.Encrypt(map[string]any{
+	state, err := p.ed.Encrypt(endec.PurposeOAuthState, map[string]any{
 		"redirect": redirectPath,
 	}, time.Minute*10)
 	if err != nil {
@@ -93,7 +93,7 @@ func (p *Provider) Link(redirectPath string) (string, error) {
 }
 
 func (p *Provider) Login(ctx context.Context, state, code string) (*account.Account, error) {
-	c, err := p.ed.Decrypt(state)
+	c, err := p.ed.Decrypt(endec.PurposeOAuthState, state)
 	if err != nil {
 		return nil, fault.Wrap(err,
 			fctx.With(ctx),
@@ -101,7 +101,16 @@ func (p *Provider) Login(ctx context.Context, state, code string) (*account.Acco
 		)
 	}
 
-	oac := p.oauthConfig(c["redirect"].(string))
+	redirect, ok := c["redirect"].(string)
+	if !ok {
+		return nil, fault.New("state value has no redirect",
+			fctx.With(ctx),
+			ftag.With(ftag.InvalidArgument),
+			fmsg.WithDesc("malformed state value", "This link is not valid, please try again from the start."),
+		)
+	}
+
+	oac := p.oauthConfig(redirect)
 
 	token, err := oac.Exchange(ctx, code, oauth2.AccessTypeOffline)
 	if err != nil {

--- a/app/services/authentication/provider/oauth/github/github.go
+++ b/app/services/authentication/provider/oauth/github/github.go
@@ -78,7 +78,7 @@ func (p *Provider) oauthConfig(redirect string) *oauth2.Config {
 }
 
 func (p *Provider) Link(redirectPath string) (string, error) {
-	state, err := p.ed.Encrypt(map[string]any{
+	state, err := p.ed.Encrypt(endec.PurposeOAuthState, map[string]any{
 		"redirect": redirectPath,
 	}, time.Minute*10)
 	if err != nil {
@@ -91,7 +91,7 @@ func (p *Provider) Link(redirectPath string) (string, error) {
 }
 
 func (p *Provider) Login(ctx context.Context, state, code string) (*account.Account, error) {
-	c, err := p.ed.Decrypt(state)
+	c, err := p.ed.Decrypt(endec.PurposeOAuthState, state)
 	if err != nil {
 		return nil, fault.Wrap(err,
 			fctx.With(ctx),
@@ -99,7 +99,16 @@ func (p *Provider) Login(ctx context.Context, state, code string) (*account.Acco
 		)
 	}
 
-	oac := p.oauthConfig(c["redirect"].(string))
+	redirect, ok := c["redirect"].(string)
+	if !ok {
+		return nil, fault.New("state value has no redirect",
+			fctx.With(ctx),
+			ftag.With(ftag.InvalidArgument),
+			fmsg.WithDesc("malformed state value", "This link is not valid, please try again from the start."),
+		)
+	}
+
+	oac := p.oauthConfig(redirect)
 
 	token, err := oac.Exchange(ctx, code, oauth2.AccessTypeOffline)
 	if err != nil {

--- a/app/services/authentication/provider/oauth/github/github_test.go
+++ b/app/services/authentication/provider/oauth/github/github_test.go
@@ -1,0 +1,56 @@
+package github
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/Southclaws/storyden/internal/config"
+	"github.com/Southclaws/storyden/internal/infrastructure/endec"
+	endecjwt "github.com/Southclaws/storyden/internal/infrastructure/endec/jwt"
+)
+
+func TestLoginRejectsPasswordResetTokenAsState(t *testing.T) {
+	t.Parallel()
+
+	cfg := config.Config{GitHubEnabled: true, JWTSecret: []byte("07d422e512b23a056ccc953994d1593f")}
+
+	ed, err := endecjwt.New(cfg)
+	require.NoError(t, err)
+
+	p, err := New(cfg, nil, ed)
+	require.NoError(t, err)
+
+	reset, err := ed.Encrypt(endec.PurposePasswordReset, endec.Claims{
+		"account_id": "cv1l2p1cpetc0gm4nqm0",
+	}, time.Hour)
+	require.NoError(t, err)
+
+	assert.NotPanics(t, func() {
+		_, err := p.Login(context.Background(), reset, "any-code")
+		assert.Error(t, err)
+	})
+}
+
+func TestLoginRejectsStateWithoutRedirect(t *testing.T) {
+	t.Parallel()
+
+	cfg := config.Config{GitHubEnabled: true, JWTSecret: []byte("07d422e512b23a056ccc953994d1593f")}
+
+	ed, err := endecjwt.New(cfg)
+	require.NoError(t, err)
+
+	p, err := New(cfg, nil, ed)
+	require.NoError(t, err)
+
+	state, err := ed.Encrypt(endec.PurposeOAuthState, endec.Claims{}, time.Minute*10)
+	require.NoError(t, err)
+
+	assert.NotPanics(t, func() {
+		_, err := p.Login(context.Background(), state, "any-code")
+		assert.Error(t, err)
+	})
+}

--- a/app/services/authentication/provider/oauth/google/google.go
+++ b/app/services/authentication/provider/oauth/google/google.go
@@ -78,7 +78,7 @@ func (p *Provider) oauthConfig(redirect string) *oauth2.Config {
 }
 
 func (p *Provider) Link(redirectPath string) (string, error) {
-	state, err := p.ed.Encrypt(map[string]any{
+	state, err := p.ed.Encrypt(endec.PurposeOAuthState, map[string]any{
 		"redirect": redirectPath,
 	}, time.Minute*10)
 	if err != nil {
@@ -91,7 +91,7 @@ func (p *Provider) Link(redirectPath string) (string, error) {
 }
 
 func (p *Provider) Login(ctx context.Context, state, code string) (*account.Account, error) {
-	c, err := p.ed.Decrypt(state)
+	c, err := p.ed.Decrypt(endec.PurposeOAuthState, state)
 	if err != nil {
 		return nil, fault.Wrap(err,
 			fctx.With(ctx),
@@ -99,7 +99,16 @@ func (p *Provider) Login(ctx context.Context, state, code string) (*account.Acco
 		)
 	}
 
-	oac := p.oauthConfig(c["redirect"].(string))
+	redirect, ok := c["redirect"].(string)
+	if !ok {
+		return nil, fault.New("state value has no redirect",
+			fctx.With(ctx),
+			ftag.With(ftag.InvalidArgument),
+			fmsg.WithDesc("malformed state value", "This link is not valid, please try again from the start."),
+		)
+	}
+
+	oac := p.oauthConfig(redirect)
 
 	token, err := oac.Exchange(ctx, code, oauth2.AccessTypeOffline)
 	if err != nil {

--- a/app/services/authentication/provider/oauth/keycloak/keycloak.go
+++ b/app/services/authentication/provider/oauth/keycloak/keycloak.go
@@ -112,7 +112,7 @@ func (p *Provider) oauthConfig(redirect string) *oauth2.Config {
 
 // Link returns the URL to redirect a user to Keycloak for authentication.
 func (p *Provider) Link(redirectPath string) (string, error) {
-	state, err := p.ed.Encrypt(map[string]any{"redirect": redirectPath}, time.Minute*10)
+	state, err := p.ed.Encrypt(endec.PurposeOAuthState, map[string]any{"redirect": redirectPath}, time.Minute*10)
 	if err != nil {
 		return "", fault.Wrap(err)
 	}
@@ -122,7 +122,7 @@ func (p *Provider) Link(redirectPath string) (string, error) {
 
 // Login completes the OAuth2 flow: exchanges code, verifies ID token, and returns the Account.
 func (p *Provider) Login(ctx context.Context, state, code string) (*account.Account, error) {
-	c, err := p.ed.Decrypt(state)
+	c, err := p.ed.Decrypt(endec.PurposeOAuthState, state)
 	if err != nil {
 		return nil, fault.Wrap(err,
 			fctx.With(ctx),
@@ -130,7 +130,15 @@ func (p *Provider) Login(ctx context.Context, state, code string) (*account.Acco
 		)
 	}
 
-	redirect := c["redirect"].(string)
+	redirect, ok := c["redirect"].(string)
+	if !ok {
+		return nil, fault.New("state value has no redirect",
+			fctx.With(ctx),
+			ftag.With(ftag.InvalidArgument),
+			fmsg.WithDesc("malformed state value", "This link is not valid, please try again from the start."),
+		)
+	}
+
 	oac := p.oauthConfig(redirect)
 	tok, err := oac.Exchange(ctx, code)
 	if err != nil {

--- a/app/services/authentication/provider/password/password_reset/token.go
+++ b/app/services/authentication/provider/password/password_reset/token.go
@@ -35,7 +35,7 @@ func (r *TokenProvider) GetResetToken(ctx context.Context, accountID account.Acc
 		accountIDKey: accountID.String(),
 	}
 
-	token, err := r.endec.Encrypt(claims, resetTokenLifespan)
+	token, err := r.endec.Encrypt(endec.PurposePasswordReset, claims, resetTokenLifespan)
 	if err != nil {
 		return "", fault.Wrap(err, fctx.With(ctx))
 	}
@@ -44,7 +44,7 @@ func (r *TokenProvider) GetResetToken(ctx context.Context, accountID account.Acc
 }
 
 func (r *TokenProvider) Validate(ctx context.Context, tokenString string) (account.AccountID, error) {
-	token, err := r.endec.Decrypt(tokenString)
+	token, err := r.endec.Decrypt(endec.PurposePasswordReset, tokenString)
 	if err != nil {
 		return account.AccountID{}, fault.Wrap(err,
 			fctx.With(ctx),

--- a/internal/infrastructure/endec/endec.go
+++ b/internal/infrastructure/endec/endec.go
@@ -4,11 +4,13 @@ import (
 	"time"
 )
 
+// Purpose is the RFC 7519 "typ" header value, explicit typing per RFC 8725
+// section 3.11 is what stops one feature's token verifying as another's
 type Purpose string
 
 const (
-	PurposePasswordReset Purpose = "password_reset"
-	PurposeOAuthState    Purpose = "oauth_state"
+	PurposePasswordReset Purpose = "storyden-password-reset+jwt"
+	PurposeOAuthState    Purpose = "storyden-oauth-state+jwt"
 )
 
 type Encrypter interface {

--- a/internal/infrastructure/endec/endec.go
+++ b/internal/infrastructure/endec/endec.go
@@ -4,12 +4,19 @@ import (
 	"time"
 )
 
+type Purpose string
+
+const (
+	PurposePasswordReset Purpose = "password_reset"
+	PurposeOAuthState    Purpose = "oauth_state"
+)
+
 type Encrypter interface {
-	Encrypt(data Claims, lifespan time.Duration) (string, error)
+	Encrypt(purpose Purpose, data Claims, lifespan time.Duration) (string, error)
 }
 
 type Decrypter interface {
-	Decrypt(message string) (Claims, error)
+	Decrypt(purpose Purpose, message string) (Claims, error)
 }
 
 type EncrypterDecrypter interface {

--- a/internal/infrastructure/endec/jwt/jwt.go
+++ b/internal/infrastructure/endec/jwt/jwt.go
@@ -13,6 +13,8 @@ import (
 	"github.com/Southclaws/storyden/internal/infrastructure/endec"
 )
 
+const purposeClaim = "sdp"
+
 type jwtEncrypterDecrypter struct {
 	key []byte
 }
@@ -35,9 +37,13 @@ func New(cfg config.Config) (endec.EncrypterDecrypter, error) {
 	return &jwtEncrypterDecrypter{key: cfg.JWTSecret}, nil
 }
 
-func (e *jwtEncrypterDecrypter) Encrypt(data endec.Claims, lifespan time.Duration) (string, error) {
+func (e *jwtEncrypterDecrypter) Encrypt(purpose endec.Purpose, data endec.Claims, lifespan time.Duration) (string, error) {
 	if len(e.key) == 0 {
 		return "", fault.New("no JWT secret provided")
+	}
+
+	if purpose == "" {
+		return "", fault.New("no token purpose provided")
 	}
 
 	var nonce [24]byte
@@ -56,6 +62,8 @@ func (e *jwtEncrypterDecrypter) Encrypt(data endec.Claims, lifespan time.Duratio
 		claims[k] = v
 	}
 
+	claims[purposeClaim] = string(purpose)
+
 	t := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
 
 	s, err := t.SignedString(e.key)
@@ -66,7 +74,7 @@ func (e *jwtEncrypterDecrypter) Encrypt(data endec.Claims, lifespan time.Duratio
 	return s, nil
 }
 
-func (e *jwtEncrypterDecrypter) Decrypt(message string) (endec.Claims, error) {
+func (e *jwtEncrypterDecrypter) Decrypt(purpose endec.Purpose, message string) (endec.Claims, error) {
 	t, err := jwt.Parse(message, e.keyfunc)
 	if err != nil {
 		return nil, fault.Wrap(err)
@@ -79,6 +87,11 @@ func (e *jwtEncrypterDecrypter) Decrypt(message string) (endec.Claims, error) {
 	claims, ok := t.Claims.(jwt.MapClaims)
 	if !ok {
 		return nil, fault.New("invalid token")
+	}
+
+	got, ok := claims[purposeClaim].(string)
+	if !ok || got != string(purpose) {
+		return nil, fault.Newf("token was not issued for %s", purpose)
 	}
 
 	return endec.Claims(claims), nil

--- a/internal/infrastructure/endec/jwt/jwt.go
+++ b/internal/infrastructure/endec/jwt/jwt.go
@@ -13,8 +13,6 @@ import (
 	"github.com/Southclaws/storyden/internal/infrastructure/endec"
 )
 
-const purposeClaim = "sdp"
-
 type jwtEncrypterDecrypter struct {
 	key []byte
 }
@@ -62,9 +60,8 @@ func (e *jwtEncrypterDecrypter) Encrypt(purpose endec.Purpose, data endec.Claims
 		claims[k] = v
 	}
 
-	claims[purposeClaim] = string(purpose)
-
 	t := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
+	t.Header["typ"] = string(purpose)
 
 	s, err := t.SignedString(e.key)
 	if err != nil {
@@ -75,7 +72,7 @@ func (e *jwtEncrypterDecrypter) Encrypt(purpose endec.Purpose, data endec.Claims
 }
 
 func (e *jwtEncrypterDecrypter) Decrypt(purpose endec.Purpose, message string) (endec.Claims, error) {
-	t, err := jwt.Parse(message, e.keyfunc)
+	t, err := jwt.Parse(message, e.keyfunc, jwt.WithValidMethods([]string{jwt.SigningMethodHS256.Alg()}))
 	if err != nil {
 		return nil, fault.Wrap(err)
 	}
@@ -84,14 +81,13 @@ func (e *jwtEncrypterDecrypter) Decrypt(purpose endec.Purpose, message string) (
 		return nil, fault.New("token flagged as invalid but no error was reported")
 	}
 
+	if typ, ok := t.Header["typ"].(string); !ok || typ != string(purpose) {
+		return nil, fault.Newf("token was not issued for %s", purpose)
+	}
+
 	claims, ok := t.Claims.(jwt.MapClaims)
 	if !ok {
 		return nil, fault.New("invalid token")
-	}
-
-	got, ok := claims[purposeClaim].(string)
-	if !ok || got != string(purpose) {
-		return nil, fault.Newf("token was not issued for %s", purpose)
 	}
 
 	return endec.Claims(claims), nil

--- a/internal/infrastructure/endec/jwt/jwt_test.go
+++ b/internal/infrastructure/endec/jwt/jwt_test.go
@@ -26,10 +26,10 @@ func TestEncryptDecrypt(t *testing.T) {
 	r.NoError(err)
 
 	t.Run("encrypt and decrypt payload", func(t *testing.T) {
-		token, err := ed.Encrypt(claims, time.Hour)
+		token, err := ed.Encrypt(endec.PurposePasswordReset, claims, time.Hour)
 		a.NoError(err)
 
-		gotClaims, err := ed.Decrypt(token)
+		gotClaims, err := ed.Decrypt(endec.PurposePasswordReset, token)
 		a.NoError(err)
 		a.Equal(claims["sub"], gotClaims["sub"])
 		a.Equal(claims["exp"], gotClaims["exp"])
@@ -42,4 +42,51 @@ func TestEncryptDecrypt(t *testing.T) {
 		r.NoError(err)
 		r.Nil(ed)
 	})
+}
+
+func TestPurposeIsNotInterchangeable(t *testing.T) {
+	t.Parallel()
+
+	ed, err := New(config.Config{JWTSecret: []byte("07d422e512b23a056ccc953994d1593f")})
+	require.NoError(t, err)
+
+	reset, err := ed.Encrypt(endec.PurposePasswordReset, endec.Claims{"account_id": "cv1l2p1cpetc0gm4nqm0"}, time.Hour)
+	require.NoError(t, err)
+
+	_, err = ed.Decrypt(endec.PurposeOAuthState, reset)
+	assert.Error(t, err, "a password reset token must not be accepted as an oauth state value")
+
+	state, err := ed.Encrypt(endec.PurposeOAuthState, endec.Claims{"redirect": "https://example.com/callback"}, time.Minute*10)
+	require.NoError(t, err)
+
+	_, err = ed.Decrypt(endec.PurposePasswordReset, state)
+	assert.Error(t, err, "an oauth state value must not be accepted as a password reset token")
+}
+
+func TestPurposeClaimCannotBeOverriddenByCaller(t *testing.T) {
+	t.Parallel()
+
+	ed, err := New(config.Config{JWTSecret: []byte("07d422e512b23a056ccc953994d1593f")})
+	require.NoError(t, err)
+
+	token, err := ed.Encrypt(endec.PurposePasswordReset, endec.Claims{
+		purposeClaim: string(endec.PurposeOAuthState),
+	}, time.Hour)
+	require.NoError(t, err)
+
+	_, err = ed.Decrypt(endec.PurposeOAuthState, token)
+	assert.Error(t, err, "claims must not be able to forge the purpose")
+
+	_, err = ed.Decrypt(endec.PurposePasswordReset, token)
+	assert.NoError(t, err)
+}
+
+func TestEncryptRequiresAPurpose(t *testing.T) {
+	t.Parallel()
+
+	ed, err := New(config.Config{JWTSecret: []byte("07d422e512b23a056ccc953994d1593f")})
+	require.NoError(t, err)
+
+	_, err = ed.Encrypt("", endec.Claims{"sub": "nobody"}, time.Hour)
+	assert.Error(t, err)
 }

--- a/internal/infrastructure/endec/jwt/jwt_test.go
+++ b/internal/infrastructure/endec/jwt/jwt_test.go
@@ -1,6 +1,9 @@
 package jwt
 
 import (
+	"encoding/base64"
+	"encoding/json"
+	"strings"
 	"testing"
 	"time"
 
@@ -63,14 +66,15 @@ func TestPurposeIsNotInterchangeable(t *testing.T) {
 	assert.Error(t, err, "an oauth state value must not be accepted as a password reset token")
 }
 
-func TestPurposeClaimCannotBeOverriddenByCaller(t *testing.T) {
+func TestPurposeCannotBeForgedFromClaims(t *testing.T) {
 	t.Parallel()
 
 	ed, err := New(config.Config{JWTSecret: []byte("07d422e512b23a056ccc953994d1593f")})
 	require.NoError(t, err)
 
+	// typ lives in the header, so a caller cannot reach it through Claims
 	token, err := ed.Encrypt(endec.PurposePasswordReset, endec.Claims{
-		purposeClaim: string(endec.PurposeOAuthState),
+		"typ": string(endec.PurposeOAuthState),
 	}, time.Hour)
 	require.NoError(t, err)
 
@@ -79,6 +83,27 @@ func TestPurposeClaimCannotBeOverriddenByCaller(t *testing.T) {
 
 	_, err = ed.Decrypt(endec.PurposePasswordReset, token)
 	assert.NoError(t, err)
+}
+
+func TestPurposeIsCarriedInTheTypHeader(t *testing.T) {
+	t.Parallel()
+
+	ed, err := New(config.Config{JWTSecret: []byte("07d422e512b23a056ccc953994d1593f")})
+	require.NoError(t, err)
+
+	token, err := ed.Encrypt(endec.PurposeOAuthState, endec.Claims{"redirect": "/"}, time.Minute)
+	require.NoError(t, err)
+
+	segments := strings.Split(token, ".")
+	require.Len(t, segments, 3)
+
+	raw, err := base64.RawURLEncoding.DecodeString(segments[0])
+	require.NoError(t, err)
+
+	var header map[string]any
+	require.NoError(t, json.Unmarshal(raw, &header))
+
+	assert.Equal(t, string(endec.PurposeOAuthState), header["typ"])
 }
 
 func TestEncryptRequiresAPurpose(t *testing.T) {


### PR DESCRIPTION
`endec` is one signing key shared by two unrelated features, password reset links and oauth state values, and the tokens carry nothing that says which is which:

```go
claims := jwt.MapClaims{
	"jti": nonce,
	"exp": jwt.NewNumericDate(expires),
}
```

no `aud`, no type, so every token it issues verifies as every other kind of token it issues

the providers then read the state claims without checking anything:

```go
oac := p.oauthConfig(c["redirect"].(string))
```

same line in `github`, `discord` and `google`, and `keycloak` does it one line up, a password reset token has `account_id` and `exp` but no `redirect`, so the assertion runs on a nil interface and the handler panics, request a reset for your own account, take the token out of the email, and send it as `state` to the oauth callback

so the fix is a `Purpose` on the endec interface that both sides must name:

```go
Encrypt(purpose Purpose, data Claims, lifespan time.Duration) (string, error)
Decrypt(purpose Purpose, message string) (Claims, error)
```

it goes into the token as a private `sdp` claim and `Decrypt` refuses anything that does not match, putting it in the signature rather than leaving it to callers means a new feature cannot forget it, and `Encrypt` rejects an empty purpose so nobody opts out by accident

the purpose claim is written after the caller's claims are merged, otherwise a caller passing `sdp` in `Claims` could pick its own, there's a test for that

the redirect assertions get the comma ok treatment too, a state token that verifies but has no redirect is now a 400 rather than a panic

two things worth knowing before merging, reset links and oauth flows already in flight will be rejected since their tokens predate the claim, that clears itself in an hour and ten minutes respectively, and i used a single `oauth_state` purpose for all four providers rather than one each, a github state is still accepted by google, that has no impact i can see because the state only carries the redirect and the code exchange uses each provider's own credentials, but say the word and i'll split it

tests cover both directions of the swap, the forged claim, the missing purpose, and `Login` no longer panicking on a reset token, `tests/oauth` passes unchanged