### PR TITLE
fix: prune expired OAuth refresh tokens instead of keeping them forever

### DIFF
--- a/app/resources/oauth/oauth_writer/writer.go
+++ b/app/resources/oauth/oauth_writer/writer.go
@@ -503,6 +503,17 @@ func (w *Writer) DeleteExpiredAuthorisationRequests(ctx context.Context, now tim
 	return deleted, nil
 }
 
+func (w *Writer) DeleteExpiredRefreshTokens(ctx context.Context, before time.Time) (int, error) {
+	deleted, err := w.db.OAuthRefreshToken.Delete().
+		Where(oauthrefreshtoken.ExpiresAtLT(before)).
+		Exec(ctx)
+	if err != nil {
+		return 0, wrapWriteError(ctx, err)
+	}
+
+	return deleted, nil
+}
+
 func (w *Writer) CreateRefreshToken(ctx context.Context, input RefreshTokenCreate) (*oauth.RefreshToken, error) {
 	row, err := w.db.OAuthRefreshToken.Create().
 		SetClientID(input.ClientID.XID()).

--- a/app/services/authentication/oauth/oauth.go
+++ b/app/services/authentication/oauth/oauth.go
@@ -35,7 +35,11 @@ const (
 
 	cleanupInterval          = time.Hour
 	dcrClientRetentionPeriod = 7 * 24 * time.Hour
-	maxUserCodeInputLength   = 32
+
+	// rotation keeps every superseded row so revokeRefreshTokenFamily can walk
+	// the chain, they are dropped once they have been unusable for this long
+	refreshTokenRetentionPeriod = 7 * 24 * time.Hour
+	maxUserCodeInputLength      = 32
 )
 
 type Error struct {
@@ -190,12 +194,19 @@ func (s *Service) cleanupExpiredRecords(ctx context.Context, logger *slog.Logger
 		return
 	}
 
-	if deviceAuthorisations > 0 || authorizationRequests > 0 || unusedDCRClients > 0 {
+	refreshTokens, err := s.tokens.DeleteExpiredRefreshTokens(ctx, now.Add(-refreshTokenRetentionPeriod))
+	if err != nil {
+		logger.Error("failed to clean expired oauth refresh tokens", slog.Any("error", err))
+		return
+	}
+
+	if deviceAuthorisations > 0 || authorizationRequests > 0 || unusedDCRClients > 0 || refreshTokens > 0 {
 		logger.Debug(
 			"cleaned expired oauth records",
 			slog.Int("device_authorizations", deviceAuthorisations),
 			slog.Int("authorization_requests", authorizationRequests),
 			slog.Int("unused_dcr_clients", unusedDCRClients),
+			slog.Int("refresh_tokens", refreshTokens),
 		)
 	}
 }

--- a/tests/oauth/cleanup_test.go
+++ b/tests/oauth/cleanup_test.go
@@ -73,6 +73,46 @@ func TestOAuthCleanup(t *testing.T) {
 				_, err = oq.GetAuthorisationRequestByRequestIDHash(root, activeHash)
 				a.NoError(err)
 			})
+
+			t.Run("refresh_tokens_are_dropped_once_they_are_long_expired", func(t *testing.T) {
+				a := assert.New(t)
+				r := require.New(t)
+
+				clientID := "cleanup-refresh-token-" + uuid.NewString()
+				client := createClient(t, root, ow, owner.ID, clientID, oauthresource.ClientTypePublic, oauthresource.ScopePolicyExplicit, opt.NewEmpty[string](), standardScopes(), []string{oauth.GrantTypeRefreshToken})
+
+				staleHash := "stale-" + uuid.NewString()
+				recentlyExpiredHash := "recent-" + uuid.NewString()
+				liveHash := "live-" + uuid.NewString()
+
+				create := func(hash string, expiresAt time.Time) {
+					_, err := ow.CreateRefreshToken(root, oauth_writer.RefreshTokenCreate{
+						ClientID:  client.ID,
+						AccountID: owner.ID,
+						TokenHash: hash,
+						Scope:     "openid",
+						ExpiresAt: expiresAt,
+					})
+					r.NoError(err)
+				}
+
+				create(staleHash, time.Now().Add(-30*24*time.Hour))
+				create(recentlyExpiredHash, time.Now().Add(-time.Hour))
+				create(liveHash, time.Now().Add(24*time.Hour))
+
+				deleted, err := ow.DeleteExpiredRefreshTokens(root, time.Now().Add(-7*24*time.Hour))
+				r.NoError(err)
+				a.Equal(1, deleted, "only rows past the retention window go")
+
+				_, err = oq.GetRefreshTokenByTokenHash(root, staleHash)
+				a.Error(err)
+
+				_, err = oq.GetRefreshTokenByTokenHash(root, recentlyExpiredHash)
+				a.NoError(err, "a token still inside the window stays so the rotation chain can be walked")
+
+				_, err = oq.GetRefreshTokenByTokenHash(root, liveHash)
+				a.NoError(err)
+			})
 		}))
 	}))
 }


### PR DESCRIPTION
`cleanupExpiredRecords` runs hourly and sweeps three things:

```go
deviceAuthorisations, err := s.tokens.DeleteExpiredDeviceAuthorisations(ctx, now)
authorizationRequests, err := s.tokens.DeleteExpiredAuthorisationRequests(ctx, now)
unusedDCRClients, err := s.tokens.DeleteUnusedDCRClients(ctx, now.Add(-dcrClientRetentionPeriod))
```

refresh tokens are not one of them, and nothing else removes them either, the only deletes on that table are the cascades in `DeleteClient` and the DCR sweep, both keyed on the client going away

that would be fine if rows were reused, but rotation guarantees the opposite, `exchangeRefreshToken` consumes the presented token and issues a fresh row, then `SetRefreshTokenReplacement` links the old one forward, the old row has to stay because `revokeRefreshTokenFamily` walks that chain when a rotated token is presented again, which is the theft detection from RFC 9700, so every refresh is a permanent row

with the defaults that adds up quickly, `OAUTH_ACCESS_TOKEN_TTL` is 15m, so a client that refreshes when its access token runs out writes about 96 rows a day, `OAUTH_REFRESH_TOKEN_TTL` is 720h, so at any moment only the last thirty days can possibly be valid and everything older is dead weight, a hundred active users for a year is a few million rows that can never be used for anything

so the sweep gains a fourth step with a seven day grace period after expiry, reusing the shape `dcrClientRetentionPeriod` already set:

```go
refreshTokens, err := s.tokens.DeleteExpiredRefreshTokens(ctx, now.Add(-refreshTokenRetentionPeriod))
```

the grace matters for the chain walk, a token that expired an hour ago still gets to be part of a family so a reuse attempt against a recently rotated token is still detected and cascades, and nothing is lost on the validation side either, `exchangeRefreshToken` already rejects on `rec.ExpiresAt.Before(time.Now())` before it looks at revocation, so a row that is gone and a row that is expired produce the same `invalid_grant`

the test creates three tokens, one expired thirty days ago, one expired an hour ago, one live, and checks only the first is swept, the existing `tests/oauth` suite including the reuse detection passes unchanged

this does not touch the api, the two endpoints that read this table still load it whole with no pagination, that is a separate change and i will follow up with it