### PR TITLE
Configure Linguist to exclude generated and vendored code

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,15 @@
+# Linguist overrides: keep GitHub's language stats representative of the
+# actual product source (Go backend + TypeScript frontend) rather than
+# generated output, vendored tooling and the separate docs site.
+
+# Panda CSS codegen output - regenerated from web/panda.config.ts on every build.
+web/styled-system/** linguist-generated=true
+home/src/styled-system/** linguist-generated=true
+
+# Vendored agent skills/plugins - third-party scripts, not product code.
+.claude/** linguist-vendored=true
+.agents/** linguist-vendored=true
+.codex/** linguist-vendored=true
+
+# Marketing site + documentation, not part of the platform itself.
+home/** linguist-documentation=true


### PR DESCRIPTION
Add `.gitattributes` configuration to improve GitHub's language statistics by excluding generated code, vendored dependencies, and documentation from the repository's language breakdown.

## Summary

This change adds a `.gitattributes` file that configures Linguist (GitHub's language detection tool) to properly categorize different parts of the codebase, ensuring that GitHub's language statistics accurately reflect the actual product source code (Go backend + TypeScript frontend) rather than generated output and third-party content.

## Key Changes

- **Generated code**: Mark Panda CSS output in `web/styled-system/` and `home/src/styled-system/` as `linguist-generated=true` since these are regenerated from `web/panda.config.ts` on every build
- **Vendored code**: Mark Claude agent directories (`.claude/`, `.agents/`, `.codex/`) as `linguist-vendored=true` to exclude third-party scripts
- **Documentation**: Mark the `home/` directory as `linguist-documentation=true` since it contains the marketing site and documentation, not platform code

## Implementation Details

This configuration ensures that GitHub's language statistics will focus on the core product codebase (Go and TypeScript) while properly excluding:
- Auto-generated styling system files
- Third-party agent/plugin scripts
- Documentation and marketing site content

https://claude.ai/code/session_01JehrDUH5JZSC6bkkpS1YyA