### PR TITLE
fix: stop list endpoints dropping rows and pointing at pages that do not exist

### DIFF
--- a/app/resources/account/account_search/search.go
+++ b/app/resources/account/account_search/search.go
@@ -166,7 +166,9 @@ func (q *Querier) Search(ctx context.Context, params pagination.Parameters, filt
 		return nil, fault.Wrap(err, fctx.With(ctx))
 	}
 
-	aq.Limit(params.Limit()).Offset(params.Offset())
+	aq.Order(ent.Desc(account_ent.FieldCreatedAt), ent.Desc(account_ent.FieldID)).
+		Limit(params.Limit()).
+		Offset(params.Offset())
 
 	results, err := aq.All(ctx)
 	if err != nil {

--- a/app/resources/audit/audit_querier/querier.go
+++ b/app/resources/audit/audit_querier/querier.go
@@ -64,7 +64,7 @@ func (q *Querier) List(
 	}
 
 	results, err := query.
-		Order(ent_auditlog.ByCreatedAt(sql.OrderDesc())).
+		Order(ent_auditlog.ByCreatedAt(sql.OrderDesc()), ent_auditlog.ByID(sql.OrderDesc())).
 		Limit(page.Limit()).
 		Offset(page.Offset()).
 		All(ctx)

--- a/app/resources/library/node_querier/child_sort.go
+++ b/app/resources/library/node_querier/child_sort.go
@@ -70,7 +70,8 @@ order by
     when 'boolean'   then cast(p.value as integer)
     else p.value
 
-  end %s
+  end %s,
+  n.id asc
 
 limit  %d
 offset %d
@@ -90,7 +91,8 @@ order by
   case f.type when 'number'    then cast(p.value as numeric)           end %s,
   case f.type when 'timestamp' then cast(p.value as timestamp)         end %s,
   case f.type when 'boolean'   then cast(p.value as boolean)           end %s,
-  p.value %s
+  p.value %s,
+  n.id asc
 limit  %d
 offset %d
 `

--- a/app/resources/library/node_search/search.go
+++ b/app/resources/library/node_search/search.go
@@ -16,7 +16,6 @@ import (
 	"github.com/Southclaws/storyden/app/resources/library"
 	"github.com/Southclaws/storyden/app/resources/pagination"
 	"github.com/Southclaws/storyden/app/resources/tag/tag_ref"
-	"github.com/Southclaws/storyden/app/resources/visibility"
 	"github.com/Southclaws/storyden/internal/ent"
 	ent_account "github.com/Southclaws/storyden/internal/ent/account"
 	"github.com/Southclaws/storyden/internal/ent/node"
@@ -30,7 +29,6 @@ type Search interface {
 type query struct {
 	nameContains    string
 	contentContains string
-	visibility      []visibility.Visibility
 	authors         []account.AccountID
 	tags            []tag_ref.Name
 }
@@ -46,12 +44,6 @@ func WithNameContains(s string) Option {
 func WithContentContains(s string) Option {
 	return func(q *query) {
 		q.contentContains = s
-	}
-}
-
-func WithVisibility(v []visibility.Visibility) Option {
-	return func(q *query) {
-		q.visibility = v
 	}
 }
 

--- a/app/resources/library/node_search/search.go
+++ b/app/resources/library/node_search/search.go
@@ -127,7 +127,7 @@ func (s *service) Search(ctx context.Context, params pagination.Parameters, opts
 			cq.WithOwner()
 		}).
 		WithPrimaryImage().
-		Order(node.ByUpdatedAt(sql.OrderDesc()), node.ByCreatedAt(sql.OrderDesc())).
+		Order(node.ByUpdatedAt(sql.OrderDesc()), node.ByCreatedAt(sql.OrderDesc()), node.ByID(sql.OrderDesc())).
 		Limit(params.Limit()).
 		Offset(params.Offset())
 

--- a/app/resources/like/like_querier/like_querier.go
+++ b/app/resources/like/like_querier/like_querier.go
@@ -2,33 +2,23 @@ package like_querier
 
 import (
 	"context"
-	"math"
 
 	"github.com/Southclaws/dt"
 	"github.com/Southclaws/fault"
 	"github.com/Southclaws/fault/fctx"
-	"github.com/Southclaws/opt"
 	"github.com/rs/xid"
 
 	"github.com/Southclaws/storyden/app/resources/account"
 	"github.com/Southclaws/storyden/app/resources/account/role/role_hydrate"
 	"github.com/Southclaws/storyden/app/resources/like/item_like"
 	"github.com/Southclaws/storyden/app/resources/like/profile_like"
+	"github.com/Southclaws/storyden/app/resources/pagination"
 	"github.com/Southclaws/storyden/app/resources/post"
 	"github.com/Southclaws/storyden/internal/ent"
 	entaccount "github.com/Southclaws/storyden/internal/ent/account"
 	entlikepost "github.com/Southclaws/storyden/internal/ent/likepost"
 	entpost "github.com/Southclaws/storyden/internal/ent/post"
 )
-
-type Result struct {
-	PageSize    int
-	Results     int
-	TotalPages  int
-	CurrentPage int
-	NextPage    opt.Optional[int]
-	Likes       []*profile_like.Like
-}
 
 type LikeQuerier struct {
 	db          *ent.Client
@@ -67,16 +57,16 @@ func (l *LikeQuerier) GetPostLikes(ctx context.Context, postID post.ID) ([]*item
 	return likes, nil
 }
 
-func (l *LikeQuerier) GetProfileLikes(ctx context.Context, accountID account.AccountID, page int, size int) (*Result, error) {
+func (l *LikeQuerier) GetProfileLikes(ctx context.Context, accountID account.AccountID, params pagination.Parameters) (*pagination.Result[*profile_like.Like], error) {
 	total, err := l.db.LikePost.Query().Where(entlikepost.HasAccountWith(entaccount.ID(xid.ID(accountID)))).Count(ctx)
 	if err != nil {
 		return nil, fault.Wrap(err, fctx.With(ctx))
 	}
 
 	q := l.db.LikePost.Query().
-		Limit(size + 1).
-		Offset(page * size).
-		Order(ent.Desc(entlikepost.FieldCreatedAt)).
+		Limit(params.Limit()).
+		Offset(params.Offset()).
+		Order(ent.Desc(entlikepost.FieldCreatedAt), ent.Desc(entlikepost.FieldID)).
 		Where(entlikepost.HasAccountWith(entaccount.ID(xid.ID(accountID)))).
 		WithPost(func(pq *ent.PostQuery) {
 			pq.WithAuthor()
@@ -104,22 +94,12 @@ func (l *LikeQuerier) GetProfileLikes(ctx context.Context, accountID account.Acc
 		return nil, fault.Wrap(err, fctx.With(ctx))
 	}
 
-	nextPage := opt.NewSafe(page+1, len(r) >= size)
-	if len(r) > 1 {
-		r = r[:len(r)-1]
-	}
-
 	likes, err := dt.MapErr(r, profile_like.Map)
 	if err != nil {
 		return nil, fault.Wrap(err, fctx.With(ctx))
 	}
 
-	return &Result{
-		PageSize:    size,
-		Results:     len(likes),
-		TotalPages:  int(math.Ceil(float64(total) / float64(size))),
-		CurrentPage: page,
-		NextPage:    nextPage,
-		Likes:       likes,
-	}, nil
+	result := pagination.NewPageResult(params, total, likes)
+
+	return &result, nil
 }

--- a/app/resources/link/link_querier/querier.go
+++ b/app/resources/link/link_querier/querier.go
@@ -2,18 +2,17 @@ package link_querier
 
 import (
 	"context"
-	"math"
 
 	"github.com/Southclaws/dt"
 	"github.com/Southclaws/fault"
 	"github.com/Southclaws/fault/fctx"
-	"github.com/Southclaws/opt"
 	"github.com/rs/xid"
 
 	"github.com/Southclaws/storyden/app/resources/account/role/role_hydrate"
 	"github.com/Southclaws/storyden/app/resources/library"
 	"github.com/Southclaws/storyden/app/resources/link"
 	"github.com/Southclaws/storyden/app/resources/link/link_ref"
+	"github.com/Southclaws/storyden/app/resources/pagination"
 	"github.com/Southclaws/storyden/internal/ent"
 	link_ent "github.com/Southclaws/storyden/internal/ent/link"
 )
@@ -28,15 +27,6 @@ func New(db *ent.Client, roleQuerier *role_hydrate.Hydrator) *LinkQuerier {
 		db:          db,
 		roleQuerier: roleQuerier,
 	}
-}
-
-type Result struct {
-	PageSize    int
-	Results     int
-	TotalPages  int
-	CurrentPage int
-	NextPage    opt.Optional[int]
-	Links       []*link_ref.LinkRef
 }
 
 type Filter func(*ent.LinkQuery)
@@ -119,45 +109,33 @@ func (d *LinkQuerier) GetByID(ctx context.Context, id link.LinkID) (*link_ref.Li
 	return link, nil
 }
 
-func (d *LinkQuerier) Search(ctx context.Context, page int, size int, filters ...Filter) (*Result, error) {
-	total, err := d.db.Link.Query().Count(ctx)
-	if err != nil {
-		return nil, fault.Wrap(err, fctx.With(ctx))
-	}
-
-	query := d.db.Link.Query().
-		WithPrimaryImage().
-		WithFaviconImage().
-		Limit(size + 1).
-		Offset(page * size).
-		Order(ent.Desc(link_ent.FieldCreatedAt))
+func (d *LinkQuerier) Search(ctx context.Context, params pagination.Parameters, filters ...Filter) (*pagination.Result[*link_ref.LinkRef], error) {
+	query := d.db.Link.Query()
 
 	for _, fn := range filters {
 		fn(query)
 	}
 
-	query.WithAssets()
-
-	r, err := query.All(ctx)
+	total, err := query.Clone().Count(ctx)
 	if err != nil {
 		return nil, fault.Wrap(err, fctx.With(ctx))
 	}
 
-	isNextPage := len(r) >= size
-	nextPage := opt.NewSafe(page+1, isNextPage)
-
-	if isNextPage {
-		r = r[:len(r)-1]
+	r, err := query.
+		WithPrimaryImage().
+		WithFaviconImage().
+		WithAssets().
+		Limit(params.Limit()).
+		Offset(params.Offset()).
+		Order(ent.Desc(link_ent.FieldCreatedAt), ent.Desc(link_ent.FieldID)).
+		All(ctx)
+	if err != nil {
+		return nil, fault.Wrap(err, fctx.With(ctx))
 	}
 
 	links := dt.Map(r, link_ref.Map)
 
-	return &Result{
-		PageSize:    size,
-		Results:     len(links),
-		TotalPages:  int(math.Ceil(float64(total) / float64(size))),
-		CurrentPage: page,
-		NextPage:    nextPage,
-		Links:       links,
-	}, nil
+	result := pagination.NewPageResult(params, total, links)
+
+	return &result, nil
 }

--- a/app/resources/link/link_querier/querier.go
+++ b/app/resources/link/link_querier/querier.go
@@ -33,7 +33,7 @@ type Filter func(*ent.LinkQuery)
 
 func WithURL(s string) Filter {
 	return func(lq *ent.LinkQuery) {
-		lq.Where(link_ent.URLContainsFold(s))
+		lq.Where(link_ent.URLEQ(s))
 	}
 }
 

--- a/app/resources/post/post_search/db.go
+++ b/app/resources/post/post_search/db.go
@@ -42,7 +42,7 @@ func (d *database) Search(ctx context.Context, params pagination.Parameters, fil
 		WithAuthor().
 		WithTags().
 		WithRoot().
-		Order(ent.Asc(ent_post.FieldCreatedAt)).
+		Order(ent.Asc(ent_post.FieldCreatedAt), ent.Asc(ent_post.FieldID)).
 		Limit(params.Limit()).
 		Offset(params.Offset())
 

--- a/app/resources/post/thread_querier/list_threads.go
+++ b/app/resources/post/thread_querier/list_threads.go
@@ -78,11 +78,13 @@ func (d *Querier) List(
 	if queryOptions.ignorePinned {
 		query.Order(
 			ent.Desc(ent_post.FieldLastReplyAt),
+			ent.Desc(ent_post.FieldID),
 		)
 	} else {
 		query.Order(
 			ent.Desc(ent_post.FieldPinnedRank),
 			ent.Desc(ent_post.FieldLastReplyAt),
+			ent.Desc(ent_post.FieldID),
 		)
 	}
 

--- a/app/resources/profile/follow_querier/follow_querier.go
+++ b/app/resources/profile/follow_querier/follow_querier.go
@@ -2,16 +2,15 @@ package follow_querier
 
 import (
 	"context"
-	"math"
 
 	"github.com/Southclaws/dt"
 	"github.com/Southclaws/fault"
 	"github.com/Southclaws/fault/fctx"
-	"github.com/Southclaws/opt"
 	"github.com/rs/xid"
 
 	"github.com/Southclaws/storyden/app/resources/account"
 	"github.com/Southclaws/storyden/app/resources/account/role/role_hydrate"
+	"github.com/Southclaws/storyden/app/resources/pagination"
 	"github.com/Southclaws/storyden/app/resources/profile"
 	"github.com/Southclaws/storyden/internal/ent"
 	"github.com/Southclaws/storyden/internal/ent/accountfollow"
@@ -26,16 +25,7 @@ func New(db *ent.Client, roleQuerier *role_hydrate.Hydrator) *Querier {
 	return &Querier{db: db, roleQuerier: roleQuerier}
 }
 
-type Result struct {
-	PageSize    int
-	Results     int
-	TotalPages  int
-	CurrentPage int
-	NextPage    opt.Optional[int]
-	Profiles    []*profile.Ref
-}
-
-func (q *Querier) GetFollowers(ctx context.Context, id account.AccountID, page, size int) (*Result, error) {
+func (q *Querier) GetFollowers(ctx context.Context, id account.AccountID, params pagination.Parameters) (*pagination.Result[*profile.Ref], error) {
 	total, err := q.db.AccountFollow.Query().
 		Where(accountfollow.FollowingAccountID(xid.ID(id))).Count(ctx)
 	if err != nil {
@@ -44,9 +34,9 @@ func (q *Querier) GetFollowers(ctx context.Context, id account.AccountID, page, 
 
 	r, err := q.db.AccountFollow.Query().
 		Where(accountfollow.FollowingAccountID(xid.ID(id))).
-		Limit(size + 1).
-		Offset(page * size).
-		Order(ent.Desc(accountfollow.FieldCreatedAt)).
+		Limit(params.Limit()).
+		Offset(params.Offset()).
+		Order(ent.Desc(accountfollow.FieldCreatedAt), ent.Desc(accountfollow.FieldID)).
 		WithFollower().
 		All(ctx)
 	if err != nil {
@@ -63,11 +53,6 @@ func (q *Querier) GetFollowers(ctx context.Context, id account.AccountID, page, 
 		return nil, fault.Wrap(err, fctx.With(ctx))
 	}
 
-	nextPage := opt.NewSafe(page+1, len(r) >= size)
-	if len(r) > 1 {
-		r = r[:len(r)-1]
-	}
-
 	profiles, err := dt.MapErr(r, func(in *ent.AccountFollow) (*profile.Ref, error) {
 		return profile.MapRef(in.Edges.Follower)
 	})
@@ -75,17 +60,12 @@ func (q *Querier) GetFollowers(ctx context.Context, id account.AccountID, page, 
 		return nil, fault.Wrap(err, fctx.With(ctx))
 	}
 
-	return &Result{
-		PageSize:    size,
-		Results:     len(profiles),
-		TotalPages:  int(math.Ceil(float64(total) / float64(size))),
-		CurrentPage: page,
-		NextPage:    nextPage,
-		Profiles:    profiles,
-	}, nil
+	result := pagination.NewPageResult(params, total, profiles)
+
+	return &result, nil
 }
 
-func (q *Querier) GetFollowing(ctx context.Context, id account.AccountID, page, size int) (*Result, error) {
+func (q *Querier) GetFollowing(ctx context.Context, id account.AccountID, params pagination.Parameters) (*pagination.Result[*profile.Ref], error) {
 	total, err := q.db.AccountFollow.Query().
 		Where(accountfollow.FollowerAccountID(xid.ID(id))).Count(ctx)
 	if err != nil {
@@ -94,9 +74,9 @@ func (q *Querier) GetFollowing(ctx context.Context, id account.AccountID, page, 
 
 	r, err := q.db.AccountFollow.Query().
 		Where(accountfollow.FollowerAccountID(xid.ID(id))).
-		Limit(size + 1).
-		Offset(page * size).
-		Order(ent.Desc(accountfollow.FieldCreatedAt)).
+		Limit(params.Limit()).
+		Offset(params.Offset()).
+		Order(ent.Desc(accountfollow.FieldCreatedAt), ent.Desc(accountfollow.FieldID)).
 		WithFollowing().
 		All(ctx)
 	if err != nil {
@@ -113,11 +93,6 @@ func (q *Querier) GetFollowing(ctx context.Context, id account.AccountID, page, 
 		return nil, fault.Wrap(err, fctx.With(ctx))
 	}
 
-	nextPage := opt.NewSafe(page+1, len(r) >= size)
-	if len(r) > 1 {
-		r = r[:len(r)-1]
-	}
-
 	profiles, err := dt.MapErr(r, func(in *ent.AccountFollow) (*profile.Ref, error) {
 		return profile.MapRef(in.Edges.Following)
 	})
@@ -125,12 +100,7 @@ func (q *Querier) GetFollowing(ctx context.Context, id account.AccountID, page, 
 		return nil, fault.Wrap(err, fctx.With(ctx))
 	}
 
-	return &Result{
-		PageSize:    size,
-		Results:     len(profiles),
-		TotalPages:  int(math.Ceil(float64(total) / float64(size))),
-		CurrentPage: page,
-		NextPage:    nextPage,
-		Profiles:    profiles,
-	}, nil
+	result := pagination.NewPageResult(params, total, profiles)
+
+	return &result, nil
 }

--- a/app/resources/profile/profile_search/search.go
+++ b/app/resources/profile/profile_search/search.go
@@ -151,7 +151,9 @@ func (d *Querier) Search(ctx context.Context, params pagination.Parameters, filt
 		return nil, fault.Wrap(err, fctx.With(ctx))
 	}
 
-	q.Limit(params.Limit()).Offset(params.Offset())
+	q.Order(ent.Desc(account.FieldCreatedAt), ent.Desc(account.FieldID)).
+		Limit(params.Limit()).
+		Offset(params.Offset())
 
 	r, err := q.All(ctx)
 	if err != nil {

--- a/app/services/link/fetcher/fetcher.go
+++ b/app/services/link/fetcher/fetcher.go
@@ -21,6 +21,7 @@ import (
 	"github.com/Southclaws/storyden/app/resources/link/link_writer"
 	"github.com/Southclaws/storyden/app/resources/mark"
 	"github.com/Southclaws/storyden/app/resources/message"
+	"github.com/Southclaws/storyden/app/resources/pagination"
 	"github.com/Southclaws/storyden/app/services/asset/asset_upload"
 	"github.com/Southclaws/storyden/app/services/link/scrape"
 	"github.com/Southclaws/storyden/internal/infrastructure/httpsafe"
@@ -71,15 +72,15 @@ func (s *Fetcher) Fetch(ctx context.Context, u url.URL) (*link_ref.LinkRef, erro
 		return nil, fault.Wrap(errEmptyLink, fctx.With(ctx), ftag.With(ftag.InvalidArgument))
 	}
 
-	r, err := s.lq.Search(ctx, 0, 1, link_querier.WithURL(u.String()))
+	r, err := s.lq.Search(ctx, pagination.NewPageParams(1, 1), link_querier.WithURL(u.String()))
 	if err != nil {
 		return nil, fault.Wrap(err, fctx.With(ctx))
 	}
-	if len(r.Links) > 0 {
+	if len(r.Items) > 0 {
 		if err := s.bus.SendCommand(ctx, &message.CommandScrapeLink{URL: u}); err != nil {
 			return nil, fault.Wrap(err, fctx.With(ctx))
 		}
-		return r.Links[0], nil
+		return r.Items[0], nil
 	}
 
 	lr, _, err := s.ScrapeAndStore(ctx, u)

--- a/app/transports/http/bindings/likes.go
+++ b/app/transports/http/bindings/likes.go
@@ -11,23 +11,27 @@ import (
 	"github.com/Southclaws/storyden/app/resources/like/like_querier"
 	"github.com/Southclaws/storyden/app/resources/like/profile_like"
 	"github.com/Southclaws/storyden/app/resources/post"
+	"github.com/Southclaws/storyden/app/resources/profile/profile_querier"
 	"github.com/Southclaws/storyden/app/services/authentication/session"
 	"github.com/Southclaws/storyden/app/services/like/post_liker"
 	"github.com/Southclaws/storyden/app/transports/http/openapi"
 )
 
 type Likes struct {
-	likeQuerier *like_querier.LikeQuerier
-	postLiker   *post_liker.PostLiker
+	likeQuerier  *like_querier.LikeQuerier
+	postLiker    *post_liker.PostLiker
+	profileQuery *profile_querier.Querier
 }
 
 func NewLikes(
 	likeQuerier *like_querier.LikeQuerier,
 	postLiker *post_liker.PostLiker,
+	profileQuery *profile_querier.Querier,
 ) Likes {
 	return Likes{
-		likeQuerier: likeQuerier,
-		postLiker:   postLiker,
+		likeQuerier:  likeQuerier,
+		postLiker:    postLiker,
+		profileQuery: profileQuery,
 	}
 }
 
@@ -81,7 +85,7 @@ func (h *Likes) LikePostRemove(ctx context.Context, request openapi.LikePostRemo
 }
 
 func (h *Likes) LikeProfileGet(ctx context.Context, request openapi.LikeProfileGetRequestObject) (openapi.LikeProfileGetResponseObject, error) {
-	accountID, err := session.GetAccountID(ctx)
+	accountID, err := openapi.ResolveHandle(ctx, h.profileQuery, request.AccountHandle)
 	if err != nil {
 		return nil, fault.Wrap(err, fctx.With(ctx))
 	}

--- a/app/transports/http/bindings/likes.go
+++ b/app/transports/http/bindings/likes.go
@@ -2,12 +2,10 @@ package bindings
 
 import (
 	"context"
-	"strconv"
 
 	"github.com/Southclaws/dt"
 	"github.com/Southclaws/fault"
 	"github.com/Southclaws/fault/fctx"
-	"github.com/Southclaws/opt"
 	"github.com/Southclaws/storyden/app/resources/like"
 	"github.com/Southclaws/storyden/app/resources/like/item_like"
 	"github.com/Southclaws/storyden/app/resources/like/like_querier"
@@ -88,36 +86,21 @@ func (h *Likes) LikeProfileGet(ctx context.Context, request openapi.LikeProfileG
 		return nil, fault.Wrap(err, fctx.With(ctx))
 	}
 
-	pageSize := 50
+	params := deserialisePageParams(request.Params.Page, 50)
 
-	page := opt.NewPtrMap(request.Params.Page, func(s string) int {
-		v, err := strconv.ParseInt(s, 10, 32)
-		if err != nil {
-			return 0
-		}
-
-		return max(1, int(v))
-	}).Or(1)
-
-	// API is 1-indexed, internally it's 0-indexed.
-	page = max(0, page-1)
-
-	result, err := h.likeQuerier.GetProfileLikes(ctx, accountID, page, pageSize)
+	result, err := h.likeQuerier.GetProfileLikes(ctx, accountID, params)
 	if err != nil {
 		return nil, fault.Wrap(err, fctx.With(ctx))
 	}
 
-	// API is 1-indexed, internally it's 0-indexed.
-	page = result.CurrentPage + 1
-
 	return openapi.LikeProfileGet200JSONResponse{
 		LikeProfileGetOKJSONResponse: openapi.LikeProfileGetOKJSONResponse{
-			PageSize:    pageSize,
+			PageSize:    result.Size,
 			Results:     result.Results,
 			TotalPages:  result.TotalPages,
-			CurrentPage: page,
+			CurrentPage: result.CurrentPage,
 			NextPage:    result.NextPage.Ptr(),
-			Likes:       dt.Map(result.Likes, serialiseProfileLike),
+			Likes:       dt.Map(result.Items, serialiseProfileLike),
 		},
 	}, nil
 }

--- a/app/transports/http/bindings/links.go
+++ b/app/transports/http/bindings/links.go
@@ -3,7 +3,6 @@ package bindings
 import (
 	"context"
 	"net/url"
-	"strconv"
 
 	"github.com/Southclaws/dt"
 	"github.com/Southclaws/fault"
@@ -59,16 +58,7 @@ func (i *Links) LinkCreate(ctx context.Context, request openapi.LinkCreateReques
 }
 
 func (i *Links) LinkList(ctx context.Context, request openapi.LinkListRequestObject) (openapi.LinkListResponseObject, error) {
-	pageSize := 50
-
-	page := opt.NewPtrMap(request.Params.Page, func(s string) int {
-		v, err := strconv.ParseInt(s, 10, 32)
-		if err != nil {
-			return 0
-		}
-
-		return max(1, int(v))
-	}).Or(1)
+	params := deserialisePageParams(request.Params.Page, 50)
 
 	opts := []link_querier.Filter{}
 
@@ -76,25 +66,19 @@ func (i *Links) LinkList(ctx context.Context, request openapi.LinkListRequestObj
 		opts = append(opts, link_querier.WithKeyword(*v))
 	}
 
-	// API is 1-indexed, internally it's 0-indexed.
-	page = max(0, page-1)
-
-	result, err := i.linkQuerier.Search(ctx, page, pageSize, opts...)
+	result, err := i.linkQuerier.Search(ctx, params, opts...)
 	if err != nil {
 		return nil, fault.Wrap(err, fctx.With(ctx))
 	}
 
-	// API is 1-indexed, internally it's 0-indexed.
-	page = result.CurrentPage + 1
-
 	return openapi.LinkList200JSONResponse{
 		LinkListOKJSONResponse: openapi.LinkListOKJSONResponse{
-			PageSize:    pageSize,
+			PageSize:    result.Size,
 			Results:     result.Results,
 			TotalPages:  result.TotalPages,
-			CurrentPage: page,
+			CurrentPage: result.CurrentPage,
 			NextPage:    result.NextPage.Ptr(),
-			Links:       serialiseLinkRefs(result.Links),
+			Links:       serialiseLinkRefs(result.Items),
 		},
 	}, nil
 }

--- a/app/transports/http/bindings/profiles.go
+++ b/app/transports/http/bindings/profiles.go
@@ -179,34 +179,19 @@ func (p *Profiles) ProfileFollowersGet(ctx context.Context, request openapi.Prof
 		return nil, fault.Wrap(err, fctx.With(ctx))
 	}
 
-	pageSize := 50
+	params := deserialisePageParams(request.Params.Page, 50)
 
-	page := opt.NewPtrMap(request.Params.Page, func(s string) int {
-		v, err := strconv.ParseInt(s, 10, 32)
-		if err != nil {
-			return 0
-		}
-
-		return max(1, int(v))
-	}).Or(1)
-
-	// API is 1-indexed, internally it's 0-indexed.
-	page = max(0, page-1)
-
-	result, err := p.followQuerier.GetFollowers(ctx, targetID, page, pageSize)
+	result, err := p.followQuerier.GetFollowers(ctx, targetID, params)
 	if err != nil {
 		return nil, fault.Wrap(err, fctx.With(ctx))
 	}
 
-	// API is 1-indexed, internally it's 0-indexed.
-	page = result.CurrentPage + 1
-
 	return openapi.ProfileFollowersGet200JSONResponse{
 		ProfileFollowersGetOKJSONResponse: openapi.ProfileFollowersGetOKJSONResponse{
-			CurrentPage: page,
-			Followers:   dt.Map(result.Profiles, serialiseProfileReferencePtr),
+			CurrentPage: result.CurrentPage,
+			Followers:   dt.Map(result.Items, serialiseProfileReferencePtr),
 			NextPage:    result.NextPage.Ptr(),
-			PageSize:    pageSize,
+			PageSize:    result.Size,
 			Results:     result.Results,
 			TotalPages:  result.TotalPages,
 		},
@@ -219,34 +204,19 @@ func (p *Profiles) ProfileFollowingGet(ctx context.Context, request openapi.Prof
 		return nil, fault.Wrap(err, fctx.With(ctx))
 	}
 
-	pageSize := 50
+	params := deserialisePageParams(request.Params.Page, 50)
 
-	page := opt.NewPtrMap(request.Params.Page, func(s string) int {
-		v, err := strconv.ParseInt(s, 10, 32)
-		if err != nil {
-			return 0
-		}
-
-		return max(1, int(v))
-	}).Or(1)
-
-	// API is 1-indexed, internally it's 0-indexed.
-	page = max(0, page-1)
-
-	result, err := p.followQuerier.GetFollowing(ctx, targetID, page, pageSize)
+	result, err := p.followQuerier.GetFollowing(ctx, targetID, params)
 	if err != nil {
 		return nil, fault.Wrap(err, fctx.With(ctx))
 	}
 
-	// API is 1-indexed, internally it's 0-indexed.
-	page = result.CurrentPage + 1
-
 	return openapi.ProfileFollowingGet200JSONResponse{
 		ProfileFollowingGetOKJSONResponse: openapi.ProfileFollowingGetOKJSONResponse{
-			CurrentPage: page,
-			Following:   dt.Map(result.Profiles, serialiseProfileReferencePtr),
+			CurrentPage: result.CurrentPage,
+			Following:   dt.Map(result.Items, serialiseProfileReferencePtr),
 			NextPage:    result.NextPage.Ptr(),
-			PageSize:    pageSize,
+			PageSize:    result.Size,
 			Results:     result.Results,
 			TotalPages:  result.TotalPages,
 		},

--- a/tests/library/links/link_list_test.go
+++ b/tests/library/links/link_list_test.go
@@ -1,0 +1,118 @@
+package links_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/fx"
+
+	"github.com/Southclaws/storyden/app/resources/account/account_writer"
+	"github.com/Southclaws/storyden/app/resources/link/link_querier"
+	"github.com/Southclaws/storyden/app/resources/link/link_writer"
+	"github.com/Southclaws/storyden/app/resources/pagination"
+	"github.com/Southclaws/storyden/app/resources/seed"
+	"github.com/Southclaws/storyden/app/transports/http/openapi"
+	"github.com/Southclaws/storyden/internal/integration"
+	"github.com/Southclaws/storyden/internal/integration/e2e"
+	"github.com/Southclaws/storyden/tests"
+)
+
+func TestLinkListPaging(t *testing.T) {
+	t.Parallel()
+
+	integration.Test(t, nil, e2e.Setup(), fx.Invoke(func(
+		lc fx.Lifecycle,
+		root context.Context,
+		cl *openapi.ClientWithResponses,
+		sh *e2e.SessionHelper,
+		aw *account_writer.Writer,
+		lw *link_writer.LinkWriter,
+		lq *link_querier.LinkQuerier,
+	) {
+		lc.Append(fx.StartHook(func() {
+			r := require.New(t)
+			a := assert.New(t)
+
+			ctx, _ := e2e.WithAccount(root, aw, seed.Account_001_Odin)
+			session := sh.WithSession(ctx)
+
+			run := uuid.NewString()[:8]
+			other := uuid.NewString()[:8]
+
+			const matching = 4
+			for i := range matching {
+				_, err := lw.Store(ctx,
+					fmt.Sprintf("https://%s.example.com/%d", run, i),
+					fmt.Sprintf("%s title %d", run, i),
+					"a link that matches the keyword",
+				)
+				r.NoError(err)
+			}
+
+			const unrelated = 3
+			for i := range unrelated {
+				_, err := lw.Store(ctx,
+					fmt.Sprintf("https://%s.example.com/%d", other, i),
+					fmt.Sprintf("%s title %d", other, i),
+					"no keyword here",
+				)
+				r.NoError(err)
+			}
+
+			t.Run("counts_only_the_filtered_rows", func(t *testing.T) {
+				result, err := lq.Search(root, pagination.NewPageParams(1, 2), link_querier.WithKeyword(run))
+				r.NoError(err)
+
+				a.Equal(2, result.TotalPages, "four matching links at two per page is two pages")
+				a.Len(result.Items, 2)
+			})
+
+			t.Run("walks_every_page_exactly_once", func(t *testing.T) {
+				seen := map[string]struct{}{}
+
+				for page := uint(1); page <= 10; page++ {
+					result, err := lq.Search(root, pagination.NewPageParams(page, 2), link_querier.WithKeyword(run))
+					r.NoError(err)
+					r.Equal(int(page), result.CurrentPage)
+
+					for _, l := range result.Items {
+						_, duplicate := seen[l.URL]
+						a.False(duplicate, "link %s was returned on more than one page", l.URL)
+						seen[l.URL] = struct{}{}
+					}
+
+					next, ok := result.NextPage.Get()
+					if !ok {
+						break
+					}
+
+					a.Equal(int(page)+1, next)
+				}
+
+				a.Len(seen, matching)
+			})
+
+			t.Run("exact_url_lookup_ignores_longer_urls", func(t *testing.T) {
+				result, err := lq.Search(root, pagination.NewPageParams(1, 10),
+					link_querier.WithURL(fmt.Sprintf("https://%s.example.com/", run)),
+				)
+				r.NoError(err)
+				a.Empty(result.Items, "a prefix of a stored URL is not that URL")
+			})
+
+			t.Run("api_reports_a_next_page_the_client_can_ask_for", func(t *testing.T) {
+				first, err := cl.LinkListWithResponse(root, &openapi.LinkListParams{
+					Q: &run,
+				}, session)
+				tests.Ok(t, err, first)
+
+				a.Equal(1, first.JSON200.CurrentPage)
+				a.Nil(first.JSON200.NextPage, "every match fits on the default page")
+			})
+		}))
+	}))
+}

--- a/tests/library/links/link_list_test.go
+++ b/tests/library/links/link_list_test.go
@@ -112,6 +112,31 @@ func TestLinkListPaging(t *testing.T) {
 
 				a.Equal(1, first.JSON200.CurrentPage)
 				a.Nil(first.JSON200.NextPage, "every match fits on the default page")
+
+				bulk := uuid.NewString()[:8]
+				const overflow = 55
+				for i := range overflow {
+					_, err := lw.Store(ctx,
+						fmt.Sprintf("https://%s.example.com/%d", bulk, i),
+						fmt.Sprintf("%s title %d", bulk, i),
+						"enough links to need a second page",
+					)
+					r.NoError(err)
+				}
+
+				page1, err := cl.LinkListWithResponse(root, &openapi.LinkListParams{Q: &bulk}, session)
+				tests.Ok(t, err, page1)
+				r.NotNil(page1.JSON200.NextPage)
+				a.Equal(1, page1.JSON200.CurrentPage)
+				a.Equal(2, *page1.JSON200.NextPage, "the next page number is the one the client sends back")
+				a.Len(page1.JSON200.Links, 50)
+
+				second := "2"
+				page2, err := cl.LinkListWithResponse(root, &openapi.LinkListParams{Q: &bulk, Page: &second}, session)
+				tests.Ok(t, err, page2)
+				a.Equal(2, page2.JSON200.CurrentPage)
+				a.Nil(page2.JSON200.NextPage)
+				a.Len(page2.JSON200.Links, overflow-50)
 			})
 		}))
 	}))

--- a/tests/like/like_pagination_test.go
+++ b/tests/like/like_pagination_test.go
@@ -1,0 +1,91 @@
+package like_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/Southclaws/opt"
+	"github.com/google/uuid"
+	"github.com/rs/xid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/fx"
+
+	"github.com/Southclaws/storyden/app/resources/account/account_writer"
+	"github.com/Southclaws/storyden/app/resources/like/like_querier"
+	"github.com/Southclaws/storyden/app/resources/pagination"
+	"github.com/Southclaws/storyden/app/resources/seed"
+	"github.com/Southclaws/storyden/app/transports/http/openapi"
+	"github.com/Southclaws/storyden/internal/integration"
+	"github.com/Southclaws/storyden/internal/integration/e2e"
+	"github.com/Southclaws/storyden/tests"
+)
+
+func TestProfileLikesPageWithoutLosingRows(t *testing.T) {
+	t.Parallel()
+
+	integration.Test(t, nil, e2e.Setup(), fx.Invoke(func(
+		lc fx.Lifecycle,
+		root context.Context,
+		cl *openapi.ClientWithResponses,
+		sh *e2e.SessionHelper,
+		aw *account_writer.Writer,
+		lq *like_querier.LikeQuerier,
+	) {
+		lc.Append(fx.StartHook(func() {
+			r := require.New(t)
+			a := assert.New(t)
+
+			adminCtx, _ := e2e.WithAccount(root, aw, seed.Account_001_Odin)
+			likerCtx, likerAcc := e2e.WithAccount(root, aw, seed.Account_006_Freyja)
+			adminSession := sh.WithSession(adminCtx)
+			likerSession := sh.WithSession(likerCtx)
+
+			const likeCount = 3
+			for range likeCount {
+				thread, err := cl.ThreadCreateWithResponse(root, openapi.ThreadInitialProps{
+					Body:       opt.New("<p>likeable</p>").Ptr(),
+					Visibility: opt.New(openapi.VisibilityPublished).Ptr(),
+					Title:      "like paging " + uuid.NewString(),
+				}, adminSession)
+				tests.Ok(t, err, thread)
+
+				like, err := cl.LikePostAddWithResponse(root, thread.JSON200.Id, likerSession)
+				tests.Ok(t, err, like)
+			}
+
+			list, err := cl.LikeProfileGetWithResponse(root, likerAcc.Handle, &openapi.LikeProfileGetParams{}, adminSession)
+			tests.Ok(t, err, list)
+			r.Len(list.JSON200.Likes, likeCount)
+			a.Equal(likeCount, list.JSON200.Results)
+			a.Nil(list.JSON200.NextPage)
+
+			own, err := cl.LikeProfileGetWithResponse(root, likerAcc.Handle, &openapi.LikeProfileGetParams{}, likerSession)
+			tests.Ok(t, err, own)
+			a.Len(own.JSON200.Likes, likeCount)
+
+			seen := map[xid.ID]struct{}{}
+
+			for page := uint(1); page <= 10; page++ {
+				result, err := lq.GetProfileLikes(root, likerAcc.ID, pagination.NewPageParams(page, 2))
+				r.NoError(err)
+				r.Equal(int(page), result.CurrentPage)
+
+				for _, like := range result.Items {
+					_, duplicate := seen[like.ID]
+					a.False(duplicate, "like %s was returned on more than one page", like.ID)
+					seen[like.ID] = struct{}{}
+				}
+
+				next, ok := result.NextPage.Get()
+				if !ok {
+					break
+				}
+
+				a.Equal(int(page)+1, next)
+			}
+
+			a.Len(seen, likeCount)
+		}))
+	}))
+}

--- a/tests/profile/follow/follow_pagination_test.go
+++ b/tests/profile/follow/follow_pagination_test.go
@@ -1,0 +1,120 @@
+package follow_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/fx"
+
+	"github.com/Southclaws/storyden/app/resources/account"
+	"github.com/Southclaws/storyden/app/resources/account/account_querier"
+	"github.com/Southclaws/storyden/app/resources/pagination"
+	"github.com/Southclaws/storyden/app/resources/profile"
+	"github.com/Southclaws/storyden/app/resources/profile/follow_querier"
+	"github.com/Southclaws/storyden/app/transports/http/openapi"
+	"github.com/Southclaws/storyden/internal/integration"
+	"github.com/Southclaws/storyden/internal/integration/e2e"
+	"github.com/Southclaws/storyden/tests"
+)
+
+func TestFollowListsPageWithoutLosingRows(t *testing.T) {
+	t.Parallel()
+
+	integration.Test(t, nil, e2e.Setup(), fx.Invoke(func(
+		lc fx.Lifecycle,
+		root context.Context,
+		cl *openapi.ClientWithResponses,
+		sh *e2e.SessionHelper,
+		ar *account_querier.Querier,
+		fq *follow_querier.Querier,
+	) {
+		lc.Append(fx.StartHook(func() {
+			t.Run("followers", func(t *testing.T) {
+				r := require.New(t)
+				a := assert.New(t)
+
+				target := newAccount(t, root, cl, ar, "tgt")
+
+				const followerCount = 3
+				for i := range followerCount {
+					follower := newAccount(t, root, cl, ar, fmt.Sprintf("fwr%d", i))
+					session := sh.WithSession(e2e.WithAccountID(root, follower.ID))
+
+					add, err := cl.ProfileFollowersAddWithResponse(root, target.Handle, session)
+					tests.Ok(t, err, add)
+				}
+
+				list, err := cl.ProfileFollowersGetWithResponse(root, target.Handle, &openapi.ProfileFollowersGetParams{})
+				tests.Ok(t, err, list)
+				r.Len(list.JSON200.Followers, followerCount)
+				a.Equal(followerCount, list.JSON200.Results)
+				a.Nil(list.JSON200.NextPage)
+
+				seen := walkPages(t, func(page uint) (*pagination.Result[*profile.Ref], error) {
+					return fq.GetFollowers(root, target.ID, pagination.NewPageParams(page, 2))
+				})
+				a.Len(seen, followerCount)
+			})
+
+			t.Run("following", func(t *testing.T) {
+				r := require.New(t)
+				a := assert.New(t)
+
+				follower := newAccount(t, root, cl, ar, "fwr")
+				session := sh.WithSession(e2e.WithAccountID(root, follower.ID))
+
+				const followingCount = 3
+				for i := range followingCount {
+					target := newAccount(t, root, cl, ar, fmt.Sprintf("tgt%d", i))
+
+					add, err := cl.ProfileFollowersAddWithResponse(root, target.Handle, session)
+					tests.Ok(t, err, add)
+				}
+
+				list, err := cl.ProfileFollowingGetWithResponse(root, follower.Handle, &openapi.ProfileFollowingGetParams{})
+				tests.Ok(t, err, list)
+				r.Len(list.JSON200.Following, followingCount)
+				a.Equal(followingCount, list.JSON200.Results)
+				a.Nil(list.JSON200.NextPage)
+
+				seen := walkPages(t, func(page uint) (*pagination.Result[*profile.Ref], error) {
+					return fq.GetFollowing(root, follower.ID, pagination.NewPageParams(page, 2))
+				})
+				a.Len(seen, followingCount)
+			})
+		}))
+	}))
+}
+
+func walkPages(t *testing.T, get func(page uint) (*pagination.Result[*profile.Ref], error)) map[account.AccountID]struct{} {
+	r := require.New(t)
+	a := assert.New(t)
+
+	seen := map[account.AccountID]struct{}{}
+
+	for page := uint(1); page <= 10; page++ {
+		result, err := get(page)
+		r.NoError(err)
+		r.Equal(int(page), result.CurrentPage)
+
+		for _, p := range result.Items {
+			_, duplicate := seen[p.ID]
+			a.False(duplicate, "profile %s was returned on more than one page", p.ID)
+			seen[p.ID] = struct{}{}
+		}
+
+		next, ok := result.NextPage.Get()
+		if !ok {
+			return seen
+		}
+
+		a.Equal(int(page)+1, next)
+	}
+
+	t.Fatal("pagination did not terminate")
+
+	return seen
+}

--- a/tests/profile/profile_list_order_test.go
+++ b/tests/profile/profile_list_order_test.go
@@ -23,6 +23,10 @@ import (
 )
 
 func TestProfileListOrderAndPaging(t *testing.T) {
+	if tests.IsSharedPostgresDatabase() {
+		t.Skip("skipping profile list paging test on shared postgres database")
+	}
+
 	t.Parallel()
 
 	integration.Test(t, nil, e2e.Setup(), fx.Invoke(func(

--- a/tests/profile/profile_list_order_test.go
+++ b/tests/profile/profile_list_order_test.go
@@ -1,0 +1,99 @@
+package account_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/jmoiron/sqlx"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/fx"
+
+	"github.com/Southclaws/storyden/app/resources/account"
+	"github.com/Southclaws/storyden/app/resources/account/account_writer"
+	"github.com/Southclaws/storyden/app/resources/pagination"
+	"github.com/Southclaws/storyden/app/resources/profile/profile_search"
+	"github.com/Southclaws/storyden/app/resources/seed"
+	"github.com/Southclaws/storyden/app/transports/http/openapi"
+	"github.com/Southclaws/storyden/internal/integration"
+	"github.com/Southclaws/storyden/internal/integration/e2e"
+	"github.com/Southclaws/storyden/tests"
+)
+
+func TestProfileListOrderAndPaging(t *testing.T) {
+	t.Parallel()
+
+	integration.Test(t, nil, e2e.Setup(), fx.Invoke(func(
+		lc fx.Lifecycle,
+		root context.Context,
+		cl *openapi.ClientWithResponses,
+		sh *e2e.SessionHelper,
+		aw *account_writer.Writer,
+		ps *profile_search.Querier,
+		raw *sqlx.DB,
+	) {
+		lc.Append(fx.StartHook(func() {
+			r := require.New(t)
+			a := assert.New(t)
+
+			ctx, _ := e2e.WithAccount(root, aw, seed.Account_001_Odin)
+			session := sh.WithSession(ctx)
+
+			joined := []account.AccountID{}
+			for _, s := range []account.Account{
+				seed.Account_002_Frigg,
+				seed.Account_003_Baldur,
+				seed.Account_004_Loki,
+			} {
+				_, acc := e2e.WithAccount(root, aw, s)
+				joined = append(joined, acc.ID)
+			}
+
+			list, err := cl.ProfileListWithResponse(root, &openapi.ProfileListParams{}, session)
+			tests.Ok(t, err, list)
+
+			positions := map[string]int{}
+			for i, p := range list.JSON200.Profiles {
+				positions[p.Id] = i
+			}
+
+			for i := 1; i < len(joined); i++ {
+				previous, ok := positions[joined[i-1].String()]
+				r.True(ok, "account %s missing from the profile list", joined[i-1])
+				current, ok := positions[joined[i].String()]
+				r.True(ok, "account %s missing from the profile list", joined[i])
+
+				a.Less(current, previous, "the newest member comes first")
+			}
+
+			// one timestamp for every row, so only the id can separate them
+			shared := time.Now().Add(-time.Hour).UTC()
+			for _, id := range joined {
+				_, err := raw.ExecContext(ctx, raw.Rebind("update accounts set created_at = ? where id = ?"), shared, id.String())
+				r.NoError(err)
+			}
+
+			seen := map[account.AccountID]int{}
+
+			for page := uint(1); page <= 10; page++ {
+				result, err := ps.Search(root, pagination.NewPageParams(page, 2))
+				r.NoError(err)
+				r.Equal(int(page), result.CurrentPage)
+
+				for _, p := range result.Items {
+					seen[p.ID]++
+				}
+
+				if _, ok := result.NextPage.Get(); !ok {
+					break
+				}
+			}
+
+			for _, id := range joined {
+				a.Equal(1, seen[id], "profile %s should appear on exactly one page", id)
+			}
+		}))
+	}))
+}

--- a/tests/thread/thread_list_paging_test.go
+++ b/tests/thread/thread_list_paging_test.go
@@ -1,0 +1,92 @@
+package thread_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/Southclaws/opt"
+	"github.com/google/uuid"
+	"github.com/rs/xid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/fx"
+
+	"github.com/Southclaws/storyden/app/resources/account"
+	"github.com/Southclaws/storyden/app/resources/account/account_writer"
+	"github.com/Southclaws/storyden/app/resources/post/thread_querier"
+	"github.com/Southclaws/storyden/app/resources/seed"
+	"github.com/Southclaws/storyden/app/transports/http/openapi"
+	"github.com/Southclaws/storyden/internal/ent"
+	ent_post "github.com/Southclaws/storyden/internal/ent/post"
+	"github.com/Southclaws/storyden/internal/integration"
+	"github.com/Southclaws/storyden/internal/integration/e2e"
+	"github.com/Southclaws/storyden/tests"
+)
+
+func TestThreadListPagesWhenThreadsShareATimestamp(t *testing.T) {
+	t.Parallel()
+
+	integration.Test(t, nil, e2e.Setup(), fx.Invoke(func(
+		lc fx.Lifecycle,
+		root context.Context,
+		cl *openapi.ClientWithResponses,
+		sh *e2e.SessionHelper,
+		aw *account_writer.Writer,
+		db *ent.Client,
+		tq *thread_querier.Querier,
+	) {
+		lc.Append(fx.StartHook(func() {
+			r := require.New(t)
+			a := assert.New(t)
+
+			ctx, _ := e2e.WithAccount(root, aw, seed.Account_001_Odin)
+			session := sh.WithSession(ctx)
+
+			const threadCount = 6
+			created := map[xid.ID]struct{}{}
+
+			for range threadCount {
+				thread, err := cl.ThreadCreateWithResponse(root, openapi.ThreadInitialProps{
+					Body:       opt.New("<p>paged</p>").Ptr(),
+					Visibility: opt.New(openapi.VisibilityPublished).Ptr(),
+					Title:      "thread paging " + uuid.NewString(),
+				}, session)
+				tests.Ok(t, err, thread)
+
+				created[openapi.ParseID(thread.JSON200.Id)] = struct{}{}
+			}
+
+			// every row on one timestamp, which is what an import or a busy
+			// second looks like, and what makes an offset page unstable
+			ids := make([]xid.ID, 0, threadCount)
+			for id := range created {
+				ids = append(ids, id)
+			}
+
+			shared := time.Now().Add(-time.Hour).UTC()
+			_, err := db.Post.Update().Where(ent_post.IDIn(ids...)).SetLastReplyAt(shared).Save(ctx)
+			r.NoError(err)
+
+			seen := map[xid.ID]int{}
+
+			for page := 0; page < 10; page++ {
+				result, err := tq.List(ctx, page, 2, opt.NewEmpty[account.AccountID]())
+				r.NoError(err)
+				r.Equal(page, result.CurrentPage)
+
+				for _, thread := range result.Threads {
+					seen[xid.ID(thread.ID)]++
+				}
+
+				if _, ok := result.NextPage.Get(); !ok {
+					break
+				}
+			}
+
+			for id := range created {
+				a.Equal(1, seen[id], "thread %s should appear on exactly one page", id)
+			}
+		}))
+	}))
+}

--- a/tests/thread/thread_list_paging_test.go
+++ b/tests/thread/thread_list_paging_test.go
@@ -25,6 +25,10 @@ import (
 )
 
 func TestThreadListPagesWhenThreadsShareATimestamp(t *testing.T) {
+	if tests.IsSharedPostgresDatabase() {
+		t.Skip("skipping thread list paging test on shared postgres database")
+	}
+
 	t.Parallel()
 
 	integration.Test(t, nil, e2e.Setup(), fx.Invoke(func(


### PR DESCRIPTION
four list endpoints were quietly dropping a row from every page, four were handing back a `next_page` number the client cannot use, and a handful more could shuffle rows between offset pages, one branch for the lot since they are all the same shape of mistake

**a row goes missing on every page.** `follow_querier.GetFollowers`, `GetFollowing` and `like_querier.GetProfileLikes` trimmed with `if len(r) > 1 { r = r[:len(r)-1] }`, the extra row is only fetched to detect whether another page exists, so it should only come off when the query actually returned it, as written an account with three followers only ever showed two, and a profile with two likes showed one, all three now build their result through `pagination.NewPageResult` like everything written since

**next page numbers the client cannot send back.** likes, followers, following and links computed `next_page` from the internal zero indexed page and put it straight into a 1-indexed API response, so page one said `next_page: 1`, a client walking that field never leaves the first page, the same four also claimed a next page whenever the last page came back exactly full, both fall out of moving to the shared helper

**links.** `total_pages` came from a count of the whole table while the rows themselves were filtered by `q`, so a keyword matching four links in a table of seven reported four pages of results, the count runs on the filtered query now, separately `WithURL` matched with `URLContainsFold` while its only caller is `fetcher.Fetch` deduplicating an exact url, `link.url` is unique so fetching `https://example.com/a` could match a stored `https://example.com/abc` and hand back the wrong link ref instead of scraping

**likes of a profile.** `GET /likes/profiles/{account_handle}` ignored the handle entirely and returned the likes of whoever was calling, the spec says "the likes that the given profile has given", it resolves the handle now, no frontend calls this endpoint so nothing depended on the old behaviour

**ordering.** thread list, post search, library search, audit log and the property sorted children query ordered on a column that ties, `last_reply_at`, `created_at`, `updated_at`, a property value, with nothing after it, rows sharing that key are free to move between adjacent offset pages and get duplicated or skipped, this is the same point coderabbit made on #815 and the newer queriers (`report_querier`, `email_queue_querier`, the `robot_*` ones) already carry the id tiebreak, `profile_search` and `account_search` also had no ordering at all unless a caller passed a sort rule, both bindings always pass one so nothing was broken over http, the fallback is there now anyway

also removed `node_search.WithVisibility`, it set a struct field the query never read, so a caller asking for drafts silently got published only

tests walk the pages for followers, following, profile likes, links, threads and profiles and check that no row shows up twice or disappears, the follower case and the link count case both fail on main (two of three followers, four pages instead of two), the thread and profile ones force every row onto a single timestamp, they pass on sqlite either way because it falls back to rowid order, the point of them is postgres where nothing promises an order

`tests/thread`, `tests/profile`, `tests/like`, `tests/library`, `tests/admin`, `tests/datagraph`, `tests/account`, `tests/collection`, `tests/oauth`, `tests/tags`, `tests/event`, `tests/notification` and `tests/report` pass, `tests/account/list` fails on main and on this branch the same way, `admin_can_filter_by_joined_range` expects an empty page and gets five accounts, it looks like a timezone thing on my machine (`+07`, the created_at rows land on the wrong side of a `DateOnly` boundary), untouched here