### PR TITLE
fix: issue session tokens from crypto/rand and store only their hash

### DIFF
--- a/app/resources/account/token/cache_key_test.go
+++ b/app/resources/account/token/cache_key_test.go
@@ -15,8 +15,8 @@ import (
 
 type keyStubRepo struct{ session Session }
 
-func (f *keyStubRepo) Issue(context.Context, account.AccountID) (*Session, error) {
-	return &f.session, nil
+func (f *keyStubRepo) Issue(context.Context, account.AccountID) (*Issued, error) {
+	return &Issued{Session: f.session}, nil
 }
 func (f *keyStubRepo) Revoke(context.Context, Token) error { return nil }
 func (f *keyStubRepo) Validate(context.Context, Token) (*Validated, error) {
@@ -30,9 +30,9 @@ func TestSessionCacheKeysAreNamespaced(t *testing.T) {
 	ctx := context.Background()
 	store := cachetest.New()
 
-	tok := Generate()
+	tok := mustGenerate(t)
 	inner := &keyStubRepo{session: Session{
-		Token:     tok,
+		TokenHash: tok.Hash(),
 		AccountID: account.AccountID(xid.New()),
 		ExpiresAt: time.Now().Add(time.Hour),
 	}}
@@ -43,9 +43,9 @@ func TestSessionCacheKeysAreNamespaced(t *testing.T) {
 	require.NoError(t, err)
 
 	_, err = store.Get(ctx, tok.String())
-	assert.Error(t, err, "the bare token must not be usable as a cache key")
+	assert.Error(t, err, "the bare secret must not be usable as a cache key")
 
-	_, err = store.Get(ctx, cachePrefix+tok.String())
+	_, err = store.Get(ctx, cachePrefix+tok.Hash())
 	assert.NoError(t, err)
 }
 
@@ -55,9 +55,9 @@ func TestSessionCacheReadWriteAndDeleteAgree(t *testing.T) {
 	ctx := context.Background()
 	store := cachetest.New()
 
-	tok := Generate()
+	tok := mustGenerate(t)
 	inner := &keyStubRepo{session: Session{
-		Token:     tok,
+		TokenHash: tok.Hash(),
 		AccountID: account.AccountID(xid.New()),
 		ExpiresAt: time.Now().Add(time.Hour),
 	}}
@@ -69,6 +69,6 @@ func TestSessionCacheReadWriteAndDeleteAgree(t *testing.T) {
 
 	require.NoError(t, repo.Revoke(ctx, tok))
 
-	_, err = store.Get(ctx, cachePrefix+tok.String())
+	_, err = store.Get(ctx, cachePrefix+tok.Hash())
 	assert.Error(t, err, "revoke must delete the key that cache and get use")
 }

--- a/app/resources/account/token/db.go
+++ b/app/resources/account/token/db.go
@@ -30,11 +30,15 @@ func New(
 	}
 }
 
-func (r *persistedRepository) Issue(ctx context.Context, accountID account.AccountID) (*Session, error) {
-	token := Token{xid.New()}
+func (r *persistedRepository) Issue(ctx context.Context, accountID account.AccountID) (*Issued, error) {
+	token, err := Generate()
+	if err != nil {
+		return nil, fault.Wrap(err, fctx.With(ctx))
+	}
 
 	create := r.db.Session.Create().
-		SetID(token.ID).
+		SetID(xid.New()).
+		SetTokenHash(token.Hash()).
 		SetAccountID(xid.ID(accountID)).
 		SetExpiresAt(time.Now().Add(Expiry))
 
@@ -43,11 +47,11 @@ func (r *persistedRepository) Issue(ctx context.Context, accountID account.Accou
 		return nil, fault.Wrap(err, fctx.With(ctx))
 	}
 
-	return Map(result), nil
+	return &Issued{Token: token, Session: *Map(result)}, nil
 }
 
-func (r *persistedRepository) Revoke(ctx context.Context, id Token) error {
-	update := r.db.Session.Update().Where(session.ID(id.ID))
+func (r *persistedRepository) Revoke(ctx context.Context, t Token) error {
+	update := r.db.Session.Update().Where(session.TokenHash(t.Hash()))
 
 	update.SetRevokedAt(time.Now())
 
@@ -60,7 +64,7 @@ func (r *persistedRepository) Revoke(ctx context.Context, id Token) error {
 }
 
 func (r *persistedRepository) Validate(ctx context.Context, t Token) (*Validated, error) {
-	query := r.db.Session.Query().Where(session.ID(t.ID))
+	query := r.db.Session.Query().Where(session.TokenHash(t.Hash()))
 
 	result, err := query.Only(ctx)
 	if err != nil {
@@ -77,7 +81,7 @@ func (r *persistedRepository) Validate(ctx context.Context, t Token) (*Validated
 
 func Map(s *ent.Session) *Session {
 	return &Session{
-		Token:     Token{s.ID},
+		TokenHash: s.TokenHash,
 		AccountID: account.AccountID(s.AccountID),
 		ExpiresAt: s.ExpiresAt,
 		RevokedAt: opt.NewPtr(s.RevokedAt),

--- a/app/resources/account/token/repo.go
+++ b/app/resources/account/token/repo.go
@@ -14,7 +14,7 @@ import (
 const cachePrefix = "account:session:"
 
 type Repository interface {
-	Issue(context.Context, account.AccountID) (*Session, error)
+	Issue(context.Context, account.AccountID) (*Issued, error)
 	Revoke(context.Context, Token) error
 	Validate(context.Context, Token) (*Validated, error)
 }
@@ -31,17 +31,17 @@ func NewCachedRepository(repo Repository, store cache.Store) Repository {
 	}
 }
 
-func (r *cachedRepo) Issue(ctx context.Context, accountID account.AccountID) (*Session, error) {
-	s, err := r.repo.Issue(ctx, accountID)
+func (r *cachedRepo) Issue(ctx context.Context, accountID account.AccountID) (*Issued, error) {
+	issued, err := r.repo.Issue(ctx, accountID)
 	if err != nil {
 		return nil, fault.Wrap(err, fctx.With(ctx))
 	}
 
-	if err := r.cache(ctx, *s); err != nil {
+	if err := r.cache(ctx, issued.Session); err != nil {
 		return nil, fault.Wrap(err, fctx.With(ctx))
 	}
 
-	return s, nil
+	return issued, nil
 }
 
 func (r *cachedRepo) Revoke(ctx context.Context, token Token) error {
@@ -118,7 +118,7 @@ func (r *cachedRepo) cache(ctx context.Context, s Session) error {
 		return nil
 	}
 
-	err = r.store.Set(ctx, cacheKey(s.Token), string(payload), ttl)
+	err = r.store.Set(ctx, cachePrefix+s.TokenHash, string(payload), ttl)
 	if err != nil {
 		return err
 	}
@@ -136,5 +136,5 @@ func (r *cachedRepo) delete(ctx context.Context, token Token) error {
 }
 
 func cacheKey(t Token) string {
-	return cachePrefix + t.String()
+	return cachePrefix + t.Hash()
 }

--- a/app/resources/account/token/repo_test.go
+++ b/app/resources/account/token/repo_test.go
@@ -21,8 +21,10 @@ type fakeRepo struct {
 	calls   int
 }
 
-func (f *fakeRepo) Issue(context.Context, account.AccountID) (*Session, error) { return f.session, nil }
-func (f *fakeRepo) Revoke(context.Context, Token) error                        { return nil }
+func (f *fakeRepo) Issue(context.Context, account.AccountID) (*Issued, error) {
+	return &Issued{Session: *f.session}, nil
+}
+func (f *fakeRepo) Revoke(context.Context, Token) error { return nil }
 
 func (f *fakeRepo) Validate(context.Context, Token) (*Validated, error) {
 	f.calls++
@@ -34,7 +36,7 @@ func (f *fakeRepo) Validate(context.Context, Token) (*Validated, error) {
 
 func liveSession(t Token) Session {
 	return Session{
-		Token:     t,
+		TokenHash: t.Hash(),
 		AccountID: account.AccountID(xid.New()),
 		ExpiresAt: time.Now().Add(time.Hour),
 	}
@@ -45,7 +47,7 @@ func seed(t *testing.T, store *cachetest.Store, s Session) {
 
 	payload, err := s.Serialise()
 	require.NoError(t, err)
-	require.NoError(t, store.Set(context.Background(), cacheKey(s.Token), string(payload), time.Hour))
+	require.NoError(t, store.Set(context.Background(), cachePrefix+s.TokenHash, string(payload), time.Hour))
 }
 
 func TestCachedValidateRejectsRevokedCachedSession(t *testing.T) {
@@ -55,7 +57,7 @@ func TestCachedValidateRejectsRevokedCachedSession(t *testing.T) {
 	inner := &fakeRepo{}
 	repo := NewCachedRepository(inner, store)
 
-	tok := Generate()
+	tok := mustGenerate(t)
 	revoked := liveSession(tok)
 	revoked.RevokedAt = opt.New(time.Now())
 	seed(t, store, revoked)
@@ -75,7 +77,7 @@ func TestCachedValidateRejectsExpiredCachedSession(t *testing.T) {
 	inner := &fakeRepo{}
 	repo := NewCachedRepository(inner, store)
 
-	tok := Generate()
+	tok := mustGenerate(t)
 	expired := liveSession(tok)
 	expired.ExpiresAt = time.Now().Add(-time.Minute)
 	seed(t, store, expired)
@@ -92,7 +94,7 @@ func TestCachedValidateFallsBackWhenEntryIsUnreadable(t *testing.T) {
 
 	store := cachetest.New()
 
-	tok := Generate()
+	tok := mustGenerate(t)
 	stored := liveSession(tok)
 	inner := &fakeRepo{session: &stored}
 	repo := NewCachedRepository(inner, store)
@@ -114,7 +116,7 @@ func TestCachedValidateServesValidCachedSession(t *testing.T) {
 	inner := &fakeRepo{}
 	repo := NewCachedRepository(inner, store)
 
-	tok := Generate()
+	tok := mustGenerate(t)
 	stored := liveSession(tok)
 	seed(t, store, stored)
 
@@ -124,4 +126,13 @@ func TestCachedValidateServesValidCachedSession(t *testing.T) {
 	require.NotNil(t, v)
 	assert.Equal(t, stored.AccountID, v.AccountID)
 	assert.Zero(t, inner.calls, "a usable cached session must not hit the database")
+}
+
+func mustGenerate(t *testing.T) Token {
+	t.Helper()
+
+	tok, err := Generate()
+	require.NoError(t, err)
+
+	return tok
 }

--- a/app/resources/account/token/revoke_test.go
+++ b/app/resources/account/token/revoke_test.go
@@ -19,8 +19,8 @@ type revokeRacingRepo struct {
 	duringRevoke func()
 }
 
-func (f *revokeRacingRepo) Issue(context.Context, account.AccountID) (*Session, error) {
-	return &f.session, nil
+func (f *revokeRacingRepo) Issue(context.Context, account.AccountID) (*Issued, error) {
+	return &Issued{Session: f.session}, nil
 }
 
 func (f *revokeRacingRepo) Revoke(context.Context, Token) error {
@@ -45,10 +45,10 @@ func TestCachedRevokeEvictsSessionCachedDuringTheWrite(t *testing.T) {
 	ctx := context.Background()
 	store := cachetest.New()
 
-	tok := Generate()
+	tok := mustGenerate(t)
 	inner := &revokeRacingRepo{
 		session: Session{
-			Token:     tok,
+			TokenHash: tok.Hash(),
 			AccountID: account.AccountID(xid.New()),
 			ExpiresAt: time.Now().Add(90 * 24 * time.Hour),
 		},
@@ -64,7 +64,7 @@ func TestCachedRevokeEvictsSessionCachedDuringTheWrite(t *testing.T) {
 	require.NoError(t, repo.Revoke(ctx, tok))
 	require.True(t, inner.revoked)
 
-	_, err := store.Get(ctx, tok.String())
+	_, err := store.Get(ctx, cacheKey(tok))
 	assert.Error(t, err, "the pre-revocation session must not survive in the cache")
 
 	v, err := repo.Validate(ctx, tok)

--- a/app/resources/account/token/token.go
+++ b/app/resources/account/token/token.go
@@ -1,67 +1,76 @@
 package token
 
 import (
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/hex"
 	"encoding/json"
 	"time"
 
 	"github.com/Southclaws/fault"
+	"github.com/Southclaws/fault/ftag"
 	"github.com/Southclaws/opt"
+
 	"github.com/Southclaws/storyden/app/resources/account"
-	"github.com/rs/xid"
 )
 
 var (
 	ErrTokenExpired = fault.New("token expired")
 	ErrTokenRevoked = fault.New("token revoked")
+	ErrTokenInvalid = fault.New("token malformed", ftag.With(ftag.Unauthenticated))
 )
 
-type Token struct{ xid.ID }
+const (
+	secretBytes  = 32
+	secretLength = 43
+)
 
-func FromString(b string) (Token, error) {
-	id, err := xid.FromString(b)
-	if err != nil {
-		return Token{}, err
+// Token is the bearer secret held by the client. It is never persisted, only
+// its hash is, so a database or cache leak cannot be replayed as a session.
+type Token struct{ secret string }
+
+func Generate() (Token, error) {
+	b := make([]byte, secretBytes)
+	if _, err := rand.Read(b); err != nil {
+		return Token{}, fault.Wrap(err)
 	}
 
-	return Token{id}, nil
+	return Token{base64.RawURLEncoding.EncodeToString(b)}, nil
 }
 
-func Generate() Token {
-	return Token{xid.New()}
-}
+func FromString(s string) (Token, error) {
+	if len(s) != secretLength {
+		return Token{}, fault.Wrap(ErrTokenInvalid)
+	}
 
-func (t Token) Bytes() []byte {
-	return t.ID.Bytes()
+	if _, err := base64.RawURLEncoding.DecodeString(s); err != nil {
+		return Token{}, fault.Wrap(ErrTokenInvalid)
+	}
+
+	return Token{s}, nil
 }
 
 func (t Token) String() string {
-	return t.ID.String()
+	return t.secret
 }
 
-// MarshalJSON encodes the token as a bare string (`"c5n4mpk1..."`).
-func (t Token) MarshalJSON() ([]byte, error) {
-	return json.Marshal(t.String())
-}
-
-// UnmarshalJSON decodes the token from a bare string.
-func (t *Token) UnmarshalJSON(b []byte) error {
-	var s string
-	if err := json.Unmarshal(b, &s); err != nil {
-		return err
-	}
-	id, err := xid.FromString(s)
-	if err != nil {
-		return err
-	}
-	*t = Token{id}
-	return nil
+func (t Token) Hash() string {
+	sum := sha256.Sum256([]byte(t.secret))
+	return hex.EncodeToString(sum[:])
 }
 
 type Session struct {
-	Token     Token                   `json:"t"`
+	TokenHash string                  `json:"h"`
 	AccountID account.AccountID       `json:"a"`
 	ExpiresAt time.Time               `json:"e"`
 	RevokedAt opt.Optional[time.Time] `json:"r"`
+}
+
+// Issued pairs a new session with the one and only copy of its secret.
+type Issued struct {
+	Token   Token
+	Session Session
 }
 
 type Validated Session

--- a/app/resources/account/token/token_test.go
+++ b/app/resources/account/token/token_test.go
@@ -1,0 +1,89 @@
+package token
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/rs/xid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGeneratedTokensAreUnpredictable(t *testing.T) {
+	t.Parallel()
+
+	const runs = 512
+
+	seen := map[string]struct{}{}
+	prefixes := map[string]struct{}{}
+
+	for range runs {
+		tok, err := Generate()
+		require.NoError(t, err)
+
+		seen[tok.String()] = struct{}{}
+		prefixes[tok.String()[:8]] = struct{}{}
+	}
+
+	assert.Len(t, seen, runs, "every secret must be distinct")
+	assert.Len(t, prefixes, runs, "no shared structure, an xid would collide here on machine and pid bytes")
+}
+
+func TestTokenIsNotAnXID(t *testing.T) {
+	t.Parallel()
+
+	tok, err := Generate()
+	require.NoError(t, err)
+
+	_, err = xid.FromString(tok.String())
+	assert.Error(t, err, "a session secret must not be parseable as the sequential id it used to be")
+}
+
+func TestFromStringRejectsMalformedSecrets(t *testing.T) {
+	t.Parallel()
+
+	tok, err := Generate()
+	require.NoError(t, err)
+
+	_, err = FromString(tok.String())
+	assert.NoError(t, err)
+
+	for name, input := range map[string]string{
+		"empty":      "",
+		"short":      tok.String()[:10],
+		"long":       tok.String() + "a",
+		"an xid":     xid.New().String(),
+		"non base64": strings.Repeat("!", secretLength),
+	} {
+		_, err := FromString(input)
+		assert.Error(t, err, name)
+	}
+}
+
+func TestHashIsStableAndHidesTheSecret(t *testing.T) {
+	t.Parallel()
+
+	tok, err := Generate()
+	require.NoError(t, err)
+
+	assert.Equal(t, tok.Hash(), tok.Hash())
+	assert.NotContains(t, tok.Hash(), tok.String())
+	assert.Len(t, tok.Hash(), 64)
+
+	other, err := Generate()
+	require.NoError(t, err)
+	assert.NotEqual(t, tok.Hash(), other.Hash())
+}
+
+func TestSerialisedSessionCarriesNoSecret(t *testing.T) {
+	t.Parallel()
+
+	tok, err := Generate()
+	require.NoError(t, err)
+
+	payload, err := Session{TokenHash: tok.Hash()}.Serialise()
+	require.NoError(t, err)
+
+	assert.NotContains(t, string(payload), tok.String(), "the cache must never hold a replayable secret")
+	assert.Contains(t, string(payload), tok.Hash())
+}

--- a/app/services/authentication/session/issuer.go
+++ b/app/services/authentication/session/issuer.go
@@ -21,10 +21,10 @@ func NewIssuer(tokenRepo token.Repository) *Issuer {
 }
 
 func (s *Issuer) Issue(ctx context.Context, accountID account.AccountID) (*token.Token, error) {
-	t, err := s.tokenRepo.Issue(ctx, accountID)
+	issued, err := s.tokenRepo.Issue(ctx, accountID)
 	if err != nil {
 		return nil, fault.Wrap(err, fctx.With(ctx))
 	}
 
-	return &t.Token, nil
+	return &issued.Token, nil
 }

--- a/internal/ent/migrate/schema.go
+++ b/internal/ent/migrate/schema.go
@@ -1688,6 +1688,7 @@ var (
 	SessionsColumns = []*schema.Column{
 		{Name: "id", Type: field.TypeString, Size: 20},
 		{Name: "created_at", Type: field.TypeTime, Default: "CURRENT_TIMESTAMP"},
+		{Name: "token_hash", Type: field.TypeString, Unique: true},
 		{Name: "expires_at", Type: field.TypeTime},
 		{Name: "revoked_at", Type: field.TypeTime, Nullable: true},
 		{Name: "account_id", Type: field.TypeString, Size: 20},
@@ -1700,7 +1701,7 @@ var (
 		ForeignKeys: []*schema.ForeignKey{
 			{
 				Symbol:     "sessions_accounts_sessions",
-				Columns:    []*schema.Column{SessionsColumns[4]},
+				Columns:    []*schema.Column{SessionsColumns[5]},
 				RefColumns: []*schema.Column{AccountsColumns[0]},
 				OnDelete:   schema.Cascade,
 			},

--- a/internal/ent/mutation.go
+++ b/internal/ent/mutation.go
@@ -49386,6 +49386,7 @@ type SessionMutation struct {
 	typ            string
 	id             *xid.ID
 	created_at     *time.Time
+	token_hash     *string
 	expires_at     *time.Time
 	revoked_at     *time.Time
 	clearedFields  map[string]struct{}
@@ -49572,6 +49573,42 @@ func (m *SessionMutation) ResetAccountID() {
 	m.account = nil
 }
 
+// SetTokenHash sets the "token_hash" field.
+func (m *SessionMutation) SetTokenHash(s string) {
+	m.token_hash = &s
+}
+
+// TokenHash returns the value of the "token_hash" field in the mutation.
+func (m *SessionMutation) TokenHash() (r string, exists bool) {
+	v := m.token_hash
+	if v == nil {
+		return
+	}
+	return *v, true
+}
+
+// OldTokenHash returns the old "token_hash" field's value of the Session entity.
+// If the Session object wasn't provided to the builder, the object is fetched from the database.
+// An error is returned if the mutation operation is not UpdateOne, or the database query fails.
+func (m *SessionMutation) OldTokenHash(ctx context.Context) (v string, err error) {
+	if !m.op.Is(OpUpdateOne) {
+		return v, errors.New("OldTokenHash is only allowed on UpdateOne operations")
+	}
+	if m.id == nil || m.oldValue == nil {
+		return v, errors.New("OldTokenHash requires an ID field in the mutation")
+	}
+	oldValue, err := m.oldValue(ctx)
+	if err != nil {
+		return v, fmt.Errorf("querying old value for OldTokenHash: %w", err)
+	}
+	return oldValue.TokenHash, nil
+}
+
+// ResetTokenHash resets all changes to the "token_hash" field.
+func (m *SessionMutation) ResetTokenHash() {
+	m.token_hash = nil
+}
+
 // SetExpiresAt sets the "expires_at" field.
 func (m *SessionMutation) SetExpiresAt(t time.Time) {
 	m.expires_at = &t
@@ -49718,12 +49755,15 @@ func (m *SessionMutation) Type() string {
 // order to get all numeric fields that were incremented/decremented, call
 // AddedFields().
 func (m *SessionMutation) Fields() []string {
-	fields := make([]string, 0, 4)
+	fields := make([]string, 0, 5)
 	if m.created_at != nil {
 		fields = append(fields, session.FieldCreatedAt)
 	}
 	if m.account != nil {
 		fields = append(fields, session.FieldAccountID)
+	}
+	if m.token_hash != nil {
+		fields = append(fields, session.FieldTokenHash)
 	}
 	if m.expires_at != nil {
 		fields = append(fields, session.FieldExpiresAt)
@@ -49743,6 +49783,8 @@ func (m *SessionMutation) Field(name string) (ent.Value, bool) {
 		return m.CreatedAt()
 	case session.FieldAccountID:
 		return m.AccountID()
+	case session.FieldTokenHash:
+		return m.TokenHash()
 	case session.FieldExpiresAt:
 		return m.ExpiresAt()
 	case session.FieldRevokedAt:
@@ -49760,6 +49802,8 @@ func (m *SessionMutation) OldField(ctx context.Context, name string) (ent.Value,
 		return m.OldCreatedAt(ctx)
 	case session.FieldAccountID:
 		return m.OldAccountID(ctx)
+	case session.FieldTokenHash:
+		return m.OldTokenHash(ctx)
 	case session.FieldExpiresAt:
 		return m.OldExpiresAt(ctx)
 	case session.FieldRevokedAt:
@@ -49786,6 +49830,13 @@ func (m *SessionMutation) SetField(name string, value ent.Value) error {
 			return fmt.Errorf("unexpected type %T for field %s", value, name)
 		}
 		m.SetAccountID(v)
+		return nil
+	case session.FieldTokenHash:
+		v, ok := value.(string)
+		if !ok {
+			return fmt.Errorf("unexpected type %T for field %s", value, name)
+		}
+		m.SetTokenHash(v)
 		return nil
 	case session.FieldExpiresAt:
 		v, ok := value.(time.Time)
@@ -49864,6 +49915,9 @@ func (m *SessionMutation) ResetField(name string) error {
 		return nil
 	case session.FieldAccountID:
 		m.ResetAccountID()
+		return nil
+	case session.FieldTokenHash:
+		m.ResetTokenHash()
 		return nil
 	case session.FieldExpiresAt:
 		m.ResetExpiresAt()

--- a/internal/ent/runtime.go
+++ b/internal/ent/runtime.go
@@ -1969,6 +1969,10 @@ func init() {
 	sessionDescAccountID := sessionFields[0].Descriptor()
 	// session.AccountIDValidator is a validator for the "account_id" field. It is called by the builders before save.
 	session.AccountIDValidator = sessionDescAccountID.Validators[0].(func(string) error)
+	// sessionDescTokenHash is the schema descriptor for token_hash field.
+	sessionDescTokenHash := sessionFields[1].Descriptor()
+	// session.TokenHashValidator is a validator for the "token_hash" field. It is called by the builders before save.
+	session.TokenHashValidator = sessionDescTokenHash.Validators[0].(func(string) error)
 	// sessionDescID is the schema descriptor for id field.
 	sessionDescID := sessionMixinFields0[0].Descriptor()
 	// session.DefaultID holds the default value on creation for the id field.

--- a/internal/ent/schema/session.go
+++ b/internal/ent/schema/session.go
@@ -22,6 +22,12 @@ func (Session) Fields() []ent.Field {
 			GoType(xid.ID{}).
 			NotEmpty(),
 
+		field.String("token_hash").
+			Immutable().
+			Unique().
+			NotEmpty().
+			Comment("SHA-256 of the bearer secret, the secret itself is never stored"),
+
 		field.Time("expires_at").
 			Immutable(),
 

--- a/internal/ent/session.go
+++ b/internal/ent/session.go
@@ -23,6 +23,8 @@ type Session struct {
 	CreatedAt time.Time `json:"created_at,omitempty"`
 	// AccountID holds the value of the "account_id" field.
 	AccountID xid.ID `json:"account_id,omitempty"`
+	// SHA-256 of the bearer secret, the secret itself is never stored
+	TokenHash string `json:"token_hash,omitempty"`
 	// ExpiresAt holds the value of the "expires_at" field.
 	ExpiresAt time.Time `json:"expires_at,omitempty"`
 	// RevokedAt holds the value of the "revoked_at" field.
@@ -58,6 +60,8 @@ func (*Session) scanValues(columns []string) ([]any, error) {
 	values := make([]any, len(columns))
 	for i := range columns {
 		switch columns[i] {
+		case session.FieldTokenHash:
+			values[i] = new(sql.NullString)
 		case session.FieldCreatedAt, session.FieldExpiresAt, session.FieldRevokedAt:
 			values[i] = new(sql.NullTime)
 		case session.FieldID, session.FieldAccountID:
@@ -94,6 +98,12 @@ func (_m *Session) assignValues(columns []string, values []any) error {
 				return fmt.Errorf("unexpected type %T for field account_id", values[i])
 			} else if value != nil {
 				_m.AccountID = *value
+			}
+		case session.FieldTokenHash:
+			if value, ok := values[i].(*sql.NullString); !ok {
+				return fmt.Errorf("unexpected type %T for field token_hash", values[i])
+			} else if value.Valid {
+				_m.TokenHash = value.String
 			}
 		case session.FieldExpiresAt:
 			if value, ok := values[i].(*sql.NullTime); !ok {
@@ -154,6 +164,9 @@ func (_m *Session) String() string {
 	builder.WriteString(", ")
 	builder.WriteString("account_id=")
 	builder.WriteString(fmt.Sprintf("%v", _m.AccountID))
+	builder.WriteString(", ")
+	builder.WriteString("token_hash=")
+	builder.WriteString(_m.TokenHash)
 	builder.WriteString(", ")
 	builder.WriteString("expires_at=")
 	builder.WriteString(_m.ExpiresAt.Format(time.ANSIC))

--- a/internal/ent/session/session.go
+++ b/internal/ent/session/session.go
@@ -19,6 +19,8 @@ const (
 	FieldCreatedAt = "created_at"
 	// FieldAccountID holds the string denoting the account_id field in the database.
 	FieldAccountID = "account_id"
+	// FieldTokenHash holds the string denoting the token_hash field in the database.
+	FieldTokenHash = "token_hash"
 	// FieldExpiresAt holds the string denoting the expires_at field in the database.
 	FieldExpiresAt = "expires_at"
 	// FieldRevokedAt holds the string denoting the revoked_at field in the database.
@@ -41,6 +43,7 @@ var Columns = []string{
 	FieldID,
 	FieldCreatedAt,
 	FieldAccountID,
+	FieldTokenHash,
 	FieldExpiresAt,
 	FieldRevokedAt,
 }
@@ -60,6 +63,8 @@ var (
 	DefaultCreatedAt func() time.Time
 	// AccountIDValidator is a validator for the "account_id" field. It is called by the builders before save.
 	AccountIDValidator func(string) error
+	// TokenHashValidator is a validator for the "token_hash" field. It is called by the builders before save.
+	TokenHashValidator func(string) error
 	// DefaultID holds the default value on creation for the "id" field.
 	DefaultID func() xid.ID
 	// IDValidator is a validator for the "id" field. It is called by the builders before save.
@@ -82,6 +87,11 @@ func ByCreatedAt(opts ...sql.OrderTermOption) OrderOption {
 // ByAccountID orders the results by the account_id field.
 func ByAccountID(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldAccountID, opts...).ToFunc()
+}
+
+// ByTokenHash orders the results by the token_hash field.
+func ByTokenHash(opts ...sql.OrderTermOption) OrderOption {
+	return sql.OrderByField(FieldTokenHash, opts...).ToFunc()
 }
 
 // ByExpiresAt orders the results by the expires_at field.

--- a/internal/ent/session/where.go
+++ b/internal/ent/session/where.go
@@ -66,6 +66,11 @@ func AccountID(v xid.ID) predicate.Session {
 	return predicate.Session(sql.FieldEQ(FieldAccountID, v))
 }
 
+// TokenHash applies equality check predicate on the "token_hash" field. It's identical to TokenHashEQ.
+func TokenHash(v string) predicate.Session {
+	return predicate.Session(sql.FieldEQ(FieldTokenHash, v))
+}
+
 // ExpiresAt applies equality check predicate on the "expires_at" field. It's identical to ExpiresAtEQ.
 func ExpiresAt(v time.Time) predicate.Session {
 	return predicate.Session(sql.FieldEQ(FieldExpiresAt, v))
@@ -184,6 +189,71 @@ func AccountIDEqualFold(v xid.ID) predicate.Session {
 func AccountIDContainsFold(v xid.ID) predicate.Session {
 	vc := v.String()
 	return predicate.Session(sql.FieldContainsFold(FieldAccountID, vc))
+}
+
+// TokenHashEQ applies the EQ predicate on the "token_hash" field.
+func TokenHashEQ(v string) predicate.Session {
+	return predicate.Session(sql.FieldEQ(FieldTokenHash, v))
+}
+
+// TokenHashNEQ applies the NEQ predicate on the "token_hash" field.
+func TokenHashNEQ(v string) predicate.Session {
+	return predicate.Session(sql.FieldNEQ(FieldTokenHash, v))
+}
+
+// TokenHashIn applies the In predicate on the "token_hash" field.
+func TokenHashIn(vs ...string) predicate.Session {
+	return predicate.Session(sql.FieldIn(FieldTokenHash, vs...))
+}
+
+// TokenHashNotIn applies the NotIn predicate on the "token_hash" field.
+func TokenHashNotIn(vs ...string) predicate.Session {
+	return predicate.Session(sql.FieldNotIn(FieldTokenHash, vs...))
+}
+
+// TokenHashGT applies the GT predicate on the "token_hash" field.
+func TokenHashGT(v string) predicate.Session {
+	return predicate.Session(sql.FieldGT(FieldTokenHash, v))
+}
+
+// TokenHashGTE applies the GTE predicate on the "token_hash" field.
+func TokenHashGTE(v string) predicate.Session {
+	return predicate.Session(sql.FieldGTE(FieldTokenHash, v))
+}
+
+// TokenHashLT applies the LT predicate on the "token_hash" field.
+func TokenHashLT(v string) predicate.Session {
+	return predicate.Session(sql.FieldLT(FieldTokenHash, v))
+}
+
+// TokenHashLTE applies the LTE predicate on the "token_hash" field.
+func TokenHashLTE(v string) predicate.Session {
+	return predicate.Session(sql.FieldLTE(FieldTokenHash, v))
+}
+
+// TokenHashContains applies the Contains predicate on the "token_hash" field.
+func TokenHashContains(v string) predicate.Session {
+	return predicate.Session(sql.FieldContains(FieldTokenHash, v))
+}
+
+// TokenHashHasPrefix applies the HasPrefix predicate on the "token_hash" field.
+func TokenHashHasPrefix(v string) predicate.Session {
+	return predicate.Session(sql.FieldHasPrefix(FieldTokenHash, v))
+}
+
+// TokenHashHasSuffix applies the HasSuffix predicate on the "token_hash" field.
+func TokenHashHasSuffix(v string) predicate.Session {
+	return predicate.Session(sql.FieldHasSuffix(FieldTokenHash, v))
+}
+
+// TokenHashEqualFold applies the EqualFold predicate on the "token_hash" field.
+func TokenHashEqualFold(v string) predicate.Session {
+	return predicate.Session(sql.FieldEqualFold(FieldTokenHash, v))
+}
+
+// TokenHashContainsFold applies the ContainsFold predicate on the "token_hash" field.
+func TokenHashContainsFold(v string) predicate.Session {
+	return predicate.Session(sql.FieldContainsFold(FieldTokenHash, v))
 }
 
 // ExpiresAtEQ applies the EQ predicate on the "expires_at" field.

--- a/internal/ent/session_create.go
+++ b/internal/ent/session_create.go
@@ -45,6 +45,12 @@ func (_c *SessionCreate) SetAccountID(v xid.ID) *SessionCreate {
 	return _c
 }
 
+// SetTokenHash sets the "token_hash" field.
+func (_c *SessionCreate) SetTokenHash(v string) *SessionCreate {
+	_c.mutation.SetTokenHash(v)
+	return _c
+}
+
 // SetExpiresAt sets the "expires_at" field.
 func (_c *SessionCreate) SetExpiresAt(v time.Time) *SessionCreate {
 	_c.mutation.SetExpiresAt(v)
@@ -142,6 +148,14 @@ func (_c *SessionCreate) check() error {
 			return &ValidationError{Name: "account_id", err: fmt.Errorf(`ent: validator failed for field "Session.account_id": %w`, err)}
 		}
 	}
+	if _, ok := _c.mutation.TokenHash(); !ok {
+		return &ValidationError{Name: "token_hash", err: errors.New(`ent: missing required field "Session.token_hash"`)}
+	}
+	if v, ok := _c.mutation.TokenHash(); ok {
+		if err := session.TokenHashValidator(v); err != nil {
+			return &ValidationError{Name: "token_hash", err: fmt.Errorf(`ent: validator failed for field "Session.token_hash": %w`, err)}
+		}
+	}
 	if _, ok := _c.mutation.ExpiresAt(); !ok {
 		return &ValidationError{Name: "expires_at", err: errors.New(`ent: missing required field "Session.expires_at"`)}
 	}
@@ -192,6 +206,10 @@ func (_c *SessionCreate) createSpec() (*Session, *sqlgraph.CreateSpec) {
 	if value, ok := _c.mutation.CreatedAt(); ok {
 		_spec.SetField(session.FieldCreatedAt, field.TypeTime, value)
 		_node.CreatedAt = value
+	}
+	if value, ok := _c.mutation.TokenHash(); ok {
+		_spec.SetField(session.FieldTokenHash, field.TypeString, value)
+		_node.TokenHash = value
 	}
 	if value, ok := _c.mutation.ExpiresAt(); ok {
 		_spec.SetField(session.FieldExpiresAt, field.TypeTime, value)
@@ -310,6 +328,9 @@ func (u *SessionUpsertOne) UpdateNewValues() *SessionUpsertOne {
 		}
 		if _, exists := u.create.mutation.AccountID(); exists {
 			s.SetIgnore(session.FieldAccountID)
+		}
+		if _, exists := u.create.mutation.TokenHash(); exists {
+			s.SetIgnore(session.FieldTokenHash)
 		}
 		if _, exists := u.create.mutation.ExpiresAt(); exists {
 			s.SetIgnore(session.FieldExpiresAt)
@@ -554,6 +575,9 @@ func (u *SessionUpsertBulk) UpdateNewValues() *SessionUpsertBulk {
 			}
 			if _, exists := b.mutation.AccountID(); exists {
 				s.SetIgnore(session.FieldAccountID)
+			}
+			if _, exists := b.mutation.TokenHash(); exists {
+				s.SetIgnore(session.FieldTokenHash)
 			}
 			if _, exists := b.mutation.ExpiresAt(); exists {
 				s.SetIgnore(session.FieldExpiresAt)


### PR DESCRIPTION
the session cookie is an xid:

```go
token := Token{xid.New()}
create := r.db.Session.Create().SetID(token.ID)
```

and `Jar.Create` puts `t.String()` straight into `storyden-session`, so the row id is the bearer credential

xid is not random, it is 4 bytes of unix seconds, 3 bytes of machine id from the hostname hash, 2 bytes of pid, then a 3 byte counter seeded once per process and incremented from there, everything except the counter is fixed for the life of the process, and any account holder can read all of it out of their own cookie

that leaves the counter, it advances across every `xid.New()` in the process rather than per session, so it is noisy, but it is still a small forward window from whatever you just observed, pair it with a timestamp guess and you are enumerating other people's live sessions, i wrote it out as a test before touching anything and reconstructing the next token byte for byte from the previous one is a few lines:

```go
forged[9], forged[10], forged[11] = byte(c>>16), byte(c>>8), byte(c)
```

so `Token` is now 32 bytes from `crypto/rand`, base64url, and it never reaches the database, `sessions.token_hash` holds the sha256 and lookups go through that, the row keeps an ordinary xid id, which is what an id is for

that split also gets the secret out of the cache, `Session` used to serialise the token itself, so anything with read access to redis had a pile of working cookies, it now carries `TokenHash` and the cache key is derived from the hash too, `Issue` returns an `Issued` pairing the session with the one copy of the secret that ever exists, and `FromString` validates length and alphabet instead of accepting anything xid could parse

**this logs everyone out on deploy.** existing rows have no hash and nothing can backfill one, that is the point, the old cookies are guessable and should stop working, worth a line in the release notes

tests cover distinctness across 512 tokens, the absence of shared prefix structure that made the old ones enumerable, `FromString` rejecting an xid and other malformed input, and the serialised session containing the hash and not the secret, `tests/account`, `tests/account/auth/...`, `tests/oauth` and `tests/thread` all pass